### PR TITLE
Add lyric editor into ruleset editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo is under [GPL V3](LICENSE) license.
 [osu!](https://github.com/ppy/osu) and it's [framework](https://github.com/ppy/osu-framework), osu!karaoke is modified from them.
 
 [RhythmKaTTE](http://juna-idler.blogspot.com/2016/05/rhythmkatte-version-01.html) and [RhythmicaLyrics](http://suwa.pupu.jp/RhythmicaLyrics.html), an open-source software to create lyric with time tag.
+Some of lyric editor in this ruleset is inspired from them.
 
 [ニコカラメーカー](http://shinta0806be.ldblog.jp/tag/%E3%83%8B%E3%82%B3%E3%82%AB%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%AB%E3%83%BC), a software to convert `.lrc` file into karaoke video with beautiful text effect.
 


### PR DESCRIPTION
Implementation of issue #66 

Main goal : 
User can fully add/edit/delete lyric with time tag in beatmap editor.
Because this pull request is huge, and it will rewrite some exist hitobject.
So move into here to manage.
Before lyric editor is complete, all the relative pull request should be merged into here.
Each todo should mark pr number.

TODO :
- [ ] Implement base `lyric maker playfield`
- [ ] Implement `karaoke text` can display time tag and it's state (is clicked, click but time is wrong, or tooltip for display click time.)
- [ ] Implement `editable drawable lyric line`(not apply layout, and will display some lyric info by badge)
- [ ] Move `Note` into lyric's nasted object, maybe will add another property to save `tone state`
- [ ] Implement add `time tag` event (by clicking space or add button in the left of the editor.)
- [ ] Implement undo/redo event(maybe can be tested until new beatmap editor/decoder has been implemented.)


