### PR TITLE
Add option to make create duplicated ruby as false.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags.Ja
             var lyric = new Lyric { Text = text };
             var rubyTags = generator.CreateRubyTags(lyric);
 
-
             Assert.AreEqual(rubyTags.Length, ruby.Length);
             foreach (var rubyTag in rubyTags)
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -12,30 +12,52 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags.Ja
     [TestFixture]
     public class JaRubyTagGeneratorTest
     {
-        [TestCase("花火大会", new[] { "はなび", "たいかい" }, false)]
-        [TestCase("花火大会", new[] { "ハナビ", "タイカイ" }, true)]
-        public void TestLyricWithCheckLineEndKeyUpWithRubyAsKatakana(string text, string[] ruby, bool applyConfig)
+        [TestCase("花火大会", new[] { "はなび", "たいかい" })]
+        [TestCase("はなび", new string[] { })]
+        public void TestCreateRubyTags(string text, string[] ruby)
         {
-            var config = generatorConfig(applyConfig ? nameof(JaRubyTagGeneratorConfig.RubyAsKatakana) : null);
+            var config = generatorConfig(null);
+            RunRubyCheckTest(text, ruby, config);
+        }
+
+        [TestCase("花火大会", new[] { "ハナビ", "タイカイ" })]
+        [TestCase("ハナビ", new string[] { })]
+        public void TestCreateRubyTagsWithRubyAsKatakana(string text, string[] ruby)
+        {
+            var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.RubyAsKatakana));
+            RunRubyCheckTest(text, ruby, config);
+        }
+
+        [TestCase("はなび", new string[] { "はな", "び" })]
+        [TestCase("ハナビ", new string[] { "はなび" })]
+        public void TestCreateRubyTagsWithEnableDuplicatedRuby(string text, string[] ruby)
+        {
+            var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.EnableDuplicatedRuby));
+            RunRubyCheckTest(text, ruby, config);
+        }
+
+        #region test helper
+
+        protected void RunRubyCheckTest(string text, string[] ruby, JaRubyTagGeneratorConfig config)
+        {
             var generator = new JaRubyTagGenerator(config);
 
             var lyric = new Lyric { Text = text };
             var rubyTags = generator.CreateRubyTags(lyric);
 
+
+            Assert.AreEqual(rubyTags.Length, ruby.Length);
             foreach (var rubyTag in rubyTags)
             {
                 Assert.IsTrue(ruby.Contains(rubyTag.Text));
             }
         }
 
-        #region test helper
-
-        private Lyric generateLyric(string text)
-            => new Lyric { Text = text };
-
         private JaRubyTagGeneratorConfig generatorConfig(params string[] properties)
         {
             var config = new JaRubyTagGeneratorConfig();
+            if (properties == null)
+                return config;
 
             foreach (var propertyName in properties)
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         public void TestLyricWithCheckLineEnd(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckLineEnd) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("か", new double[] { 0 }, false)]
@@ -25,14 +25,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         public void TestLyricWithCheckLineEndKeyUp(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckLineEndKeyUp) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [Ignore("This feature has not been implemented")]
         public void TestLyricWithCheckBlankLine(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckBlankLine) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("     ", new double[] { 0, 1, 2, 3, 4 }, false)]
@@ -40,14 +40,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         public void TestLyricWithCheckWhiteSpace(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [Ignore("This feature has not been implemented")]
         public void TestLyricWithCheckWhiteSpaceKeyUp(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("a　b　c　d　e", new double[] { 0, 2, 4, 6, 8 }, false)]
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         {
             var config = generatorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAlphabet) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("0　1　2　3　4", new double[] { 0, 2, 4, 6, 8 }, false)]
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         {
             var config = generatorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceDigit) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("!　!　!　!　！", new double[] { 0, 2, 4, 6, 8 }, false)]
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         {
             var config = generatorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAsciiSymbol) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("がんばって", new double[] { 0, 2, 4 }, false)]
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         public void TestLyricWithCheckWhiteCheckん(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkん) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         [TestCase("買って", new double[] { 0, 2 }, false)]
@@ -94,12 +94,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags.Ja
         public void TestLyricWithCheckっ(string lyric, double[] index, bool applyConfig)
         {
             var config = generatorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkっ) : null);
-            RunTimeTagCheckText(lyric, index, config);
+            RunTimeTagCheckTest(lyric, index, config);
         }
 
         #region test helper
 
-        protected void RunTimeTagCheckText(string lyricText, double[] index, JaTimeTagGeneratorConfig config)
+        protected void RunTimeTagCheckTest(string lyricText, double[] index, JaTimeTagGeneratorConfig config)
         {
             var generator = new JaTimeTagGenerator(config);
             var lyric = generateLyric(lyricText);

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
@@ -47,20 +47,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja
                 tokenStream.IncrementToken();
 
                 // Get parsed result, result is Katakana.
-                var parsedResult = result.ToString();
-                if (string.IsNullOrEmpty(parsedResult))
+                var katakana = result.ToString();
+                if (string.IsNullOrEmpty(katakana))
                     break;
 
                 // Convert to Hiragana as default.
-                if (!Config.RubyAsKatakana)
+                var hiragana = JpStringUtils.ToHiragana(katakana);
+                if (!Config.EnableDuplicatedRuby)
                 {
-                    parsedResult = JpStringUtils.ToHiragana(parsedResult);
+                    // Not add deplicated ruby if same as parent.
+                    var parentText = text.Substring(offsetAtt.StartOffset, offsetAtt.EndOffset - offsetAtt.StartOffset);
+                    if (parentText == katakana || parentText == hiragana)
+                        continue;
                 }
 
                 // Make tag
                 tags.Add(new RubyTag
                 {
-                    Text = parsedResult,
+                    Text = Config.RubyAsKatakana ? katakana : hiragana,
                     StartIndex = offsetAtt.StartOffset,
                     EndIndex = offsetAtt.EndOffset
                 });

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
@@ -5,6 +5,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja
 {
     public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig
     {
+        /// <summary>
+        /// Generate ruby as Katakana.
+        /// </summary>
         public bool RubyAsKatakana { get; set; }
+
+        /// <summary>
+        /// Generate ruby even it's same as lyric.
+        /// </summary>
+        public bool EnableDuplicatedRuby { get; set; }
     }
 }


### PR DESCRIPTION
Found issue in #252 
Should not generate ruby if text is katakana or hiragana