### PR TITLE
Implement translate selector.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
@@ -13,6 +14,8 @@ using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Visual;
+using System.Globalization;
+
 namespace osu.Game.Rulesets.Karaoke.Tests.Graphics
 {
     public class TestSceneLanguageSelectionDialog : OsuManualInputManagerTestScene
@@ -44,7 +47,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Graphics
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = dialog = new LanguageSelectionDialog();
+            var language = new Bindable<CultureInfo>(new CultureInfo("ja"));
+            Child = dialog = new LanguageSelectionDialog
+            {
+                Current = language,
+            };
         });
 
         [SetUpSteps]

--- a/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
-using osu.Game.Rulesets.Karaoke.Edit.Translate;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
 using osu.Game.Screens.Edit;
@@ -23,7 +22,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Graphics
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         private DialogOverlay dialogOverlay;
-        private TranslateManager manager;
 
         private LanguageSelectionDialog dialog;
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Graphics/TestSceneLanguageSelectionDialog.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit.Translate;
+using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Visual;
+namespace osu.Game.Rulesets.Karaoke.Tests.Graphics
+{
+    public class TestSceneLanguageSelectionDialog : OsuManualInputManagerTestScene
+    {
+        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+
+        private DialogOverlay dialogOverlay;
+        private TranslateManager manager;
+
+        private LanguageSelectionDialog dialog;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var beatmap = new TestKaraokeBeatmap(null);
+            var karaokeBeatmap = new KaraokeBeatmapConverter(beatmap, new KaraokeRuleset()).Convert();
+            var editorBeatmap = new EditorBeatmap(karaokeBeatmap);
+            Dependencies.Cache(editorBeatmap);
+
+            base.Content.AddRange(new Drawable[]
+            {
+                Content,
+                dialogOverlay = new DialogOverlay()
+            });
+
+            Dependencies.Cache(dialogOverlay);
+        }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = dialog = new LanguageSelectionDialog();
+        });
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("show dialog", () => dialog.Show());
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
@@ -32,6 +32,6 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
             }
         }
 
-        public override string ToString() => Value.ToString();
+        public override string ToString() => Value.Name;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using System.Globalization;
+
+namespace osu.Game.Rulesets.Karaoke.Bindables
+{
+    public class BindableCultureInfo : Bindable<CultureInfo>
+    {
+        public BindableCultureInfo(CultureInfo value = default)
+            : base(value)
+        {
+        }
+
+        public override void Parse(object input)
+        {
+            switch (input)
+            {
+                case string str:
+                    Value = new CultureInfo(str);
+                    break;
+                case int lcid:
+                    Value = new CultureInfo(lcid);
+                    break;
+                case CultureInfo cultureInfo:
+                    Value = cultureInfo;
+                    break;
+                default:
+                    base.Parse(input);
+                    break;
+            }
+        }
+
+        public override string ToString() => Value.ToString();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
@@ -15,23 +15,32 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
 
         public override void Parse(object input)
         {
+            if (input == null)
+            {
+                Value = null;
+                return;
+            }
+
             switch (input)
             {
                 case string str:
                     Value = new CultureInfo(str);
                     break;
+
                 case int lcid:
                     Value = new CultureInfo(lcid);
                     break;
+
                 case CultureInfo cultureInfo:
                     Value = cultureInfo;
                     break;
+
                 default:
                     base.Parse(input);
                     break;
             }
         }
 
-        public override string ToString() => Value.Name;
+        public override string ToString() => Value?.Name;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -59,7 +59,8 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             switch (lookup)
             {
                 case KaraokeRulesetSetting.PreferLanguage:
-                    base.AddBindable(lookup, new BindableCultureInfo());
+                    // todo : need to hve a default value here because it will cause error if object is null.
+                    base.AddBindable(lookup, new BindableCultureInfo(new CultureInfo("en-US")));
                     break;
                 default:
                     base.AddBindable(lookup, bindable);

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Configuration.Tracking;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Configuration;
+using osu.Game.Rulesets.Karaoke.Bindables;
 using osu.Game.Rulesets.Karaoke.UI;
+using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Configuration
 {
@@ -49,6 +52,19 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // Device
             Set(KaraokeRulesetSetting.MicrophoneDevice, "");
+        }
+
+        protected override void AddBindable<TBindable>(KaraokeRulesetSetting lookup, Bindable<TBindable> bindable)
+        {
+            switch (lookup)
+            {
+                case KaraokeRulesetSetting.PreferLanguage:
+                    base.AddBindable(lookup, new BindableCultureInfo());
+                    break;
+                default:
+                    base.AddBindable(lookup, bindable);
+                    break;
+            }
         }
 
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -20,9 +21,9 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // Translate
             var useTranslate = getValue<bool>(KaraokeRulesetSetting.UseTranslate);
-            var preferLanguage = getValue<string>(KaraokeRulesetSetting.PreferLanguage);
+            var preferLanguage = getValue<CultureInfo>(KaraokeRulesetSetting.PreferLanguage);
             var availableTranslate = beatmap?.AvailableTranslates();
-            var selectedLanguage = availableTranslate?.FirstOrDefault(t => t.Name == preferLanguage) ?? availableTranslate?.FirstOrDefault();
+            var selectedLanguage = availableTranslate?.FirstOrDefault(t => t == preferLanguage) ?? availableTranslate?.FirstOrDefault();
             Set(KaraokeRulesetSession.UseTranslate, useTranslate);
             Set(KaraokeRulesetSession.PreferLanguage, selectedLanguage?.Name ?? "");
 

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osuTK;
 using osuTK.Graphics;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -18,8 +22,16 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
     {
         protected override string Title => "Select language";
 
-        private TranslateSearchTextBox filter;
+        private LanguageSelectionSearchTextBox filter;
         private DrawableLanguageList languageList;
+
+        private readonly BindableWithCurrent<CultureInfo> current = new BindableWithCurrent<CultureInfo>();
+
+        public Bindable<CultureInfo> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
 
         public LanguageSelectionDialog()
         {
@@ -27,20 +39,19 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             Size = new Vector2(0.5f, 0.8f);
 
             var languages = new BindableList<CultureInfo>(CultureInfo.GetCultures(CultureTypes.NeutralCultures));
-
             Child = new GridContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 RowDimensions = new[]
                 {
-                    new Dimension(GridSizeMode.Absolute, 50),
+                    new Dimension(GridSizeMode.Absolute, 40),
                     new Dimension(GridSizeMode.Distributed)
                 },
                 Content = new[]
                 {
                     new Drawable[]
                     {
-                        filter = new TranslateSearchTextBox
+                        filter = new LanguageSelectionSearchTextBox
                         {
                             RelativeSizeAxes = Axes.X,
                         }
@@ -50,6 +61,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                         languageList = new DrawableLanguageList
                         {
                             RelativeSizeAxes = Axes.Both,
+                            RequestSelection = (item) =>
+                            {
+                                Current.Value = item;
+                                Hide();
+                            },
                             Items = { BindTarget = languages }
                         }
                     }
@@ -57,13 +73,14 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             };
 
             filter.Current.BindValueChanged(e => languageList.Filter(e.NewValue));
+            Current.BindValueChanged(e => languageList.SelectedSet.Value = e.NewValue);
         }
 
-        public class TranslateSearchTextBox : SearchTextBox
+        public class LanguageSelectionSearchTextBox : SearchTextBox
         {
             protected override Color4 SelectionColour => Color4.Gray;
 
-            public TranslateSearchTextBox()
+            public LanguageSelectionSearchTextBox()
             {
                 PlaceholderText = @"type in keywords...";
             }
@@ -71,24 +88,41 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
 
         public class DrawableLanguageList : OsuRearrangeableListContainer<CultureInfo>
         {
-            public void Filter(string text)
-            {
-                var items = (SearchContainer<RearrangeableListItem<CultureInfo>>)ListContainer;
-                items.SearchTerm = text;
-            }
+            public readonly Bindable<CultureInfo> SelectedSet = new Bindable<CultureInfo>();
 
-            protected override FillFlowContainer<RearrangeableListItem<CultureInfo>> CreateListFillFlowContainer() => new SearchContainer<RearrangeableListItem<CultureInfo>>
+            public Action<CultureInfo> RequestSelection;
+
+            private SearchContainer<RearrangeableListItem<CultureInfo>> searchContainer;
+
+            protected override FillFlowContainer<RearrangeableListItem<CultureInfo>> CreateListFillFlowContainer() => searchContainer = new SearchContainer<RearrangeableListItem<CultureInfo>>
             {
                 Spacing = new Vector2(0, 3),
                 LayoutDuration = 200,
                 LayoutEasing = Easing.OutQuint,
             };
 
+            public void Filter(string text)
+            {
+                searchContainer.SearchTerm = text;
+            }
+
             protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
-                => new DrawableLanguageListItem(item);
+                => new DrawableLanguageListItem(item)
+                {
+                    SelectedSet = { BindTarget = SelectedSet },
+                    RequestSelection = set => RequestSelection?.Invoke(set)
+                };
 
             public class DrawableLanguageListItem : OsuRearrangeableListItem<CultureInfo>, IFilterable
             {
+                public readonly Bindable<CultureInfo> SelectedSet = new Bindable<CultureInfo>();
+                
+                public Action<CultureInfo> RequestSelection;
+
+                private TextFlowContainer text;
+
+                private Color4 selectedColour;
+
                 public DrawableLanguageListItem(CultureInfo item)
                     : base(item)
                 {
@@ -102,12 +136,38 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                     };
                 }
 
-                protected override Drawable CreateContent() => new OsuTextFlowContainer
+                [BackgroundDependencyLoader]
+                private void load(OsuColour colours)
+                {
+                    selectedColour = colours.Yellow;
+                    HandleColour = colours.Gray5;
+                }
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+
+                    SelectedSet.BindValueChanged(set =>
+                    {
+                        if (set.OldValue?.Equals(Model) != true && set.NewValue?.Equals(Model) != true)
+                            return;
+
+                        text.FadeColour(set.NewValue.Equals(Model) ? selectedColour : Color4.White, FADE_DURATION);
+                    }, true);
+                }
+
+                protected override Drawable CreateContent() => text = new OsuTextFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Text = Model.EnglishName,
                 };
+                protected override bool OnClick(ClickEvent e)
+                {
+                    RequestSelection?.Invoke(Model);
+                    return true;
+                }
+
                 public IEnumerable<string> FilterTerms { get; }
 
                 private bool matchingFilter = true;

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osuTK;
+using osuTK.Graphics;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
@@ -17,70 +18,116 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
     {
         protected override string Title => "Select language";
 
+        private TranslateSearchTextBox filter;
+        private DrawableLanguageList languageList;
+
         public LanguageSelectionDialog()
         {
             RelativeSizeAxes = Axes.Both;
             Size = new Vector2(0.5f, 0.8f);
-        }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            var languages = new BindableList<CultureInfo>(CultureInfo.GetCultures(CultureTypes.AllCultures));
-            Children = new Drawable[]
+            var languages = new BindableList<CultureInfo>(CultureInfo.GetCultures(CultureTypes.NeutralCultures));
+
+            Child = new GridContainer
             {
-                new DrawableLanguageList
+                RelativeSizeAxes = Axes.Both,
+                RowDimensions = new[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Items = { BindTarget = languages }
+                    new Dimension(GridSizeMode.Absolute, 50),
+                    new Dimension(GridSizeMode.Distributed)
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        filter = new TranslateSearchTextBox
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        }
+                    },
+                    new Drawable[]
+                    {
+                        languageList = new DrawableLanguageList
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Items = { BindTarget = languages }
+                        }
+                    }
                 }
             };
+
+            filter.Current.BindValueChanged(e => languageList.Filter(e.NewValue));
+        }
+
+        public class TranslateSearchTextBox : SearchTextBox
+        {
+            protected override Color4 SelectionColour => Color4.Gray;
+
+            public TranslateSearchTextBox()
+            {
+                PlaceholderText = @"type in keywords...";
+            }
         }
 
         public class DrawableLanguageList : OsuRearrangeableListContainer<CultureInfo>
         {
-            protected override FillFlowContainer<RearrangeableListItem<CultureInfo>> CreateListFillFlowContainer() => new Flow
+            public void Filter(string text)
             {
-                DragActive = { BindTarget = DragActive }
+                var items = (SearchContainer<RearrangeableListItem<CultureInfo>>)ListContainer;
+                items.SearchTerm = text;
+            }
+
+            protected override FillFlowContainer<RearrangeableListItem<CultureInfo>> CreateListFillFlowContainer() => new SearchContainer<RearrangeableListItem<CultureInfo>>
+            {
+                Spacing = new Vector2(0, 3),
+                LayoutDuration = 200,
+                LayoutEasing = Easing.OutQuint,
             };
 
             protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
                 => new DrawableLanguageListItem(item);
 
-            /// <summary>
-            /// The flow of <see cref="DrawableLanguageListItem"/>. Disables layout easing unless a drag is in progress.
-            /// </summary>
-            private class Flow : FillFlowContainer<RearrangeableListItem<CultureInfo>>
-            {
-                public readonly IBindable<bool> DragActive = new Bindable<bool>();
-
-                public Flow()
-                {
-                    Spacing = new Vector2(0, 5);
-                    LayoutEasing = Easing.OutQuint;
-                }
-
-                protected override void LoadComplete()
-                {
-                    base.LoadComplete();
-                    DragActive.BindValueChanged(active => LayoutDuration = active.NewValue ? 200 : 0);
-                }
-            }
-
-            public class DrawableLanguageListItem : OsuRearrangeableListItem<CultureInfo>
+            public class DrawableLanguageListItem : OsuRearrangeableListItem<CultureInfo>, IFilterable
             {
                 public DrawableLanguageListItem(CultureInfo item)
                     : base(item)
                 {
                     Padding = new MarginPadding { Left = 5 };
+                    FilterTerms = new List<string>
+                    {
+                        item.Name,
+                        item.DisplayName,
+                        item.EnglishName,
+                        item.NativeName
+                    };
                 }
 
                 protected override Drawable CreateContent() => new OsuTextFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Text = Model.DisplayName,
+                    Text = Model.EnglishName,
                 };
+                public IEnumerable<string> FilterTerms { get; }
+
+                private bool matchingFilter = true;
+
+                public bool MatchingFilter
+                {
+                    get => matchingFilter;
+                    set
+                    {
+                        if (matchingFilter == value)
+                            return;
+
+                        matchingFilter = value;
+                        updateFilter();
+                    }
+                }
+
+                private void updateFilter() => this.FadeTo(MatchingFilter ? 1 : 0, 200);
+
+                public bool FilteringActive { get; set; }
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Graphics.Containers;
+using osuTK;
+using System.Globalization;
+
+namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
+{
+    public class LanguageSelectionDialog : TitleFocusedOverlayContainer
+    {
+        protected override string Title => "Select language";
+
+        public LanguageSelectionDialog()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(0.5f, 0.8f);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            var languages = new BindableList<CultureInfo>(CultureInfo.GetCultures(CultureTypes.AllCultures));
+            Children = new Drawable[]
+            {
+                new DrawableLanguageList
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Items = { BindTarget = languages }
+                }
+            };
+        }
+
+        public class DrawableLanguageList : OsuRearrangeableListContainer<CultureInfo>
+        {
+            protected override FillFlowContainer<RearrangeableListItem<CultureInfo>> CreateListFillFlowContainer() => new Flow
+            {
+                DragActive = { BindTarget = DragActive }
+            };
+
+            protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
+                => new DrawableLanguageListItem(item);
+
+            /// <summary>
+            /// The flow of <see cref="DrawableLanguageListItem"/>. Disables layout easing unless a drag is in progress.
+            /// </summary>
+            private class Flow : FillFlowContainer<RearrangeableListItem<CultureInfo>>
+            {
+                public readonly IBindable<bool> DragActive = new Bindable<bool>();
+
+                public Flow()
+                {
+                    Spacing = new Vector2(0, 5);
+                    LayoutEasing = Easing.OutQuint;
+                }
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+                    DragActive.BindValueChanged(active => LayoutDuration = active.NewValue ? 200 : 0);
+                }
+            }
+
+            public class DrawableLanguageListItem : OsuRearrangeableListItem<CultureInfo>
+            {
+                public DrawableLanguageListItem(CultureInfo item)
+                    : base(item)
+                {
+                    Padding = new MarginPadding { Left = 5 };
+                }
+
+                protected override Drawable CreateContent() => new OsuTextFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Text = Model.DisplayName,
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke
 
             try
             {
-                var selectedDevice = config.GetBindable<string>(KaraokeRulesetSetting.MicrophoneDevice).Value;
+                var selectedDevice = config.Get<string>(KaraokeRulesetSetting.MicrophoneDevice);
                 var microphoneList = new MicrophoneManager().MicrophoneDeviceNames.ToList();
 
                 // Find index by selection id

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -88,8 +88,7 @@ namespace osu.Game.Rulesets.Karaoke.UI
                         {
                             // maybe this overlay has been moved into internal.
                         }
-                    }
-                    
+                    } 
                 },
                 // Pitch
                 new SettingsCheckbox

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Overlays;
 
 namespace osu.Game.Rulesets.Karaoke.UI
@@ -22,10 +23,14 @@ namespace osu.Game.Rulesets.Karaoke.UI
         {
         }
 
+        [Resolved]
+        protected OsuGame Geme { get; private set; }
+
         private KaraokeChangelogOverlay changelogOverlay;
+        private LanguageSelectionDialog languageSelectionDialog;
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game)
+        private void load()
         {
             var config = (KaraokeRulesetConfigManager)Config;
             var microphoneManager = new MicrophoneManager();
@@ -59,10 +64,31 @@ namespace osu.Game.Rulesets.Karaoke.UI
                     LabelText = "Translate",
                     Current = config.GetBindable<bool>(KaraokeRulesetSetting.UseTranslate)
                 },
-                new SettingsTextBox
+                new SettingsButton
                 {
-                    LabelText = "Prefer language",
-                    Current = config.GetBindable<string>(KaraokeRulesetSetting.PreferLanguage)
+                    Text = "Prefer language",
+                    TooltipText = "Select perfer translate language.",
+                    Action = () =>
+                    {
+                        try
+                        {
+                            if (DisplayContainer == null)
+                                return;
+
+                            if (languageSelectionDialog == null && !DisplayContainer.Children.OfType<LanguageSelectionDialog>().Any())
+                                DisplayContainer.Add(languageSelectionDialog = new LanguageSelectionDialog
+                                {
+                                    // Current = config.GetBindable<string>(KaraokeRulesetSetting.PreferLanguage)
+                                });
+
+                            languageSelectionDialog?.Show();
+                        }
+                        catch
+                        {
+                            // maybe this overlay has been moved into internal.
+                        }
+                    }
+                    
                 },
                 // Pitch
                 new SettingsCheckbox
@@ -113,19 +139,26 @@ namespace osu.Game.Rulesets.Karaoke.UI
                     TooltipText = "Let's see what karaoke! changed.",
                     Action = () =>
                     {
-                        var overlayContent = game.Children[3] as Container;
+                        try
+                        {
+                            if (DisplayContainer == null)
+                                return;
 
-                        if (overlayContent == null)
-                            return;
+                            if (changelogOverlay == null && !DisplayContainer.Children.OfType<KaraokeChangelogOverlay>().Any())
+                                DisplayContainer.Add(changelogOverlay = new KaraokeChangelogOverlay("karaoke-dev"));
 
-                        if (changelogOverlay == null && !overlayContent.Children.OfType<KaraokeChangelogOverlay>().Any())
-                            overlayContent.Add(changelogOverlay = new KaraokeChangelogOverlay("karaoke-dev"));
-
-                        changelogOverlay?.Show();
+                            changelogOverlay?.Show();
+                        }
+                        catch
+                        {
+                            // maybe this overlay has been moved into internal.
+                        }
                     }
                 }
             };
         }
+
+        protected Container DisplayContainer => Geme?.Children[3] as Container;
 
         private class PitchSlider : OsuSliderBar<int>
         {

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Karaoke.UI
                             if (languageSelectionDialog == null && !DisplayContainer.Children.OfType<LanguageSelectionDialog>().Any())
                                 DisplayContainer.Add(languageSelectionDialog = new LanguageSelectionDialog
                                 {
-                                    // Current = config.GetBindable<string>(KaraokeRulesetSetting.PreferLanguage)
+                                    Current = config.GetBindable<CultureInfo>(KaraokeRulesetSetting.PreferLanguage)
                                 });
 
                             languageSelectionDialog?.Show();

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;


### PR DESCRIPTION
Implementation of #283 .
Also deal with issue #294, now it's able to save/load language and can just use `config.GetBindable<CultureInfo>(KaraokeRulesetSetting.PreferLanguage)`.

![image](https://user-images.githubusercontent.com/9100368/101661073-33de3d80-3a8b-11eb-9945-e6d705235c50.png)
This is how it looks like now

![image](https://user-images.githubusercontent.com/9100368/101660102-23799300-3a8a-11eb-959f-375643a9879d.png)
Also need to fix this in the future, maybe it's better to open language selector in the new screen.
