### PR TITLE
Implement drag screen in lyric import.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
@@ -10,8 +10,10 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
 using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Tests.Resources;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Visual;
+using System.IO;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 {
@@ -24,9 +26,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
-        private ImportLyricScreen screen;
-
         private DialogOverlay dialogOverlay;
+        private ImportLyricScreen screen;
+        private ImportLyricManager importManager;
 
         public TestSceneImportLyric()
         {
@@ -44,15 +46,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
             {
                 Content,
                 dialogOverlay = new DialogOverlay(),
+                importManager = new ImportLyricManager()
             });
 
             Dependencies.Cache(dialogOverlay);
+            Dependencies.Cache(importManager);
         }
 
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = screen = new ImportLyricScreen();
+            var temp = TestResources.GetTestLrcForImport("default");
+            Child = screen = new ImportLyricScreen(new FileInfo(temp));
         });
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneImportLyric.cs
@@ -3,6 +3,9 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
@@ -19,6 +22,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
         [Cached(typeof(IBeatSnapProvider))]
         private readonly EditorBeatmap editorBeatmap;
 
+        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+
+        private ImportLyricScreen screen;
+
+        private DialogOverlay dialogOverlay;
+
         public TestSceneImportLyric()
         {
             var beatmap = new TestKaraokeBeatmap(null);
@@ -30,7 +39,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
         private void load()
         {
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
-            Child = new ImportLyricScreen();
+
+            base.Content.AddRange(new Drawable[]
+            {
+                Content,
+                dialogOverlay = new DialogOverlay(),
+            });
+
+            Dependencies.Cache(dialogOverlay);
         }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = screen = new ImportLyricScreen();
+        });
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricEditorScreen.cs
@@ -9,7 +9,7 @@ using osu.Framework.Timing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
-using osu.Game.Rulesets.Karaoke.Edit.Import;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
 using osu.Game.Rulesets.Karaoke.Edit.LyricEditor;
 using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Tests.Resources;
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 
         private LyricEditorScreen screen;
 
-        private ImportManager importManager;
+        private ImportLyricManager importManager;
 
         public TestSceneLyricEditorScreen()
         {
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
             {
                 Content,
                 dialogOverlay = new DialogOverlay(),
-                importManager = new ImportManager()
+                importManager = new ImportLyricManager()
             });
 
             Dependencies.Cache(dialogOverlay);

--- a/osu.Game.Rulesets.Karaoke/Edit/Import/ImportManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Import/ImportManager.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
-using osu.Game.Screens.Edit;
 using System.IO;
 using System.Linq;
 
@@ -14,52 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Import
 {
     public class ImportManager : Component
     {
-        public static string[] LyricFormatExtensions { get; } = { ".lrc", ".kar" };
         public static string[] NicokaraSkinFormatExtensions { get; } = { ".nkmproj" };
-
-        private const string backup_lrc_name = "backup.lrc";
-
-        [Resolved]
-        private EditorBeatmap editorBeatmap { get; set; }
-
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
-
-        public void ImportLrcFile(FileInfo info)
-        {
-            if (!info.Exists)
-                throw new FileNotFoundException("Lyric file does not found!");
-
-            var isFormatMatch = LyricFormatExtensions.Contains(info.Extension);
-            if (!isFormatMatch)
-                throw new FileLoadException("Only .lrc or .kar karaoke file is supported now");
-
-            var set = beatmap.Value.BeatmapSetInfo;
-            var oldFile = set.Files?.FirstOrDefault(f => f.Filename == backup_lrc_name);
-
-            using (var stream = info.OpenRead())
-            {
-                // todo : make a backup if has new lyric file.
-                /*
-                if (oldFile != null)
-                    beatmaps.ReplaceFile(set, oldFile, stream, backup_lrc_name);
-                else
-                    beatmaps.AddFile(set, stream, backup_lrc_name);
-                */
-
-                // Import and replace all the file.
-                using (var reader = new Game.IO.LineBufferedReader(stream))
-                {
-                    var decoder = new LrcDecoder();
-                    var lrcBeatmap = decoder.Decode(reader);
-
-                    // todo : remove all notes and lyric
-                    // or just clear all beatmap because not really sure is singer should be removed also?
-
-                    // then re-add the lyric.
-                }
-            }
-        }
 
         public void ImportNicokaraSkinFile(FileInfo info)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageSubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
 {
     public class AssignLanguageSubScreen : ImportLyricSubScreen
@@ -10,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         public override string ShortTitle => "Language";
 
         public override ImportLyricStep Step => ImportLyricStep.AssignLanguage;
+
+        public override IconUsage Icon => FontAwesome.Solid.Globe;
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/Components/DrawableDragFile.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/Components/DrawableDragFile.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile.Components
+{
+    public class DrawableDragFile : Container
+    {
+        public DrawableDragFile()
+        {
+            Masking = true;
+            BorderThickness = 5;
+            BorderColour = Colour4.White;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Name = "Printing border stupid box",
+                    RelativeSizeAxes = Axes.Both,
+                    AlwaysPresent = true,
+                    Alpha = 0
+                },
+                new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Spacing = new Vector2(10),
+                    Direction = FillDirection.Horizontal,
+                    Children = new Drawable[]
+                    {
+                        new SpriteIcon
+                        {
+                            Size = new Vector2(32),
+                            Icon = FontAwesome.Solid.Upload
+                        },
+                        new SpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Text = "Drag file into here"
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
                     return;
                 }
 
-                DialogOverlay.Push(new ImportLyricDialog(fileInfo, execute =>
+                DialogOverlay.Push(new ImportLyricDialog(execute =>
                 {
                     if (!execute)
                         return;

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 {
     public class DragFileSubScreen : ImportLyricSubScreen
@@ -10,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
         public override string ShortTitle => "Import";
 
         public override ImportLyricStep Step => ImportLyricStep.ImportLyric;
+
+        public override IconUsage Icon => FontAwesome.Solid.Upload;
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -1,19 +1,52 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Database;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile.Components;
+using osuTK;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 {
-    public class DragFileSubScreen : ImportLyricSubScreen
+    public class DragFileSubScreen : ImportLyricSubScreen, ICanAcceptFiles
     {
         public override string Title => "Import";
-
         public override string ShortTitle => "Import";
-
         public override ImportLyricStep Step => ImportLyricStep.ImportLyric;
-
         public override IconUsage Icon => FontAwesome.Solid.Upload;
+
+        public IEnumerable<string> HandledExtensions => ImportLyricManager.LyricFormatExtensions;
+
+        public DragFileSubScreen()
+        {
+            InternalChild = new DrawableDragFile
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(300, 120)
+            };
+        }
+
+        public Task Import(params string[] paths)
+        {
+            Schedule(() =>
+            {
+                var fileInfo = new FileInfo(paths.First());
+                DialogOverlay.Push(new ImportLyricDialog(fileInfo, success =>
+                {
+                    if (success)
+                    {
+                        Complete();
+                    }
+                }));
+            });
+            return Task.CompletedTask;
+        }
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Database;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile.Components;
+using osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog;
 using osuTK;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,6 +25,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
         public override IconUsage Icon => FontAwesome.Solid.Upload;
 
         public IEnumerable<string> HandledExtensions => ImportLyricManager.LyricFormatExtensions;
+
+        [Resolved]
+        private ImportLyricManager importManager { get; set; }
 
         public DragFileSubScreen()
         {
@@ -43,11 +50,45 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
         {
             Schedule(() =>
             {
-                DialogOverlay.Push(new ImportLyricDialog(fileInfo, success =>
+                // Check file is exist
+                if (!fileInfo.Exists)
                 {
-                    if (success)
+                    DialogOverlay.Push(createFileNotFoundDialog());
+                    return;
+                }
+
+                // Check format is match
+                if (!ImportLyricManager.LyricFormatExtensions.Contains(fileInfo.Extension))
+                {
+                    DialogOverlay.Push(createFormatNotMatchDialog());
+                    return;
+                }
+
+                DialogOverlay.Push(new ImportLyricDialog(fileInfo, execute =>
+                {
+                    if (!execute)
+                        return;
+
+                    try
                     {
-                        Complete();
+                        importManager.ImportLrcFile(fileInfo);
+                        DialogOverlay.Push(createCompleteDialog());
+                    }
+                    catch (Exception ex)
+                    {
+                        switch (ex)
+                        {
+                            case FileNotFoundException _:
+                                DialogOverlay.Push(createFileNotFoundDialog());
+                                break;
+
+                            case FileLoadException loadException:
+                                DialogOverlay.Push(createLoadExceptionDialog(loadException));
+                                break;
+                            default:
+                                DialogOverlay.Push(createUnknownExceptionDialog());
+                                break;
+                        }
                     }
                 }));
             });
@@ -57,5 +98,48 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
         {
             ScreenStack.Push(ImportLyricStep.AssignLanguage);
         }
+
+        private PopupDialog createFileNotFoundDialog()
+            => new OkPopupDialog
+            {
+                Icon = FontAwesome.Regular.QuestionCircle,
+                HeaderText = "Seems file is not exist",
+                BodyText = $"Drag the file then drop again.",
+            };
+
+        private PopupDialog createFormatNotMatchDialog()
+            => new OkPopupDialog
+            {
+                Icon = FontAwesome.Solid.ExclamationTriangle,
+                HeaderText = "This type of file is not supported",
+                BodyText = $"May sure this type of file is supported.",
+            };
+
+        private PopupDialog createLoadExceptionDialog(FileLoadException loadException)
+            => new OkPopupDialog
+            {
+                Icon = FontAwesome.Solid.Bug,
+                HeaderText = @"File loading error",
+                BodyText = loadException.Message,
+            };
+
+        private PopupDialog createUnknownExceptionDialog()
+            => new OkPopupDialog
+            {
+                Icon = FontAwesome.Solid.Bug,
+                HeaderText = @"Unknown error",
+                BodyText = @"Unknown error QAQa."
+            };
+
+        private PopupDialog createCompleteDialog()
+            => new OkPopupDialog(ok =>
+            {
+                Complete();
+            })
+            {
+                Icon = FontAwesome.Regular.CheckCircle,
+                HeaderText = @"Import success",
+                BodyText = "Lyrics has been imported."
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileSubScreen.cs
@@ -34,9 +34,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 
         public Task Import(params string[] paths)
         {
+            var fileInfo = new FileInfo(paths.First());
+            ImportLyricFile(fileInfo);
+            return Task.CompletedTask;
+        }
+
+        public void ImportLyricFile(FileInfo fileInfo)
+        {
             Schedule(() =>
             {
-                var fileInfo = new FileInfo(paths.First());
                 DialogOverlay.Push(new ImportLyricDialog(fileInfo, success =>
                 {
                     if (success)
@@ -45,7 +51,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
                     }
                 }));
             });
-            return Task.CompletedTask;
         }
 
         public override void Complete()

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
@@ -2,22 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.IO;
-using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
-using osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 {
     public class ImportLyricDialog : PopupDialog
     {
-        [Resolved]
-        private DialogOverlay dialogOverlay { get; set; }
-
-        public ImportLyricDialog(FileInfo info, Action<bool> resetAction = null)
+        public ImportLyricDialog(Action<bool> resetAction = null)
         {
             Icon = FontAwesome.Regular.TrashAlt;
             HeaderText = @"Confirm import lyric file?";

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
@@ -15,9 +15,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
     public class ImportLyricDialog : PopupDialog
     {
         [Resolved]
-        private ImportLyricManager importManager { get; set; }
-
-        [Resolved]
         private DialogOverlay dialogOverlay { get; set; }
 
         public ImportLyricDialog(FileInfo info, Action<bool> resetAction = null)
@@ -31,96 +28,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
                 new PopupDialogOkButton
                 {
                     Text = @"Yes. Go for it.",
-                    Action = () =>
-                    {
-                        var success = processImport(info);
-                        resetAction?.Invoke(success);
-                    }
+                    Action = () => resetAction?.Invoke(true),
                 },
                 new PopupDialogCancelButton
                 {
                     Text = @"No! Abort mission!",
+                    Action = () => resetAction?.Invoke(false),
                 },
             };
         }
-
-        private bool processImport(FileInfo info)
-        {
-            try
-            {
-                // Check file is exist
-                if (!info.Exists)
-                {
-                    dialogOverlay.Push(createFileNotFoundDialog());
-                    return false;
-                }
-
-                // Check format is match
-                if (!ImportLyricManager.LyricFormatExtensions.Contains(info.Extension))
-                {
-                    dialogOverlay.Push(createFormatNotMatchDialog());
-                    return false;
-                }
-
-                importManager.ImportLrcFile(info);
-                dialogOverlay.Push(new OkPopupDialog
-                {
-                    Icon = FontAwesome.Regular.CheckCircle,
-                    HeaderText = @"Import success",
-                    BodyText = "Lyrics has been imported."
-                });
-                return true;
-            }
-            catch (Exception ex)
-            {
-                switch (ex)
-                {
-                    case FileNotFoundException _:
-                        dialogOverlay.Push(createFileNotFoundDialog());
-                        break;
-
-                    case FileLoadException loadException:
-                        dialogOverlay.Push(createLoadExceptionDialog(loadException));
-                        break;
-                    default:
-                        dialogOverlay.Push(createUnknownExceptionDialog());
-                        break;
-                }
-
-                return false;
-            }
-        }
-
-        private PopupDialog createFileNotFoundDialog()
-            => new OkPopupDialog
-            {
-                Icon = FontAwesome.Regular.QuestionCircle,
-                HeaderText = "Seems file is not exist",
-                BodyText = $"Drag the file then drop again.",
-            };
-
-        private PopupDialog createFormatNotMatchDialog()
-            => new OkPopupDialog
-            {
-                Icon = FontAwesome.Solid.ExclamationTriangle,
-                HeaderText = "This type of file is not supported",
-                BodyText = $"May sure this type of file is supported.",
-            };
-
-        private PopupDialog createLoadExceptionDialog(FileLoadException loadException)
-            => new OkPopupDialog
-            {
-                Icon = FontAwesome.Solid.Bug,
-                HeaderText = @"File loading error",
-                BodyText = loadException.Message,
-            };
-
-        private PopupDialog createUnknownExceptionDialog()
-            => new OkPopupDialog
-            {
-                Icon = FontAwesome.Solid.Bug,
-                HeaderText = @"Unknown error",
-                BodyText = @"Unknown error QAQa."
-            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/ImportLyricDialog.cs
@@ -9,12 +9,12 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Import
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
 {
     public class ImportLyricDialog : PopupDialog
     {
         [Resolved]
-        private ImportManager importManager { get; set; }
+        private ImportLyricManager importManager { get; set; }
 
         [Resolved]
         private DialogOverlay dialogOverlay { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRuby/GenerateRubySubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby
 {
     public class GenerateRubySubScreen : ImportLyricSubScreen
@@ -10,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRuby
         public override string ShortTitle => "Generate ruby";
 
         public override ImportLyricStep Step => ImportLyricStep.GenerateRuby;
+
+        public override IconUsage Icon => FontAwesome.Solid.Gem;
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagSubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
 {
     public class GenerateTimeTagSubScreen : ImportLyricSubScreen
@@ -10,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
         public override string ShortTitle => "Generate time tag";
 
         public override ImportLyricStep Step => ImportLyricStep.GenerateTimeTag;
+
+        public override IconUsage Icon => FontAwesome.Solid.Tag;
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -138,6 +139,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
             {
                 base.LoadComplete();
                 AccentColour = Color4Extensions.FromHex("#e35c99");
+            }
+
+            protected override void SelectTab(TabItem<IScreen> tab)
+            {
+                if (tab.Value == Current.Value)
+                    return;
+
+                if (!(Current.Value is IImportLyricSubScreen currentScreen))
+                    return;
+
+                if (!(tab.Value is IImportLyricSubScreen targetScreen))
+                    return;
+
+                currentScreen.CanRollBack(targetScreen, enabled =>
+                {
+                    if (enabled)
+                        base.SelectTab(tab);
+                });   
             }
 
             protected override TabItem<IScreen> CreateTabItem(IScreen value) => new HeaderBreadcrumbTabItem(value)

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public interface IImportLyricSubScreen
@@ -10,5 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         string Title { get; }
 
         string ShortTitle { get; }
+
+        void CanRollBack(IImportLyricSubScreen rollBackScreen, Action<bool> callBack);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/IImportLyricSubScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
@@ -12,6 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         string Title { get; }
 
         string ShortTitle { get; }
+
+        IconUsage Icon { get; }
 
         void CanRollBack(IImportLyricSubScreen rollBackScreen, Action<bool> callBack);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricManager.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
+using osu.Game.Screens.Edit;
+using System.IO;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
+{
+    public class ImportLyricManager : Component
+    {
+        public static string[] LyricFormatExtensions { get; } = { ".lrc", ".kar" };
+
+        private const string backup_lrc_name = "backup.lrc";
+
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
+
+        public void ImportLrcFile(FileInfo info)
+        {
+            if (!info.Exists)
+                throw new FileNotFoundException("Lyric file does not found!");
+
+            var isFormatMatch = LyricFormatExtensions.Contains(info.Extension);
+            if (!isFormatMatch)
+                throw new FileLoadException("Only .lrc or .kar karaoke file is supported now");
+
+            var set = beatmap.Value.BeatmapSetInfo;
+            var oldFile = set.Files?.FirstOrDefault(f => f.Filename == backup_lrc_name);
+
+            using (var stream = info.OpenRead())
+            {
+                // todo : make a backup if has new lyric file.
+                /*
+                if (oldFile != null)
+                    beatmaps.ReplaceFile(set, oldFile, stream, backup_lrc_name);
+                else
+                    beatmaps.AddFile(set, stream, backup_lrc_name);
+                */
+
+                // Import and replace all the file.
+                using (var reader = new Game.IO.LineBufferedReader(stream))
+                {
+                    var decoder = new LrcDecoder();
+                    var lrcBeatmap = decoder.Decode(reader);
+
+                    // todo : remove all notes and lyric
+                    // or just clear all beatmap because not really sure is singer should be removed also?
+
+                    // then re-add the lyric.
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricScreen.cs
@@ -6,8 +6,11 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile;
 using osu.Game.Screens.Edit;
+using System.IO;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
@@ -17,6 +20,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         [Cached]
         private readonly ImportLyricSubScreenStack screenStack;
+
+        public ImportLyricScreen(FileInfo fileInfo)
+            : this()
+        {
+            if (!(screenStack.CurrentScreen is DragFileSubScreen dragFileSubScreen))
+                throw new ScreenStack.ScreenNotInStackException($"{nameof(DragFileSubScreen)} does not in the screen.");
+
+            dragFileSubScreen.ImportLyricFile(fileInfo);
+        }
 
         public ImportLyricScreen()
             : base(EditorScreenMode.SongSetup)

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -3,9 +3,13 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog;
 using osu.Game.Screens;
+using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
@@ -19,6 +23,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         [Resolved]
         protected ImportLyricSubScreenStack ScreenStack { get; private set; }
+
+        [Resolved(CanBeNull = true)]
+        protected DialogOverlay DialogOverlay { get; private set; }
 
         public abstract string ShortTitle { get; }
 
@@ -71,6 +78,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         }
 
         public abstract void Complete();
+
+        public virtual void CanRollBack(IImportLyricSubScreen rollBackScreen, Action<bool> callBack)
+        {
+            DialogOverlay?.Push(new OkPopupDialog(callBack)
+            {
+                Icon = FontAwesome.Regular.ArrowAltCircleLeft,
+                HeaderText = @"Roll-back",
+                BodyText = $"Will roll-back to screen named {rollBackScreen.ShortTitle}",
+            });
+        }
 
         public override string ToString() => Title;
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         [Resolved]
         protected ImportLyricSubScreenStack ScreenStack { get; private set; }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         protected DialogOverlay DialogOverlay { get; private set; }
 
         public abstract string ShortTitle { get; }
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         public virtual void CanRollBack(IImportLyricSubScreen rollBackScreen, Action<bool> callBack)
         {
-            DialogOverlay?.Push(new OkPopupDialog(callBack)
+            DialogOverlay.Push(new OkPopupDialog(callBack)
             {
                 Icon = rollBackScreen.Icon,
                 HeaderText = rollBackScreen.ShortTitle,

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricSubScreen.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         public abstract ImportLyricStep Step { get; }
 
+        public abstract IconUsage Icon { get; }
+
         public ImportLyricSubScreen()
         {
             Anchor = Anchor.Centre;
@@ -83,9 +85,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         {
             DialogOverlay?.Push(new OkPopupDialog(callBack)
             {
-                Icon = FontAwesome.Regular.ArrowAltCircleLeft,
-                HeaderText = @"Roll-back",
-                BodyText = $"Will roll-back to screen named {rollBackScreen.ShortTitle}",
+                Icon = rollBackScreen.Icon,
+                HeaderText = rollBackScreen.ShortTitle,
+                BodyText = $"Will roll-back to step '{rollBackScreen.Title}'",
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Success/SuccessSubScreen.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success
 {
     public class SuccessSubScreen : ImportLyricSubScreen
@@ -10,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.Success
         public override string ShortTitle => "Success";
 
         public override ImportLyricStep Step => ImportLyricStep.GenerateTimeTag;
+
+        public override IconUsage Icon => FontAwesome.Regular.CheckCircle;
 
         public override void Complete()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
                 return false;
 
             // todo : should open import screen instead.
-            dialogOverlay?.Push(new ImportLyricDialog(info));
+            //dialogOverlay?.Push(new ImportLyricDialog(info));
 
             return true;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricEditor/LyricEditorScreen.cs
@@ -14,7 +14,8 @@ using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Timeline;
-using osu.Game.Rulesets.Karaoke.Edit.Import;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
+using osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
@@ -29,7 +30,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
         private FillFlowContainer<Button> controls;
         private LyricRearrangeableListContainer container;
 
-        public IEnumerable<string> HandledExtensions => ImportManager.LyricFormatExtensions;
+        public IEnumerable<string> HandledExtensions => ImportLyricManager.LyricFormatExtensions;
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
@@ -65,6 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.LyricEditor
             if (!info.Exists)
                 return false;
 
+            // todo : should open import screen instead.
             dialogOverlay?.Push(new ImportLyricDialog(info));
 
             return true;

--- a/osu.Game.Rulesets.Karaoke/Graphics/Overlays/Dialog/OkPopupDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Overlays/Dialog/OkPopupDialog.cs
@@ -2,18 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Overlays.Dialog;
+using System;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.Overlays.Dialog
 {
     public class OkPopupDialog : PopupDialog
     {
-        public OkPopupDialog()
+        public OkPopupDialog(Action<bool> okAction = null)
         {
             Buttons = new PopupDialogButton[]
             {
-                new PopupDialogCancelButton
+                new PopupDialogOkButton
                 {
                     Text = @"OK",
+                    Action = () => okAction?.Invoke(true),
                 },
             };
         }


### PR DESCRIPTION
Implement first page of #250 
What's add: 
- Enable to assign target file while opening lyric import screen.
- Separate import lyric manager from exist import manager.
- Move exist `ImportLyricDialog` into `ImportLyric >> DragFile` and rewrite logic.
- Give every sub screen an different icon.
- Ask before switching to different stage.
- OK dialog will have an call-back.