### PR TITLE
Base implementation of lyric import screen.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
+using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit
+{
+    [TestFixture]
+    public class TestSceneImportLyric : EditorClockTestScene
+    {
+        [Cached(typeof(EditorBeatmap))]
+        [Cached(typeof(IBeatSnapProvider))]
+        private readonly EditorBeatmap editorBeatmap;
+
+        public TestSceneImportLyric()
+        {
+            var beatmap = new TestKaraokeBeatmap(null);
+            var karaokeBeatmap = new KaraokeBeatmapConverter(beatmap, new KaraokeRuleset()).Convert() as KaraokeBeatmap;
+            editorBeatmap = new EditorBeatmap(karaokeBeatmap);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+            Child = new ImportLyricScreen();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
@@ -5,5 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
 {
     public class AssignLanguageSubScreen : ImportLyricSubScreen
     {
+        public override string Title => "Language";
+
+        public override string ShortTitle => "Language";
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
+{
+    public class AssignLanguageSubScreen : ImportLyricSubScreen
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
@@ -8,5 +8,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         public override string Title => "Language";
 
         public override string ShortTitle => "Language";
+
+        public override ImportLyricStep Step => ImportLyricStep.AssignLanguage;
+
+        public override void Complete()
+        {
+            ScreenStack.Push(ImportLyricStep.GenerateRuby);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
+{
+    public class DragFileSubScreen : ImportLyricSubScreen
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -8,5 +8,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
         public override string Title => "Import";
 
         public override string ShortTitle => "Import";
+
+        public override ImportLyricStep Step => ImportLyricStep.ImportLyric;
+
+        public override void Complete()
+        {
+            ScreenStack.Push(ImportLyricStep.AssignLanguage);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -5,5 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 {
     public class DragFileSubScreen : ImportLyricSubScreen
     {
+        public override string Title => "Import";
+
+        public override string ShortTitle => "Import";
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
@@ -5,5 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby
 {
     public class GenerateRubySubScreen : ImportLyricSubScreen
     {
+        public override string Title => "Generate ruby";
+
+        public override string ShortTitle => "Generate ruby";
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
@@ -8,5 +8,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby
         public override string Title => "Generate ruby";
 
         public override string ShortTitle => "Generate ruby";
+
+        public override ImportLyricStep Step => ImportLyricStep.GenerateRuby;
+
+        public override void Complete()
+        {
+            ScreenStack.Push(ImportLyricStep.GenerateTimeTag);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby
+{
+    public class GenerateRubySubScreen : ImportLyricSubScreen
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
@@ -5,5 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
 {
     public class GenerateTimeTagSubScreen : ImportLyricSubScreen
     {
+        public override string Title => "Generate time tag";
+
+        public override string ShortTitle => "Generate time tag";
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
+{
+    public class GenerateTimeTagSubScreen : ImportLyricSubScreen
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
@@ -8,5 +8,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
         public override string Title => "Generate time tag";
 
         public override string ShortTitle => "Generate time tag";
+
+        public override ImportLyricStep Step => ImportLyricStep.GenerateTimeTag;
+
+        public override void Complete()
+        {
+            ScreenStack.Push(ImportLyricStep.Success);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Screens;
+using osuTK;
+using osuTK.Graphics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public class Header : Container
+    {
+        public const float HEIGHT = 80;
+
+        public Header(ScreenStack stack)
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
+
+            HeaderBreadcrumbControl breadcrumbs;
+            ImportLyricHeaderTitle title;
+
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4Extensions.FromHex(@"#1f1921"),
+                },
+                new Container
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Left = WaveOverlayContainer.WIDTH_PADDING + OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
+                    Children = new Drawable[]
+                    {
+                        title = new ImportLyricHeaderTitle
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.BottomLeft,
+                        },
+                        breadcrumbs = new HeaderBreadcrumbControl(stack)
+                        {
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft
+                        }
+                    },
+                },
+            };
+
+            breadcrumbs.Current.ValueChanged += screen =>
+            {
+                if (screen.NewValue is IImportLyricSubScreen multiScreen)
+                    title.Screen = multiScreen;
+            };
+
+            breadcrumbs.Current.TriggerChange();
+        }
+
+        private class ImportLyricHeaderTitle : CompositeDrawable
+        {
+            private const float spacing = 6;
+
+            private readonly OsuSpriteText dot;
+            private readonly OsuSpriteText pageTitle;
+
+            public IImportLyricSubScreen Screen
+            {
+                set => pageTitle.Text = value.ShortTitle;
+            }
+
+            public ImportLyricHeaderTitle()
+            {
+                AutoSizeAxes = Axes.Both;
+
+                InternalChildren = new Drawable[]
+                {
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Spacing = new Vector2(spacing, 0),
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: 24),
+                                Text = "Import lyric"
+                            },
+                            dot = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: 24),
+                                Text = "·"
+                            },
+                            pageTitle = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: 24),
+                            }
+                        }
+                    },
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                pageTitle.Colour = dot.Colour = colours.Yellow;
+            }
+        }
+
+        private class HeaderBreadcrumbControl : ScreenBreadcrumbControl
+        {
+            public HeaderBreadcrumbControl(ScreenStack stack)
+                : base(stack)
+            {
+                RelativeSizeAxes = Axes.X;
+                StripColour = Color4.Transparent;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                AccentColour = Color4Extensions.FromHex("#e35c99");
+            }
+
+            protected override TabItem<IScreen> CreateTabItem(IScreen value) => new HeaderBreadcrumbTabItem(value)
+            {
+                AccentColour = AccentColour
+            };
+
+            private class HeaderBreadcrumbTabItem : BreadcrumbTabItem
+            {
+                public HeaderBreadcrumbTabItem(IScreen value)
+                    : base(value)
+                {
+                    Bar.Colour = Color4.Transparent;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
@@ -15,8 +15,6 @@ using osu.Game.Overlays;
 using osu.Game.Screens;
 using osuTK;
 using osuTK.Graphics;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
@@ -5,6 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public interface IImportLyricSubScreen
     {
+        ImportLyricStep Step { get; }
+
         string Title { get; }
 
         string ShortTitle { get; }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public interface IImportLyricSubScreen
+    {
+        string Title { get; }
+
+        string ShortTitle { get; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
@@ -1,15 +1,69 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public class ImportLyricScreen : EditorScreen
     {
+        private readonly ImportLyricWaveContainer waves;
+        private readonly ScreenStack screenStack;
+
         public ImportLyricScreen()
             : base(EditorScreenMode.SongSetup)
         {
+            var backgroundColour = Color4Extensions.FromHex(@"3e3a44");
+
+            InternalChild = waves = new ImportLyricWaveContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = backgroundColour,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Top = Header.HEIGHT },
+                        Child = screenStack = new ImportLyricSubScreenStack { RelativeSizeAxes = Axes.Both }
+                    },
+                    new Header(screenStack),
+                }
+            };
+
+            screenStack.Push(new DragFileSubScreen());
+            screenStack.Push(new AssignLanguageSubScreen());
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            waves.Show();
+        }
+
+        private class ImportLyricWaveContainer : WaveContainer
+        {
+            protected override bool StartHidden => true;
+
+            public ImportLyricWaveContainer()
+            {
+                FirstWaveColour = Color4Extensions.FromHex(@"654d8c");
+                SecondWaveColour = Color4Extensions.FromHex(@"554075");
+                ThirdWaveColour = Color4Extensions.FromHex(@"44325e");
+                FourthWaveColour = Color4Extensions.FromHex(@"392850");
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public class ImportLyricScreen : EditorScreen
+    {
+        public ImportLyricScreen()
+            : base(EditorScreenMode.SongSetup)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage;
-using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
@@ -16,7 +14,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
     public class ImportLyricScreen : EditorScreen
     {
         private readonly ImportLyricWaveContainer waves;
-        private readonly ScreenStack screenStack;
+
+        [Cached]
+        private readonly ImportLyricSubScreenStack screenStack;
 
         public ImportLyricScreen()
             : base(EditorScreenMode.SongSetup)
@@ -43,8 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
                 }
             };
 
-            screenStack.Push(new DragFileSubScreen());
-            screenStack.Push(new AssignLanguageSubScreen());
+            screenStack.Push(ImportLyricStep.ImportLyric);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricStep.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricStep.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public enum ImportLyricStep
+    {
+        ImportLyric,
+
+        AssignLanguage,
+
+        GenerateRuby,
+
+        GenerateTimeTag,
+
+        Success,
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -7,9 +7,11 @@ using osu.Game.Screens;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
-    public class ImportLyricSubScreen : OsuScreen
+    public abstract class ImportLyricSubScreen : OsuScreen, IImportLyricSubScreen
     {
         [Cached]
         private readonly Bindable<ImportLyricStep> Step = new Bindable<ImportLyricStep>();
+
+        public abstract string ShortTitle { get; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -2,16 +2,36 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public abstract class ImportLyricSubScreen : OsuScreen, IImportLyricSubScreen
     {
-        [Cached]
-        private readonly Bindable<ImportLyricStep> Step = new Bindable<ImportLyricStep>();
+        [Resolved]
+        protected ImportLyricSubScreenStack ScreenStack { get; private set; }
 
         public abstract string ShortTitle { get; }
+
+        public abstract ImportLyricStep Step { get; }
+
+        public ImportLyricSubScreen()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new OsuButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 240,
+                    Text = $"{Title}, Click to next step.",
+                    Action = Complete
+                }
+            };
+        }
+
+        public abstract void Complete();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Screens;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public class ImportLyricSubScreen : OsuScreen
+    {
+        [Cached]
+        private readonly Bindable<ImportLyricStep> Step = new Bindable<ImportLyricStep>();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Screens;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens;
 
@@ -10,6 +11,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public abstract class ImportLyricSubScreen : OsuScreen, IImportLyricSubScreen
     {
+        public const float X_SHIFT = 200;
+        public const double X_MOVE_DURATION = 800;
+        public const double RESUME_TRANSITION_DELAY = DISAPPEAR_DURATION / 2;
+        public const double APPEAR_DURATION = 800;
+        public const double DISAPPEAR_DURATION = 500;
+
         [Resolved]
         protected ImportLyricSubScreenStack ScreenStack { get; private set; }
 
@@ -19,6 +26,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         public ImportLyricSubScreen()
         {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+
             InternalChildren = new Drawable[]
             {
                 new OsuButton
@@ -32,6 +43,35 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
             };
         }
 
+        public override void OnEntering(IScreen last)
+        {
+            this.FadeInFromZero(APPEAR_DURATION, Easing.OutQuint);
+            this.FadeInFromZero(APPEAR_DURATION, Easing.OutQuint);
+            this.MoveToX(X_SHIFT).MoveToX(0, X_MOVE_DURATION, Easing.OutQuint);
+        }
+
+        public override bool OnExiting(IScreen next)
+        {
+            this.FadeOut(DISAPPEAR_DURATION, Easing.OutQuint);
+            this.MoveToX(X_SHIFT, X_MOVE_DURATION, Easing.OutQuint);
+
+            return false;
+        }
+
+        public override void OnResuming(IScreen last)
+        {
+            this.Delay(RESUME_TRANSITION_DELAY).FadeIn(APPEAR_DURATION, Easing.OutQuint);
+            this.MoveToX(0, X_MOVE_DURATION, Easing.OutQuint);
+        }
+
+        public override void OnSuspending(IScreen next)
+        {
+            this.FadeOut(DISAPPEAR_DURATION, Easing.OutQuint);
+            this.MoveToX(-X_SHIFT, X_MOVE_DURATION, Easing.OutQuint);
+        }
+
         public abstract void Complete();
+
+        public override string ToString() => Title;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreenStack.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreenStack.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public class ImportLyricSubScreenStack : OsuScreenStack
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreenStack.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreenStack.cs
@@ -1,11 +1,44 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success;
 using osu.Game.Screens;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public class ImportLyricSubScreenStack : OsuScreenStack
     {
+        public void Push(ImportLyricStep step)
+        {
+            switch (step)
+            {
+                case ImportLyricStep.ImportLyric:
+                    Push(new DragFileSubScreen());
+                    return;
+
+                case ImportLyricStep.AssignLanguage:
+                    Push(new AssignLanguageSubScreen());
+                    return;
+
+                case ImportLyricStep.GenerateRuby:
+                    Push(new GenerateRubySubScreen());
+                    return;
+
+                case ImportLyricStep.GenerateTimeTag:
+                    Push(new GenerateTimeTagSubScreen());
+                    return;
+
+                case ImportLyricStep.Success:
+                    Push(new SuccessSubScreen());
+                    return;
+
+                default:
+                    throw new ScreenNotCurrentException("Screen is not in the lyric import step.");
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
@@ -5,5 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success
 {
     public class SuccessSubScreen : ImportLyricSubScreen
     {
+        public override string Title => "Success";
+
+        public override string ShortTitle => "Success";
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
@@ -8,5 +8,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success
         public override string Title => "Success";
 
         public override string ShortTitle => "Success";
+
+        public override ImportLyricStep Step => ImportLyricStep.GenerateTimeTag;
+
+        public override void Complete()
+        {
+            // todo : close pop-up
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success
+{
+    public class SuccessSubScreen : ImportLyricSubScreen
+    {
+    }
+}


### PR DESCRIPTION
Because don't let user to have chance to mess-up.
So need to make those things in order:
  1. Create lyric text.
  2. Add ruby/romaji(need to check which language this lyric is).
  3. Add time tag(need to add ruby before).

And singer drag cannot handle such complex step, so this PR is create a screen with multi step to handle.
All import `.txt`, `.kar`, `.lrc` file will show this import screen and let use to run all the step.

There are total five step in this import screen:
- Drag
- Set language to each lyric (force)
- Run auto ruby generator and preview(if Japanese lyric contains)
- Run time tag generator and preview.
- Finish

Also, this screen stack design will reference how multi room design.
![image](https://user-images.githubusercontent.com/9100368/99473286-a2991100-298d-11eb-9f0e-48d001aa12ac.png)
