### PR TITLE
Save translate into lyric hit object.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -114,13 +114,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
             Assert.AreEqual(lyrics[1].Translates.Count, 2);
 
             // Check chinese translate
-            Assert.AreEqual(lyrics[0].Translates[0], "卡拉OK");
-            Assert.AreEqual(lyrics[1].Translates[0], "喜歡");
+            var chineseLanguageId = translates[0].Id;
+            Assert.AreEqual(lyrics[0].Translates[chineseLanguageId], "卡拉OK");
+            Assert.AreEqual(lyrics[1].Translates[chineseLanguageId], "喜歡");
 
 
             // Check english translate
-            Assert.AreEqual(lyrics[0].Translates[1], "karaoke");
-            Assert.AreEqual(lyrics[1].Translates[1], "like it");
+            var englishLanguageId = translates[1].Id;
+            Assert.AreEqual(lyrics[0].Translates[englishLanguageId], "karaoke");
+            Assert.AreEqual(lyrics[1].Translates[englishLanguageId], "like it");
         }
 
         private KaraokeBeatmap decodeBeatmap(string fileName)

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -100,23 +100,27 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
             var beatmap = decodeBeatmap("karaoke-translate-samples");
 
             // Get translate
-            var translates = beatmap.GetTranslates();
+            var translates = beatmap.AvailableTranslates();
+            var lyrics = beatmap.HitObjects.OfType<LyricLine>().ToList();
 
             // Check is not null
             Assert.IsTrue(translates != null);
 
             // Check translate count
-            Assert.AreEqual(translates.Count, 2);
+            Assert.AreEqual(translates.Count(), 2);
+
+            // All lyric should have two translates
+            Assert.AreEqual(lyrics[0].Translates.Count, 2);
+            Assert.AreEqual(lyrics[1].Translates.Count, 2);
 
             // Check chinese translate
-            Assert.AreEqual(translates["zh-TW"].Count, 2);
-            Assert.AreEqual(translates["zh-TW"][0], "卡拉OK");
-            Assert.AreEqual(translates["zh-TW"][1], "喜歡");
+            Assert.AreEqual(lyrics[0].Translates[0], "卡拉OK");
+            Assert.AreEqual(lyrics[1].Translates[0], "喜歡");
+
 
             // Check english translate
-            Assert.AreEqual(translates["en-US"].Count, 2);
-            Assert.AreEqual(translates["en-US"][0], "karaoke");
-            Assert.AreEqual(translates["en-US"][1], "like it");
+            Assert.AreEqual(lyrics[0].Translates[1], "karaoke");
+            Assert.AreEqual(lyrics[1].Translates[1], "like it");
         }
 
         private KaraokeBeatmap decodeBeatmap(string fileName)

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -118,7 +118,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
             Assert.AreEqual(lyrics[0].Translates[chineseLanguageId], "卡拉OK");
             Assert.AreEqual(lyrics[1].Translates[chineseLanguageId], "喜歡");
 
-
             // Check english translate
             var englishLanguageId = translates[1].Id;
             Assert.AreEqual(lyrics[0].Translates[englishLanguageId], "karaoke");

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapEncoderTest.cs
@@ -69,7 +69,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                                 Text = "ke"
                             }
                         },
-                        TranslateText = "karaoke"
                     }
                 }
             };

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricLineLayout.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricLineLayout.cs
@@ -393,7 +393,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                 // Apply property
                 lyric.StartTime = startTime;
                 lyric.Duration = duration;
-                lyric.TranslateText = translate;
+                lyric.Translates.Add(0, translate);
+                lyric.ApplyDisplayTranslate(0);
                 lyric.TimeTags = new Dictionary<TimeTagIndex, double>
                 {
                     { new TimeTagIndex(0), startTime },

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricLineStyle.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricLineStyle.cs
@@ -372,8 +372,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                         EndIndex = 4,
                         Text = "ke"
                     }
-                },
-                TranslateText = "karaoke"
+                }
             };
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneTranslate.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneTranslate.cs
@@ -97,16 +97,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
             lyricPreview.LyricLines = lyricLines;
             translateEditor.LanguageDropdown.Items = new[]
             {
-                "zh-TW",
-                "en-US",
-                "ja-JP"
+                new BeatmapSetOnlineLanguage
+                {
+                    Id = 1,
+                    Name = "zh-TW"
+                },
+                new BeatmapSetOnlineLanguage
+                {
+                    Id = 2,
+                    Name = "en-US"
+                },
+                new BeatmapSetOnlineLanguage
+                {
+                    Id = 3,
+                    Name = "ja-JP"
+                }
             };
             translateEditor.LanguageDropdown.Current.BindValueChanged(value =>
             {
                 // Save translate first
                 var oldLanguageCode = value.OldValue;
 
-                if (!string.IsNullOrEmpty(oldLanguageCode))
+                if (oldLanguageCode != null)
                 {
                     // Get translate and fill empty
                     var insertTranslate = translateEditor.Translates.ToList();
@@ -114,7 +126,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 
                     if (beatmap.AvailableTranslates().Contains(oldLanguageCode))
                     {
-                        var translate = beatmap.GetTranslate(oldLanguageCode);
+                        var translate = beatmap.AvailableTranslates();
                         translate.Clear();
                         translate.AddRange(insertTranslate);
                     }
@@ -267,7 +279,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 
         public class TranslateEditor : FillFlowContainer
         {
-            public OsuDropdown<string> LanguageDropdown { get; }
+            public OsuDropdown<BeatmapSetOnlineLanguage> LanguageDropdown { get; }
 
             private readonly FillFlowContainer<OsuTextBox> translateTextBoxes;
 
@@ -277,7 +289,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                 Spacing = new Vector2(COLUMN_SPACING);
                 Children = new Drawable[]
                 {
-                    LanguageDropdown = new OsuDropdown<string>
+                    LanguageDropdown = new OsuDropdown<BeatmapSetOnlineLanguage>
                     {
                         RelativeSizeAxes = Axes.X,
                     },

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneTranslate.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneTranslate.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneLyricLine.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneLyricLine.cs
@@ -70,8 +70,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
                         Text = "ke"
                     }
                 },
-                TranslateText = "karaoke"
             };
+
+            lyric.Translates.Add(0, "karaoke");
+            lyric.ApplyDisplayTranslate(0);
 
             lyric.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Karaoke.sln.DotSettings
+++ b/osu.Game.Rulesets.Karaoke.sln.DotSettings
@@ -903,11 +903,13 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=beatmap_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catmull/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coronavirus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Demibold/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dropdown_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Feuille/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hatsune/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobjects/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kanji/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kaze/@EntryIndexedValue">True</s:Boolean>
@@ -918,6 +920,7 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leaderboards/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lyric_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=macbook/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Miku/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Naka/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nkmproj/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playfield/@EntryIndexedValue">True</s:Boolean>
@@ -936,4 +939,5 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=splitted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Taiko/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unranked/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=upppppdate/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=upppppdate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=vocaloid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -249,15 +249,11 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
             var availableTranslates = new List<BeatmapSetOnlineLanguage>();
 
             var lyrics = beatmap.HitObjects.OfType<LyricLine>().ToList();
-            var translates = translateLines.Select(translate =>
+            var translates = translateLines.Select(translate => new
             {
-                // format should like @tr[en-US]=First translate
-                return new
-                {
-                    key = translate.Split('=').FirstOrDefault()?.Split('[').LastOrDefault()?.Split(']').FirstOrDefault(),
-                    value = translate.Split('=').LastOrDefault()
-                };
-            }).GroupBy(x => x.key, y=>y.value).ToList();
+                key = translate.Split('=').FirstOrDefault()?.Split('[').LastOrDefault()?.Split(']').FirstOrDefault(),
+                value = translate.Split('=').LastOrDefault()
+            }).GroupBy(x => x.key, y => y.value).ToList();
 
             for (int i = 0; i < translates.Count(); i++)
             {
@@ -268,6 +264,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                 var values = singleLanguage.ToList();
 
                 var size = Math.Min(lyrics.Count(), singleLanguage.Count());
+
                 for (int j = 0; j < size; j++)
                 {
                     lyrics[j].Translates.Add(id, values[j]);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
             for (int i = 0; i < translates.Count(); i++)
             {
-                var id = 1 + 1;
+                var id = i + 1;
                 var singleLanguage = translates[i];
 
                 var key = singleLanguage.Key;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -246,27 +246,44 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
         private void processTranslate(Beatmap beatmap, IEnumerable<string> translateLines)
         {
-            var dictionary = new LegacyPropertyDictionary();
+            var availableTranslates = new List<BeatmapSetOnlineLanguage>();
 
-            foreach (var translateLine in translateLines)
+            var lyrics = beatmap.HitObjects.OfType<LyricLine>().ToList();
+            var translates = translateLines.Select(translate =>
             {
                 // format should like @tr[en-US]=First translate
-                var translateLanguage = translateLine.Split('=').FirstOrDefault()?.Split('[').LastOrDefault()?.Split(']').FirstOrDefault();
-                var translateStr = translateLine.Split('=').LastOrDefault();
+                return new
+                {
+                    key = translate.Split('=').FirstOrDefault()?.Split('[').LastOrDefault()?.Split(']').FirstOrDefault(),
+                    value = translate.Split('=').LastOrDefault()
+                };
+            }).GroupBy(x => x.key, y=>y.value).ToList();
 
-                // Add into dictionary
-                if (dictionary.Translates.TryGetValue(translateLanguage, out var list))
+            for (int i = 0; i < translates.Count(); i++)
+            {
+                var id = 1 + 1;
+                var singleLanguage = translates[i];
+
+                var key = singleLanguage.Key;
+                var values = singleLanguage.ToList();
+
+                var size = Math.Min(lyrics.Count(), singleLanguage.Count());
+                for (int j = 0; j < size; j++)
                 {
-                    list.Add(translateStr);
+                    lyrics[j].Translates.Add(id, values[j]);
                 }
-                else
+
+                availableTranslates.Add(new BeatmapSetOnlineLanguage
                 {
-                    dictionary.Translates.Add(translateLanguage, new List<string>
-                    {
-                        translateStr
-                    });
-                }
+                    Id = id,
+                    Name = key
+                });
             }
+
+            var dictionary = new LegacyPropertyDictionary
+            {
+                AvailableTranslates = availableTranslates.ToArray()
+            };
 
             beatmap.HitObjects.Add(dictionary);
         }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapEncoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapEncoder.cs
@@ -75,11 +75,15 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
             if (!output.AnyTranslate())
                 yield break;
 
-            foreach (var (languageCode, translates) in output.GetTranslates())
+            var lyrics = output.HitObjects.OfType<LyricLine>().ToList();
+            var availableTranslates = output.AvailableTranslates();
+
+            foreach (var translate in availableTranslates)
             {
-                foreach (var translate in translates)
+                foreach (var lyric in lyrics)
                 {
-                    yield return $"@tr[{languageCode}]={translate}";
+                    var translateString = lyric.Translates.TryGetValue(translate.Id, out string value) ? value : "";
+                    yield return $"@tr[{translate.Name}]={translateString}";
                 }
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -12,13 +12,13 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 {
     public class KaraokeBeatmap : Beatmap<KaraokeHitObject>
     {
-        public BeatmapSetOnlineLanguage[] AvailableTranslates { get; set; } = new BeatmapSetOnlineLanguage[] { };
+        public BeatmapSetOnlineLanguage[] AvailableTranslates { get; set; } = { };
 
         public SingerMetadata SingerMetadata { get; set; } = new SingerMetadata();
 
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
-            int singers = SingerMetadata.Singers.Count();
+            int singers = SingerMetadata.Singers.Count;
             int lyrics = HitObjects.Count(s => s is LyricLine);
 
             var defaultStatistic = new List<BeatmapStatistic>

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 {
     public class KaraokeBeatmap : Beatmap<KaraokeHitObject>
     {
-        public IDictionary<string, List<string>> Translates { get; set; } = new Dictionary<string, List<string>>();
+        public BeatmapSetOnlineLanguage[] AvailableTranslates { get; set; } = new BeatmapSetOnlineLanguage[] { };
 
         public SingerMetadata SingerMetadata { get; set; } = new SingerMetadata();
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
@@ -25,12 +25,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
             var beatmap = base.ConvertBeatmap(original, cancellationToken);
 
             // Apply property created from legacy decoder
-            var propertyDicrionary = beatmap.HitObjects.OfType<LegacyPropertyDictionary>().FirstOrDefault();
+            var propertyDictionary = beatmap.HitObjects.OfType<LegacyPropertyDictionary>().FirstOrDefault();
 
-            if (propertyDicrionary != null)
+            if (propertyDictionary != null)
             {
-                (beatmap as KaraokeBeatmap).AvailableTranslates = propertyDicrionary.AvailableTranslates;
-                beatmap.HitObjects.Remove(propertyDicrionary);
+                (beatmap as KaraokeBeatmap).AvailableTranslates = propertyDictionary.AvailableTranslates;
+                beatmap.HitObjects.Remove(propertyDictionary);
             }
 
             return beatmap;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
             if (propertyDicrionary != null)
             {
-                (beatmap as KaraokeBeatmap).Translates = propertyDicrionary.Translates;
+                (beatmap as KaraokeBeatmap).AvailableTranslates = propertyDicrionary.AvailableTranslates;
                 beatmap.HitObjects.Remove(propertyDicrionary);
             }
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
@@ -13,17 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
     {
         public static bool IsScorable(this IBeatmap beatmap) => beatmap?.HitObjects.OfType<Note>().Any(x => x.Display) ?? false;
 
-        public static IDictionary<string, List<string>> GetTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.Translates;
-
-        public static List<string> GetTranslate(this IBeatmap beatmap, string languageCode)
-        {
-            if (beatmap.GetTranslates().TryGetValue(languageCode, out var result))
-                return result;
-
-            return null;
-        }
-
-        public static string[] AvailableTranslates(this IBeatmap beatmap) => beatmap?.GetTranslates()?.Keys.ToArray() ?? new string[] { };
+        public static BeatmapSetOnlineLanguage[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates;
 
         public static bool AnyTranslate(this IBeatmap beatmap) => beatmap?.AvailableTranslates()?.Any() ?? false;
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
@@ -13,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
     {
         public static bool IsScorable(this IBeatmap beatmap) => beatmap?.HitObjects.OfType<Note>().Any(x => x.Display) ?? false;
 
-        public static BeatmapSetOnlineLanguage[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates ?? new BeatmapSetOnlineLanguage[] { } ;
+        public static BeatmapSetOnlineLanguage[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates ?? new BeatmapSetOnlineLanguage[] { };
 
         public static bool AnyTranslate(this IBeatmap beatmap) => beatmap?.AvailableTranslates()?.Any() ?? false;
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
     {
         public static bool IsScorable(this IBeatmap beatmap) => beatmap?.HitObjects.OfType<Note>().Any(x => x.Display) ?? false;
 
-        public static BeatmapSetOnlineLanguage[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates;
+        public static BeatmapSetOnlineLanguage[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates ?? new BeatmapSetOnlineLanguage[] { } ;
 
         public static bool AnyTranslate(this IBeatmap beatmap) => beatmap?.AvailableTranslates()?.Any() ?? false;
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
 
         public Color4 Color { get; set; }
 
-        public string Avater { get; set; }
+        public string Avatar { get; set; }
 
         public string Description { get; set; }
     }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/SingerMetadata.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/SingerMetadata.cs
@@ -31,14 +31,14 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
                 throw new NullReferenceException("Singer cannot be null.");
 
             if (!Singers.Contains(singer))
-                throw new ArgumentOutOfRangeException("Singer is not in the list");
+                throw new ArgumentOutOfRangeException("Singer is not in the list.");
 
             // Remove sub singers.
-            var subsingers = GetSubSingers(singer);
+            var subSingers = GetSubSingers(singer);
 
-            foreach (var subsinger in subsingers)
+            foreach (var subSinger in subSingers)
             {
-                RemoveSubSinger(subsinger);
+                RemoveSubSinger(subSinger);
             }
 
             // remove singer

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             var availableTranslate = beatmap?.AvailableTranslates();
             var selectedLanguage = availableTranslate?.FirstOrDefault(t => t.Name == preferLanguage) ?? availableTranslate?.FirstOrDefault();
             Set(KaraokeRulesetSession.UseTranslate, useTranslate);
-            Set(KaraokeRulesetSession.PreferLanguage, selectedLanguage);
+            Set(KaraokeRulesetSession.PreferLanguage, selectedLanguage?.Name ?? "");
 
             var displayRuby = getValue<bool>(KaraokeRulesetSetting.DisplayRuby);
             var displayRomaji = getValue<bool>(KaraokeRulesetSetting.DisplayRomaji);

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             var useTranslate = getValue<bool>(KaraokeRulesetSetting.UseTranslate);
             var preferLanguage = getValue<string>(KaraokeRulesetSetting.PreferLanguage);
             var availableTranslate = beatmap?.AvailableTranslates();
-            var selectedLanguage = availableTranslate?.FirstOrDefault(t => t == preferLanguage) ?? availableTranslate?.FirstOrDefault();
+            var selectedLanguage = availableTranslate?.FirstOrDefault(t => t.Name == preferLanguage) ?? availableTranslate?.FirstOrDefault();
             Set(KaraokeRulesetSession.UseTranslate, useTranslate);
             Set(KaraokeRulesetSession.PreferLanguage, selectedLanguage);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             }
 
             if (EditorBeatmap.SelectedHitObjects.All(x => x is Note)
-                && EditorBeatmap.SelectedHitObjects.Count() > 1)
+                && EditorBeatmap.SelectedHitObjects.Count > 1)
             {
                 var menu = new List<MenuItem>();
                 var selectedObject = EditorBeatmap.SelectedHitObjects.Cast<Note>().OrderBy(x => x.StartTime);

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPractice.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPractice.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Mods
                 Name = "Toggle Practice",
                 Text = "Practice",
                 TooltipText = "Open/Close practice overlay",
-                Action = () => ToggleVisibility()
+                Action = ToggleVisibility
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyricLine.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyricLine.cs
@@ -42,7 +42,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.TopLeft,
-                    Text = hitObject.TranslateText
                 }
             };
 

--- a/osu.Game.Rulesets.Karaoke/Objects/LegacyPropertyDictionary.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/LegacyPropertyDictionary.cs
@@ -2,13 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
     public class LegacyPropertyDictionary : KaraokeHitObject
     {
-        public IDictionary<string, List<string>> Translates { get; } = new Dictionary<string, List<string>>();
+        public BeatmapSetOnlineLanguage[] AvailableTranslates { get; set; }
 
         public IDictionary<int, Singer> Singers { get; set; } = new Dictionary<int, Singer>();
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/LyricLine.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/LyricLine.cs
@@ -119,13 +119,23 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         public readonly Bindable<string> TranslateTextBindable = new Bindable<string>();
 
         /// <summary>
-        /// Translate text
+        /// Translates
         /// </summary>
-        [JsonIgnore]
-        public string TranslateText
+        public IDictionary<int, string> Translates { get; set; }
+
+        /// <summary>
+        /// Display target translate
+        /// </summary>
+        /// <param name="id"></param>
+        public bool ApplyDisplayTranslate(int id)
         {
-            get => TranslateTextBindable.Value;
-            set => TranslateTextBindable.Value = value;
+            if (Translates.TryGetValue(id, out string translate))
+            {
+                TranslateTextBindable.Value = translate;
+                return true;
+            }
+
+            return false;
         }
 
         public IEnumerable<Note> CreateDefaultNotes()

--- a/osu.Game.Rulesets.Karaoke/Objects/LyricLine.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/LyricLine.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// <summary>
         /// Translates
         /// </summary>
-        public IDictionary<int, string> Translates { get; set; }
+        public IDictionary<int, string> Translates { get; set; } = new Dictionary<int, string>();
 
         /// <summary>
         /// Display target translate

--- a/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
+++ b/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
 
                 foreach (var noteEvent in noteEvents)
                 {
-                    // TOOD : add note into here
+                    // TODO : add note into here
                 }
 
                 // todo : add list of note colors to present state.
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
             {
                 internal DrawableNote(HitResult result)
                 {
-                    // TOOD : assign color with different hit result.
+                    // TODO : assign color with different hit result.
                 }
             }
         }

--- a/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -73,9 +72,9 @@ namespace osu.Game.Rulesets.Karaoke.UI
             var lyrics = Beatmap.HitObjects.OfType<LyricLine>().ToList();
             var availableTranslates = Beatmap.AvailableTranslates();
 
-
             // If contain target language
             var targetTranslateLanguage = availableTranslates.FirstOrDefault(x => x.Name == targetLanguage);
+
             if (isTranslate && targetTranslateLanguage != null)
             {
                 lyrics.ForEach(x => x.ApplyDisplayTranslate(targetTranslateLanguage.Id));

--- a/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
@@ -70,23 +70,15 @@ namespace osu.Game.Rulesets.Karaoke.UI
             var isTranslate = translate.Value;
             var targetLanguage = translateLanguage.Value;
 
-            var lyric = Beatmap.HitObjects.OfType<LyricLine>().ToList();
-            var translateDictionary = Beatmap.GetTranslates();
+            var lyrics = Beatmap.HitObjects.OfType<LyricLine>().ToList();
+            var availableTranslates = Beatmap.AvailableTranslates();
 
-            // Clear exist translate
-            lyric.ForEach(x => x.TranslateText = null);
 
             // If contain target language
-            if (isTranslate && targetLanguage != null
-                            && Beatmap.AvailableTranslates().Contains(targetLanguage))
+            var targetTranslateLanguage = availableTranslates.FirstOrDefault(x => x.Name == targetLanguage);
+            if (isTranslate && targetTranslateLanguage != null)
             {
-                var translate = Beatmap.GetTranslate(targetLanguage);
-
-                // Apply translate
-                for (int i = 0; i < Math.Min(lyric.Count, translate.Count); i++)
-                {
-                    lyric[i].TranslateText = translate[i];
-                }
+                lyrics.ForEach(x => x.ApplyDisplayTranslate(targetTranslateLanguage.Id));
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/ControlOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/ControlOverlay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Overlays.Settings
 
             // Add translate group if this beatmap has translate
             if (beatmap.AnyTranslate())
-                Add(new TranslateSettings(beatmap.GetTranslates()) { Expanded = false });
+                Add(new TranslateSettings(beatmap.AvailableTranslates()) { Expanded = false });
         }
 
         public override SettingButton CreateToggleButton() => new SettingButton

--- a/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/PlayerSettings/TranslateSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/PlayerSettings/TranslateSettings.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -35,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Overlays.Settings.PlayerSettings
                 translateDropDown = new OsuDropdown<string>
                 {
                     RelativeSizeAxes = Axes.X,
-                    Items = translates.Select(x=>x.Name)
+                    Items = translates.Select(x => x.Name)
                 },
             };
         }

--- a/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/PlayerSettings/TranslateSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Overlays/Settings/PlayerSettings/TranslateSettings.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
@@ -17,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Overlays.Settings.PlayerSettings
         private readonly OsuSpriteText translateText;
         private readonly OsuDropdown<string> translateDropDown;
 
-        public TranslateSettings(IDictionary<string, List<string>> translates)
+        public TranslateSettings(BeatmapSetOnlineLanguage[] translates)
             : base("Translate")
         {
             Children = new Drawable[]
@@ -33,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Overlays.Settings.PlayerSettings
                 translateDropDown = new OsuDropdown<string>
                 {
                     RelativeSizeAxes = Axes.X,
-                    Items = translates.Keys
+                    Items = translates.Select(x=>x.Name)
                 },
             };
         }


### PR DESCRIPTION
Implementation of #205 

What's update in this branch : 
- [x] add `IDictionary<int, string> Translates` in `LyricLine` to record list of translates. 
- [x] add `BeatmapSetOnlineLanguage[] AvailableTranslates` in `KaraokeBeatmap` and `LegacyPropertyDictionary` to record has how many lyric translate can be use.
- [x] remove exist `IDictionary<string, List<string>>`.
- [x] fix compile error
- [x] fix test case error
- [x] post clean-up code. 
