### PR TITLE
Move Generator out of LyricEditor namespace

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags.Ja;
-using osu.Game.Rulesets.Karaoke.Objects;
 using System;
 using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja;
+using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Tests.Edit.LyricEditor.Generator.RubyTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags.Ja
 {
     [TestFixture]
     public class JaRubyTagGeneratorTest

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.TimeTags.Ja;
-using osu.Game.Rulesets.Karaoke.Objects;
 using System;
 using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags.Ja;
+using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Tests.Edit.LyricEditor.Generator.TimeTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
 {
     [TestFixture]
     public class JaTimeTagGeneratorTest

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
 using osu.Game.Rulesets.Karaoke.Utils;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
 {

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Internal;
 using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.IO;
 using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Ja;
 using Lucene.Net.Analysis.TokenAttributes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
-using System.Collections.Generic;
-using System.IO;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja
 {
     public class JaRubyTagGenerator : RubyTagGenerator<JaRubyTagGeneratorConfig>
     {
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags.Ja
 
             // Reset the stream and convert all result
             tokenStream.Reset();
+
             while (true)
             {
                 // Read next token
@@ -51,7 +52,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags.Ja
                     break;
 
                 // Convert to Hiragana as default.
-                if (!Config.RubyAsKatakana) {
+                if (!Config.RubyAsKatakana)
+                {
                     parsedResult = JpStringUtils.ToHiragana(parsedResult);
                 }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja
 {
     public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
@@ -3,7 +3,7 @@
 
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
 {
     public abstract class RubyTagGenerator<T> where T : RubyTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorConfig.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.RubyTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
 {
     public abstract class RubyTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/Ja/JaTimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/Ja/JaTimeTagGenerator.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
-using System;
-using System.Collections.Generic;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.TimeTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags.Ja
 {
     public class JaTimeTagGenerator : TimeTagGenerator<JaTimeTagGeneratorConfig>
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.TimeTags.Ja
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags.Ja
 {
     public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
 {
     public abstract class TimeTagGenerator<T> where T : TimeTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorConfig.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor.Generator.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
 {
     public abstract class TimeTagGeneratorConfig
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Import/ImportLyricDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Import/ImportLyricDialog.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
-using System;
-using System.IO;
 using osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Import

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutManager.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,9 +11,6 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
 using osu.Game.Skinning;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Layout
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/PositionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/PositionSection.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Layout
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/PreviewSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/PreviewSection.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -11,11 +16,6 @@ using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Layout
 {
@@ -74,10 +74,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                 }
             }, true);
 
-            previewSampleDropdown.Current.BindValueChanged(e =>
-            {
-                manager.PreviewLyric.Value = getLyricSampleBySelection(e.NewValue);
-            }, true);
+            previewSampleDropdown.Current.BindValueChanged(e => { manager.PreviewLyric.Value = getLyricSampleBySelection(e.NewValue); }, true);
 
             previewStyleDropdown.Current.BindValueChanged(e =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/RubyRomajiSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/RubyRomajiSection.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Layout
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -9,17 +13,13 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Edit.Import;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Timeline;
+using osu.Game.Rulesets.Karaoke.Edit.Import;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Skinning;
 using osuTK;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/RubyRomaji/Components/LyricList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/RubyRomaji/Components/LyricList.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -14,8 +16,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Graphics;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.RubyRomaji.Components
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/RubyRomaji/RubyRomajiEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/RubyRomaji/RubyRomajiEditSection.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.RubyRomaji
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/LyricPlacementColumn.cs
@@ -45,10 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components
                     {
                         new[]
                         {
-                            CreateSingerInfo(singer).With(x =>
-                            {
-                                x.RelativeSizeAxes = Axes.Both;
-                            }),
+                            CreateSingerInfo(singer).With(x => { x.RelativeSizeAxes = Axes.Both; }),
                             new Box
                             {
                                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/LyricTimelineSelectionHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/LyricTimelineSelectionHandler.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
-using System.Collections.Generic;
-using System.Linq;
 using static osu.Game.Rulesets.Karaoke.Edit.Components.Timeline.TimelineBlueprintContainer;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components.Timeline

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/SingerTimeline.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Components/Timeline/SingerTimeline.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Input.Events;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Components.Timeline
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerEditSection.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Singers.Components;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerHitObjectComposer.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Edit.Tools;
-using osu.Game.Rulesets.Objects.Drawables;
 using System;
 using System.Collections.Generic;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -10,9 +13,6 @@ using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Style/LyricColorSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Style/LyricColorSection.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Style
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Style/LyricFontSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Style/LyricFontSection.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 using osu.Game.Skinning;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Style
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Style/LyricStylePreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Style/LyricStylePreview.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -10,7 +11,6 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
-using System.Collections.Generic;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Style

--- a/osu.Game.Rulesets.Karaoke/Edit/Style/StyleManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Style/StyleManager.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
 using osu.Game.Skinning;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Style
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/LanguageManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/LanguageManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,7 +9,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Translate
 {
@@ -28,10 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
             if (beatmap?.PlayableBeatmap is KaraokeBeatmap karaokeBeatmap)
             {
                 Languages.AddRange(karaokeBeatmap.AvailableTranslates);
-                Languages.BindCollectionChanged((a, b) =>
-                {
-                    karaokeBeatmap.AvailableTranslates = Languages.ToArray();
-                });
+                Languages.BindCollectionChanged((a, b) => { karaokeBeatmap.AvailableTranslates = Languages.ToArray(); });
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateEditSection.cs
@@ -1,23 +1,23 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics;
-using osu.Game.Screens.Edit;
-using System.Linq;
-using osu.Game.Rulesets.Karaoke.Edit.Translate.Components;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
-using osu.Game.Rulesets.Karaoke.Objects;
 using System;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Karaoke.Graphics;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Edit.Translate.Components;
+using osu.Game.Rulesets.Karaoke.Graphics;
+using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Translate
 {
@@ -201,10 +201,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
                 Origin = Anchor.CentreLeft,
                 RelativeSizeAxes = Axes.X,
             };
-            languageDropdown.Current.BindValueChanged(v =>
-            {
-                textBox.Text = lyric.Translates.TryGetValue(v.NewValue.Id, out string translate) ? translate : null;
-            });
+            languageDropdown.Current.BindValueChanged(v => { textBox.Text = lyric.Translates.TryGetValue(v.NewValue.Id, out string translate) ? translate : null; });
             textBox.Current.BindValueChanged(textBoxValue =>
             {
                 var translateText = textBoxValue.NewValue;

--- a/osu.Game.Rulesets.Karaoke/Graphics/Overlays/Dialog/OkPopupDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Overlays/Dialog/OkPopupDialog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Overlays.Dialog;

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledDropdown.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledDropdown.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
-using System.Collections.Generic;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
 {

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledRealTimeSliderBar.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledRealTimeSliderBar.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
-using System;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
 {

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using osu.Framework.Graphics.Sprites;
-using System;
-using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
 {

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinLookup.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinLookup.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Utils;
 using System.IO;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning
 {

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Microsoft.EntityFrameworkCore.Internal;
-using osu.Framework.Graphics.Sprites;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Rulesets.Karaoke.Utils
 {
@@ -181,7 +181,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <param name="other">Fix way</param>
         /// <param name="self">Fix way</param>
         /// <returns>Time tags with dictionary format.</returns>
-        public static IReadOnlyDictionary<TimeTagIndex, double> ToDictionary(Tuple<TimeTagIndex, double?>[] timeTags, bool applyFix = true, GroupCheck other = GroupCheck.Asc, SelfCheck self = SelfCheck.BasedOnStart)
+        public static IReadOnlyDictionary<TimeTagIndex, double> ToDictionary(Tuple<TimeTagIndex, double?>[] timeTags, bool applyFix = true, GroupCheck other = GroupCheck.Asc,
+                                                                             SelfCheck self = SelfCheck.BasedOnStart)
         {
             // sorted value
             var sortedTimeTags = applyFix ? FixInvalid(timeTags, other, self) : Sort(timeTags);


### PR DESCRIPTION
- Move `Generator` out of `LyricEditor` namespace
*- Clean-up some code.