### PR TITLE
Record fill time tags(include duplicated).

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
@@ -17,14 +17,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
         [Test]
         public void TestSerialize()
         {
-            var rowTimeTag = new List<Tuple<TimeTagIndex, double>>
+            var rowTimeTag = new List<Tuple<TimeTagIndex, double?>>
             {
-                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.Start), 1000d),
-                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1100d),
-                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1200d),
+                Tuple.Create<TimeTagIndex, double?>(new TimeTagIndex(0, TimeTagIndex.IndexState.Start), 1000d),
+                Tuple.Create<TimeTagIndex, double?>(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1100d),
+                Tuple.Create<TimeTagIndex, double?>(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1200d),
             };
 
             var result = JsonConvert.SerializeObject(rowTimeTag, createSettings());
+
             Assert.AreEqual(result, "[\r\n  \"0,0,1000\",\r\n  \"0,1,1100\",\r\n  \"0,1,1200\"\r\n]");
         }
 
@@ -32,10 +33,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
         public void TestDeserialize()
         {
             var jsonString = "[\r\n  \"0,0,1000\",\r\n  \"0,1,1100\",\r\n  \"0,1,1200\"\r\n]";
-            var result = JsonConvert.DeserializeObject<List<Tuple<TimeTagIndex, double>>>(jsonString, createSettings());
+            var result = JsonConvert.DeserializeObject<List<Tuple<TimeTagIndex, double?>>>(jsonString, createSettings());
+
             Assert.AreEqual(result.Count, 3);
-
-
             Assert.AreEqual(result[0].Item1.Index, 0);
             Assert.AreEqual(result[0].Item1.State, TimeTagIndex.IndexState.Start);
             Assert.AreEqual(result[0].Item2, 1000);

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.IO.Serialization;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
+{
+    [TestFixture]
+    public class TimeTagsConverterTest
+    {
+        [Test]
+        public void TestSerialize()
+        {
+            var rowTimeTag = new List<Tuple<TimeTagIndex, double>>
+            {
+                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.Start), 1000d),
+                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1100d),
+                Tuple.Create(new TimeTagIndex(0, TimeTagIndex.IndexState.End), 1200d),
+            };
+
+            var result = JsonConvert.SerializeObject(rowTimeTag, createSettings());
+            Assert.AreEqual(result, "[\r\n  \"0,0,1000\",\r\n  \"0,1,1100\",\r\n  \"0,1,1200\"\r\n]");
+        }
+
+        [Test]
+        public void TestDeserialize()
+        {
+            var jsonString = "[\r\n  \"0,0,1000\",\r\n  \"0,1,1100\",\r\n  \"0,1,1200\"\r\n]";
+            var result = JsonConvert.DeserializeObject<List<Tuple<TimeTagIndex, double>>>(jsonString, createSettings());
+            Assert.AreEqual(result.Count, 3);
+
+
+            Assert.AreEqual(result[0].Item1.Index, 0);
+            Assert.AreEqual(result[0].Item1.State, TimeTagIndex.IndexState.Start);
+            Assert.AreEqual(result[0].Item2, 1000);
+        }
+
+        private JsonSerializerSettings createSettings()
+        {
+            var globalSetting = JsonSerializableExtensions.CreateGlobalSettings();
+            globalSetting.Converters = new JsonConverter[] { new TimeTagsConverter() };
+            return globalSetting;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Import/ImportManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Import/ImportManager.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Import
                 */
 
                 // Import and replace all the file.
-                using (var reader = new IO.LineBufferedReader(stream))
+                using (var reader = new Game.IO.LineBufferedReader(stream))
                 {
                     var decoder = new LrcDecoder();
                     var lrcBeatmap = decoder.Decode(reader);

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
@@ -10,9 +10,9 @@ using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
 {
-    public class TimeTagsConverter : JsonConverter<List<Tuple<TimeTagIndex, double>>>
+    public class TimeTagsConverter : JsonConverter<List<Tuple<TimeTagIndex, double?>>>
     {
-        public override List<Tuple<TimeTagIndex, double>> ReadJson(JsonReader reader, Type objectType, List<Tuple<TimeTagIndex, double>> existingValues, bool hasExistingValue, JsonSerializer serializer)
+        public override List<Tuple<TimeTagIndex, double?>> ReadJson(JsonReader reader, Type objectType, List<Tuple<TimeTagIndex, double?>> existingValues, bool hasExistingValue, JsonSerializer serializer)
         {
             var obj = JArray.Load(reader);
 
@@ -22,18 +22,18 @@ namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
                 return deserializeTuple(value);
             }).ToList();
 
-            Tuple<TimeTagIndex, double> deserializeTuple(string str)
+            Tuple<TimeTagIndex, double?> deserializeTuple(string str)
             {
                 var strArray = str.Split(',');
 
                 var state = strArray[1] == "0" ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
                 var timeTag = new TimeTagIndex(int.Parse(strArray[0]), state);
-                var time = int.Parse(strArray[2]);
-                return new Tuple<TimeTagIndex, double>(timeTag, time);
+                var time = strArray[2] != "" ? int.Parse(strArray[2]) : default(double?);
+                return new Tuple<TimeTagIndex, double?>(timeTag, time);
             }
         }
 
-        public override void WriteJson(JsonWriter writer, List<Tuple<TimeTagIndex, double>> values, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, List<Tuple<TimeTagIndex, double?>> values, JsonSerializer serializer)
         {
             writer.WriteStartArray();
 
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
 
             writer.WriteEndArray();
 
-            string serializeTuple(Tuple<TimeTagIndex, double> timeTagTuple)
+            string serializeTuple(Tuple<TimeTagIndex, double?> timeTagTuple)
             {
                 var tag = timeTagTuple.Item1;
                 var state = tag.State == TimeTagIndex.IndexState.Start ? "0" : "1";

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using osu.Framework.Graphics.Sprites;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public class TimeTagsConverter : JsonConverter<List<Tuple<TimeTagIndex, double>>>
+    {
+        public override List<Tuple<TimeTagIndex, double>> ReadJson(JsonReader reader, Type objectType, List<Tuple<TimeTagIndex, double>> existingValues, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var obj = JArray.Load(reader);
+
+            return obj.Select(line =>
+            {
+                var value = line.ToString();
+                return deserializeTuple(value);
+            }).ToList();
+
+            Tuple<TimeTagIndex, double> deserializeTuple(string str)
+            {
+                var strArray = str.Split(',');
+
+                var state = strArray[1] == "0" ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
+                var timeTag = new TimeTagIndex(int.Parse(strArray[0]), state);
+                var time = int.Parse(strArray[2]);
+                return new Tuple<TimeTagIndex, double>(timeTag, time);
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, List<Tuple<TimeTagIndex, double>> values, JsonSerializer serializer)
+        {
+            writer.WriteStartArray();
+
+            foreach (var value in values)
+            {
+                writer.WriteValue(serializeTuple(value));
+            }
+
+            writer.WriteEndArray();
+
+            string serializeTuple(Tuple<TimeTagIndex, double> timeTagTuple)
+            {
+                var tag = timeTagTuple.Item1;
+                var state = tag.State == TimeTagIndex.IndexState.Start ? "0" : "1";
+                var time = timeTagTuple.Item2;
+                return $"{tag.Index},{state},{time}";
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
@@ -10,9 +10,9 @@ using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
 {
-    public class TimeTagsConverter : JsonConverter<List<Tuple<TimeTagIndex, double?>>>
+    public class TimeTagsConverter : JsonConverter<IReadOnlyList<Tuple<TimeTagIndex, double?>>>
     {
-        public override List<Tuple<TimeTagIndex, double?>> ReadJson(JsonReader reader, Type objectType, List<Tuple<TimeTagIndex, double?>> existingValues, bool hasExistingValue, JsonSerializer serializer)
+        public override IReadOnlyList<Tuple<TimeTagIndex, double?>> ReadJson(JsonReader reader, Type objectType, IReadOnlyList<Tuple<TimeTagIndex, double?>> existingValues, bool hasExistingValue, JsonSerializer serializer)
         {
             var obj = JArray.Load(reader);
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
             }
         }
 
-        public override void WriteJson(JsonWriter writer, List<Tuple<TimeTagIndex, double?>> values, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, IReadOnlyList<Tuple<TimeTagIndex, double?>> values, JsonSerializer serializer)
         {
             writer.WriteStartArray();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -41,6 +42,8 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             get => TimeTagsBindable.Value;
             set => TimeTagsBindable.Value = value;
         }
+
+        public List<Tuple<TimeTagIndex, double>> RowTimeTags { get; set; }
 
         public double LyricStartTime => TimeTags?.FirstOrDefault().Value ?? StartTime;
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -37,13 +37,13 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// <summary>
         /// Time tags
         /// </summary>
-        public IReadOnlyDictionary<TimeTagIndex, double?> TimeTags
+        public IReadOnlyDictionary<TimeTagIndex, double> TimeTags
         {
             get => TimeTagsBindable.Value;
             set => TimeTagsBindable.Value = value;
         }
 
-        public List<Tuple<TimeTagIndex, double>> RowTimeTags { get; set; }
+        public List<Tuple<TimeTagIndex, double?>> RowTimeTags { get; set; }
 
         public double LyricStartTime => TimeTags?.FirstOrDefault().Value ?? StartTime;
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             set => TimeTagsBindable.Value = value;
         }
 
-        public List<Tuple<TimeTagIndex, double?>> RowTimeTags { get; set; }
+        public IReadOnlyList<Tuple<TimeTagIndex, double?>> RowTimeTags { get; set; }
 
         public double LyricStartTime => TimeTags?.FirstOrDefault().Value ?? StartTime;
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// <summary>
         /// Time tags
         /// </summary>
-        public IReadOnlyDictionary<TimeTagIndex, double> TimeTags
+        public IReadOnlyDictionary<TimeTagIndex, double?> TimeTags
         {
             get => TimeTagsBindable.Value;
             set => TimeTagsBindable.Value = value;


### PR DESCRIPTION
It might use json as future beatmap's format, so write json convertor to deal with this.

Also, add `RowTimeTags` to record all `timetags` because it might have duplicated `timetag` in `japanese lyric`.