### PR TITLE
Implement auto-detect lyric's language.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
@@ -3,16 +3,29 @@
 
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Languages;
+using osu.Game.Rulesets.Karaoke.Objects;
+using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.Languages
 {
     [TestFixture]
     public class LanguageDetectorTest
     {
-        [TestCase("花火大会", "Ja-jp")]
+        [TestCase("花火大会", "zh-CN")]
+        [TestCase("Testing", "en-US")]
         public void TestDetectLanguage(string text, string language)
         {
             var detector = new LanguageDetector();
+            var result = detector.DetectLanguage(new Lyric { Text = text });
+            Assert.AreEqual(result, new CultureInfo(language));
+        }
+
+        //[Ignore("Japanese text not supported now")]
+        [TestCase("ハナビ", "ja-jp")]
+        [TestCase("はなび", "ja-jp")]
+        public void TestJapaneseLanguage(string text, string language)
+        {
+            TestDetectLanguage(text, language);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.Languages
         [TestCase("はなび", "ja-jp")]
         public void TestJapaneseLanguage(string text, string language)
         {
-            // todo : should fix this dictionay to add all Hiragana and Katakana
+            // todo : should fix this dictionary to add all Hiragana and Katakana
             // https://github.com/pdonald/language-detection/blob/master/LanguageDetection/Profiles/ja
             TestDetectLanguage(text, language);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Languages;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.Languages
+{
+    [TestFixture]
+    public class LanguageDetectorTest
+    {
+        [TestCase("花火大会", "Ja-jp")]
+        public void TestDetectLanguage(string text, string language)
+        {
+            var detector = new LanguageDetector();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/Languages/LanguageDetectorTest.cs
@@ -12,20 +12,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.Languages
     public class LanguageDetectorTest
     {
         [TestCase("花火大会", "zh-CN")]
+        [TestCase("花火大會", "zh-TW")]
         [TestCase("Testing", "en-US")]
         public void TestDetectLanguage(string text, string language)
         {
-            var detector = new LanguageDetector();
+            var detector = new LanguageDetector(generageConfig());
             var result = detector.DetectLanguage(new Lyric { Text = text });
             Assert.AreEqual(result, new CultureInfo(language));
         }
 
-        //[Ignore("Japanese text not supported now")]
+        [Ignore("Japanese text not supported now")]
         [TestCase("ハナビ", "ja-jp")]
         [TestCase("はなび", "ja-jp")]
         public void TestJapaneseLanguage(string text, string language)
         {
+            // todo : should fix this dictionay to add all Hiragana and Katakana
+            // https://github.com/pdonald/language-detection/blob/master/LanguageDetection/Profiles/ja
             TestDetectLanguage(text, language);
+        }
+
+        private LanguageDetectorConfig generageConfig()
+        {
+            return new LanguageDetectorConfig();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.OpenNlp;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Analysis.TokenAttributes;
+using Lucene.Net.Util;
+using System.IO;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
+{
+    public class LanguageDetector
+    {
+        public LanguageDetector()
+        {
+            // this is copied from :
+            // https://fabian-kostadinov.github.io/2018/09/08/introduction-to-lucene-opennlp-part1/
+            var version = LuceneVersion.LUCENE_48;
+
+            var text = "The quick brown fox jumped over the lazy dogs.";
+
+            var analyzer = new StandardAnalyzer(version);
+
+            // We're using a string reader to return a token stream. This allows us to observe the tokens
+            // while they are being processed by our analyzer.
+            TokenStream stream = analyzer.GetTokenStream("field", new StringReader(text));
+
+            // CharTermAttribute will contain the actual token word
+            CharTermAttribute termAtt = stream.AddAttribute<CharTermAttribute>();
+
+            // TypeAttribute will contain the OpenNLP POS (Treebank II) tag
+            TypeAttribute typeAtt = stream.AddAttribute<TypeAttribute>();
+
+            try
+            {
+                stream.Reset();
+
+                // Print all tokens until stream is exhausted
+                while (stream.IncrementToken()) {
+                    var result = termAtt.ToString() + ": " + typeAtt.Type;
+                }
+
+                stream.End();
+
+            }
+            finally
+            {
+                stream.Dispose();
+            }
+        }
+
+        /*
+        public class OpenNLPAnalyzer : Analyzer
+        {
+            protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+            {
+                Tokenizer tokenizer = new OpenNLPTokenizer(reader);
+
+                TokenFilter tokenFilter = new OpenNLPPOSFilter();
+                return new TokenStreamComponents(tokenizer, tokenFilter);
+            }
+        }
+        */
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Karaoke.Objects;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -9,21 +10,37 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
 {
     public class LanguageDetector
     {
+        private readonly LanguageDetection.LanguageDetector detector = new LanguageDetection.LanguageDetector();
+
+        public LanguageDetector(LanguageDetectorConfig config)
+        {
+            var targetLanguages = config?.AcceptLanguage?.Where(x => x != null).ToList() ?? new List<CultureInfo>();
+            if (targetLanguages.Any())
+            {
+                detector.AddLanguages(targetLanguages.Select(x => x.Name).ToArray());
+            }
+            else
+            {
+                detector.AddAllLanguages();
+            }
+        }
+
         public CultureInfo DetectLanguage(Lyric lyric)
         {
-            var detector = new LanguageDetection.LanguageDetector();
-            detector.AddAllLanguages();
             var result = detector.DetectAll(lyric.Text);
             var languageCode = result.FirstOrDefault()?.Language;
 
+            if (languageCode == null)
+                return null;
+
+            // make some language conversion here
             switch (languageCode)
             {
-                case "zho":
-                    return new CultureInfo("zh-CN");
-                case "eng":
+                // todo : need to think about is this needed?
+                case "en":
                     return new CultureInfo("en-US");
                 default:
-                    return null;
+                    return new CultureInfo(languageCode);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -1,66 +1,30 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Lucene.Net.Analysis;
-using Lucene.Net.Analysis.OpenNlp;
-using Lucene.Net.Analysis.Standard;
-using Lucene.Net.Analysis.TokenAttributes;
-using Lucene.Net.Util;
-using System.IO;
+using osu.Game.Rulesets.Karaoke.Objects;
+using System.Globalization;
+using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
 {
     public class LanguageDetector
     {
-        public LanguageDetector()
+        public CultureInfo DetectLanguage(Lyric lyric)
         {
-            // this is copied from :
-            // https://fabian-kostadinov.github.io/2018/09/08/introduction-to-lucene-opennlp-part1/
-            var version = LuceneVersion.LUCENE_48;
+            var detector = new LanguageDetection.LanguageDetector();
+            detector.AddAllLanguages();
+            var result = detector.DetectAll(lyric.Text);
+            var languageCode = result.FirstOrDefault()?.Language;
 
-            var text = "The quick brown fox jumped over the lazy dogs.";
-
-            var analyzer = new StandardAnalyzer(version);
-
-            // We're using a string reader to return a token stream. This allows us to observe the tokens
-            // while they are being processed by our analyzer.
-            TokenStream stream = analyzer.GetTokenStream("field", new StringReader(text));
-
-            // CharTermAttribute will contain the actual token word
-            CharTermAttribute termAtt = stream.AddAttribute<CharTermAttribute>();
-
-            // TypeAttribute will contain the OpenNLP POS (Treebank II) tag
-            TypeAttribute typeAtt = stream.AddAttribute<TypeAttribute>();
-
-            try
+            switch (languageCode)
             {
-                stream.Reset();
-
-                // Print all tokens until stream is exhausted
-                while (stream.IncrementToken()) {
-                    var result = termAtt.ToString() + ": " + typeAtt.Type;
-                }
-
-                stream.End();
-
-            }
-            finally
-            {
-                stream.Dispose();
+                case "zho":
+                    return new CultureInfo("zh-CN");
+                case "eng":
+                    return new CultureInfo("en-US");
+                default:
+                    return null;
             }
         }
-
-        /*
-        public class OpenNLPAnalyzer : Analyzer
-        {
-            protected override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
-            {
-                Tokenizer tokenizer = new OpenNLPTokenizer(reader);
-
-                TokenFilter tokenFilter = new OpenNLPPOSFilter();
-                return new TokenStreamComponents(tokenizer, tokenFilter);
-            }
-        }
-        */
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetectorConfig.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
+{
+    public class LanguageDetectorConfig
+    {
+        public CultureInfo[] AcceptLanguage { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
+    <PackageReference Include="Lucene.Net.Analysis.OpenNLP" Version="4.8.0-beta00013" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="1.2.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.0.10" />

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
-    <PackageReference Include="LanguageDetection.NETStandard" Version="1.3.1" />
+    <PackageReference Include="LanguageDetection" Version="1.2.0" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="1.2.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.0.10" />

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
-    <PackageReference Include="Lucene.Net.Analysis.OpenNLP" Version="4.8.0-beta00013" />
+    <PackageReference Include="LanguageDetection.NETStandard" Version="1.3.1" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="1.2.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.0.10" />


### PR DESCRIPTION
Implementation of #263 .

The final way is use this package called [language-detection](https://github.com/pdonald/language-detection), it provide a simple way to detect language.
But now it does not fully support Japanese lyric, should fix this dictionary to add all Hiragana and Katakana.