### PR TITLE
Update to latest version.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Timeline/TimelineBlueprintContainer.cs
@@ -37,7 +37,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Timeline
 
         private SelectionBlueprint placementBlueprint;
 
-        public TimelineBlueprintContainer()
+        public TimelineBlueprintContainer(HitObjectComposer composer)
+            : base(composer)
         {
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class KaraokeBlueprintContainer : ComposeBlueprintContainer
     {
-        public KaraokeBlueprintContainer(IEnumerable<DrawableHitObject> drawableHitObjects)
-            : base(drawableHitObjects)
+        public KaraokeBlueprintContainer(HitObjectComposer composer)
+            : base(composer)
         {
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -71,8 +71,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         protected override DrawableRuleset<KaraokeHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             => drawableRuleset = new DrawableKaraokeEditRuleset(ruleset, beatmap, mods);
 
-        protected override ComposeBlueprintContainer CreateBlueprintContainer(IEnumerable<DrawableHitObject> hitObjects)
-            => new KaraokeBlueprintContainer(hitObjects);
+        protected override ComposeBlueprintContainer CreateBlueprintContainer()
+            => new KaraokeBlueprintContainer(this);
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => Array.Empty<HitObjectCompositionTool>();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
             return true;
         }
 
-        protected override Drawable CreateTimelineContent() => new TimelineBlueprintContainer();
+        protected override Drawable CreateTimelineContent() => new TimelineBlueprintContainer(null);
 
         protected override Drawable CreateMainContent()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
@@ -40,6 +40,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
         [Resolved(CanBeNull = true)]
         private DialogOverlay dialogOverlay { get; set; }
 
+        [Resolved(CanBeNull = true)]
+        private KaraokeHitObjectComposer composer { get; set; }
+
         public LyricEditorScreen()
             : base(EditorScreenMode.Compose)
         {
@@ -70,7 +73,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
             return true;
         }
 
-        protected override Drawable CreateTimelineContent() => new TimelineBlueprintContainer(null);
+        protected override Drawable CreateTimelineContent() => new TimelineBlueprintContainer(composer);
 
         protected override Drawable CreateMainContent()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,8 +22,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components
             this.singer = singer;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        [BackgroundDependencyLoader(true)]
+        private void load(OverlayColourProvider colourProvider, [CanBeNull]KaraokeHitObjectComposer composer)
         {
             InternalChildren = new Drawable[]
             {
@@ -57,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components
                             new SingerTimeline
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Child = new LyricBlueprintContainer(null, singer)
+                                Child = new LyricBlueprintContainer(composer, singer)
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components
                             new SingerTimeline
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Child = new LyricBlueprintContainer(singer)
+                                Child = new LyricBlueprintContainer(null, singer)
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/LyricBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/LyricBlueprintContainer.cs
@@ -14,23 +14,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components.Timeline
     {
         private readonly Singer singer;
 
-        public LyricBlueprintContainer(Singer singer)
+        public LyricBlueprintContainer(HitObjectComposer composer, Singer singer)
+            : base(composer)
         {
             this.singer = singer;
-        }
-
-        protected override void AddBlueprintFor(HitObject hitObject)
-        {
-            if (!(hitObject is Lyric))
-                return;
-
-            base.AddBlueprintFor(hitObject);
         }
 
         protected override SelectionHandler CreateSelectionHandler()
             => new LyricTimelineSelectionHandler();
 
         protected override SelectionBlueprint CreateBlueprintFor(HitObject hitObject)
-            => new LyricTimelineHitObjectBlueprint(hitObject, singer);
+        {
+             if (!(hitObject is Lyric))
+                return null;
+
+             return new LyricTimelineHitObjectBlueprint(hitObject, singer);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -2,7 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
@@ -11,6 +15,7 @@ using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
 using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
@@ -21,8 +26,16 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 {
     public class DrawableLyric : DrawableKaraokeHitObject
     {
-        private readonly KarakeSpriteText karaokeText;
-        private readonly OsuSpriteText translateText;
+        private KarakeSpriteText karaokeText;
+        private OsuSpriteText translateText;
+
+        public readonly IBindable<string> TextBindable = new Bindable<string>();
+        public readonly IBindable<Tuple<TimeTagIndex, double?>[]> TimeTagsBindable = new Bindable<Tuple<TimeTagIndex, double?>[]>();
+        public readonly IBindable<RubyTag[]> RubyTagsBindable = new Bindable<RubyTag[]>();
+        public readonly IBindable<RomajiTag[]> RomajiTagsBindable = new Bindable<RomajiTag[]>();
+        public readonly IBindable<int[]> SingersBindable = new Bindable<int[]>();
+        public readonly IBindable<int> LayoutIndexBindable = new Bindable<int>();
+        public readonly IBindable<string> TranslateTextBindable = new Bindable<string>();
 
         /// <summary>
         /// Invoked when a <see cref="JudgementResult"/> has been applied by this <see cref="DrawableHitObject"/> or a nested <see cref="DrawableHitObject"/>.
@@ -31,9 +44,19 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
         public new Lyric HitObject => (Lyric)base.HitObject;
 
-        public DrawableLyric(Lyric hitObject)
+        public DrawableLyric()
+            : this(null)
+        {
+        }
+
+        public DrawableLyric([CanBeNull] Lyric hitObject)
             : base(hitObject)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        { 
             Scale = new Vector2(2f);
             AutoSizeAxes = Axes.Both;
             InternalChildren = new Drawable[]
@@ -46,21 +69,41 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 }
             };
 
-            hitObject.TextBindable.BindValueChanged(text => { karaokeText.Text = text.NewValue; }, true);
+            LifetimeEnd = HitObject.EndTime + 1000;
 
-            hitObject.TimeTagsBindable.BindValueChanged(timeTags => { karaokeText.TimeTags = TimeTagsUtils.ToDictionary(timeTags.NewValue); }, true);
+            TextBindable.BindValueChanged(text => { karaokeText.Text = text.NewValue; });
+            TimeTagsBindable.BindValueChanged(timeTags => { karaokeText.TimeTags = TimeTagsUtils.ToDictionary(timeTags.NewValue); });
+            RubyTagsBindable.BindValueChanged(rubyTags => { ApplyRuby(); });
+            RomajiTagsBindable.BindValueChanged(romajiTags => { ApplyRomaji(); });
+            SingersBindable.BindValueChanged(index => { ApplySkin(CurrentSkin, false); });
+            LayoutIndexBindable.BindValueChanged(index => { ApplySkin(CurrentSkin, false); });
+            TranslateTextBindable.BindValueChanged(text => { translateText.Text = text.NewValue ?? ""; });
+        }
 
-            hitObject.RubyTagsBindable.BindValueChanged(rubyTags => { ApplyRuby(); }, true);
+        protected override void OnApply(HitObject hitObject)
+        {
+            base.OnApply(hitObject);
 
-            hitObject.RomajiTagsBindable.BindValueChanged(romajiTags => { ApplyRomaji(); }, true);
+            TextBindable.BindTo(HitObject.TextBindable);
+            TimeTagsBindable.BindTo(HitObject.TimeTagsBindable);
+            RubyTagsBindable.BindTo(HitObject.RubyTagsBindable);
+            RomajiTagsBindable.BindTo(HitObject.RomajiTagsBindable);
+            SingersBindable.BindTo(HitObject.SingersBindable);
+            LayoutIndexBindable.BindTo(HitObject.LayoutIndexBindable);
+            TranslateTextBindable.BindTo(HitObject.TranslateTextBindable);
+        }
 
-            hitObject.SingersBindable.BindValueChanged(index => { ApplySkin(CurrentSkin, false); }, true);
+        protected override void OnFree(HitObject hitObject)
+        {
+            base.OnFree(hitObject);
 
-            hitObject.LayoutIndexBindable.BindValueChanged(index => { ApplySkin(CurrentSkin, false); }, true);
-
-            hitObject.TranslateTextBindable.BindValueChanged(text => { translateText.Text = text.NewValue ?? ""; }, true);
-
-            LifetimeEnd = hitObject.EndTime + 1000;
+            TextBindable.UnbindFrom(HitObject.TextBindable);
+            TimeTagsBindable.UnbindFrom(HitObject.TimeTagsBindable);
+            RubyTagsBindable.UnbindFrom(HitObject.RubyTagsBindable);
+            RomajiTagsBindable.UnbindFrom(HitObject.RomajiTagsBindable);
+            SingersBindable.UnbindFrom(HitObject.SingersBindable);
+            LayoutIndexBindable.UnbindFrom(HitObject.LayoutIndexBindable);
+            TranslateTextBindable.UnbindFrom(HitObject.TranslateTextBindable);
         }
 
         protected override void ClearInternal(bool disposeChildren = true)
@@ -223,7 +266,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                     return;
 
                 displayRuby = value;
-                ApplyRuby();
+                Schedule(() => ApplyRuby());
             }
         }
 
@@ -238,7 +281,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                     return;
 
                 displayRomaji = value;
-                ApplyRomaji();
+                Schedule(() => ApplyRomaji());
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -106,6 +106,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             TranslateTextBindable.UnbindFrom(HitObject.TranslateTextBindable);
         }
 
+        protected override void UpdateInitialTransforms()
+        {
+            base.UpdateInitialTransforms();
+
+            // Manually set to reduce the number of future alive objects to a bare minimum.
+            LifetimeStart = HitObject.StartTime - HitObject.TimePreempt;
+        }
+
         protected override void ClearInternal(bool disposeChildren = true)
         {
         }

--- a/osu.Game.Rulesets.Karaoke/UI/DrawableNoteJudgement.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/DrawableNoteJudgement.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.UI
 {
@@ -15,22 +16,52 @@ namespace osu.Game.Rulesets.Karaoke.UI
         {
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void ApplyMissAnimations()
         {
-            if (JudgementText != null)
-                JudgementText.Font = JudgementText.Font.With(size: 15);
-        }
+            if (!(JudgementBody.Drawable is DefaultKaraokeJudgementPiece))
+            {
+                // this is temporary logic until mania's skin transformer returns IAnimatableJudgements
+                JudgementBody.ScaleTo(1.6f);
+                JudgementBody.ScaleTo(1, 100, Easing.In);
 
-        protected override double FadeInDuration => 50;
+                JudgementBody.MoveTo(Vector2.Zero);
+                JudgementBody.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                JudgementBody.RotateTo(0);
+                JudgementBody.RotateTo(40, 800, Easing.InQuint);
+                JudgementBody.FadeOutFromOne(800);
+
+                LifetimeEnd = JudgementBody.LatestTransformEndTime;
+            }
+
+            base.ApplyMissAnimations();
+        }
 
         protected override void ApplyHitAnimations()
         {
             JudgementBody.ScaleTo(0.8f);
             JudgementBody.ScaleTo(1, 250, Easing.OutElastic);
 
-            JudgementBody.Delay(FadeInDuration).ScaleTo(0.75f, 250);
-            this.Delay(FadeInDuration).FadeOut(200);
+            JudgementBody.Delay(50)
+                         .ScaleTo(0.75f, 250)
+                         .FadeOut(200);
+        }
+
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultKaraokeJudgementPiece(result);
+
+        private class DefaultKaraokeJudgementPiece : DefaultJudgementPiece
+        {
+            public DefaultKaraokeJudgementPiece(HitResult result)
+                : base(result)
+            {
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                JudgementText.Font = JudgementText.Font.With(size: 25);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="1.0.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.0.10" />
-    <PackageReference Include="ppy.osu.Game" Version="2020.1109.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2020.1114.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />
     <PackageReference Include="NicoKaraParser" Version="1.1.0" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="1.2.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.0.10" />
-    <PackageReference Include="ppy.osu.Game" Version="2020.1114.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2020.1121.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />
     <PackageReference Include="NicoKaraParser" Version="1.1.0" />
     <PackageReference Include="Zipangu" Version="1.1.8" />


### PR DESCRIPTION
Update to latest nuget package.

Seems it will cause some breaking errors : 
- `TimelineBlueprintContainer` not working in `singer` or `lyric maker` screen because it need `HitObjectComposer`.
  - Might create singer's own `HitObjectComposer`(e.g: `SingerHitObjectComposer`) and implement playfield, then in playfield to implement create drawable.
- `Lyric` shows very early in playing screen(Fixed).
- Cannot see result page now, and here's the error.
    > A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Cannot mutate the children of a Loaded CompositeDrawable while not on the update thread. Consider using Schedule to schedule the mutation operation.)
    - Oops It's caused in older version, #249 will handler it.

Also : 
- See `OsuPlayfield` because create drawable is moved into playfield.
- Check `DrawableHitObject` to see is there any change like adding or removing methods.