### PR TITLE
Create state manager into lyric editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagIndexUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagIndexUtilsTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Utils
+{
+    [TestFixture]
+    public class TimeTagIndexUtilsTest
+    {
+        [TestCase(0, TimeTagIndex.IndexState.Start, 0)]
+        [TestCase(0, TimeTagIndex.IndexState.End, 1)]
+        [TestCase(-1, TimeTagIndex.IndexState.Start, -1)] // In utils not checking is index out of range
+        [TestCase(-1, TimeTagIndex.IndexState.End, 0)]
+        public void TestToLyricIndex(int index, TimeTagIndex.IndexState state, int actualIndex)
+        {
+            var timeTagIndex = new TimeTagIndex(index, state);
+            Assert.AreEqual(TimeTagIndexUtils.ToLyricIndex(timeTagIndex), actualIndex);
+        }
+
+        [TestCase(TimeTagIndex.IndexState.Start, TimeTagIndex.IndexState.End)]
+        [TestCase(TimeTagIndex.IndexState.End, TimeTagIndex.IndexState.Start)]
+        public void TestReverseState(TimeTagIndex.IndexState state, TimeTagIndex.IndexState actualState)
+        {
+            Assert.AreEqual(TimeTagIndexUtils.ReverseState(state), actualState);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CursorPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CursorPosition.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
-    public struct CursorPosition
+    public readonly struct CursorPosition
     {
         public CursorPosition(Lyric lyric, TimeTagIndex timeTagIndex)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CursorPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CursorPosition.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
+{
+    public struct CursorPosition
+    {
+        public CursorPosition(Lyric lyric, TimeTagIndex timeTagIndex)
+        {
+            Lyric = lyric;
+            Index = timeTagIndex;
+        }
+
+        public Lyric Lyric { get; }
+
+        public TimeTagIndex Index { get; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -93,6 +93,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return lyricEditorStateManager.MoveCursor(CursorAction.Last);
             }
 
+            if (lyricEditorStateManager.Mode != Mode.TimeTagEditMode)
+                return false;
+
             // edit time tag action
             var currentTimeTag = lyricEditorStateManager.BindableRecordCursorPosition.Value;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             }
 
             // edit time tag action
-            var currentTimeTag = lyricEditorStateManager.BindableCursorPosition.Value;
+            var currentTimeTag = lyricEditorStateManager.BindableRecordCursorPosition.Value;
 
             switch (e.Key)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case Key.N:
                     var createdTimeTag = timeTagManager?.AddTimeTag(currentTimeTag);
                     if (createdTimeTag != null)
-                        lyricEditorStateManager.MoveCursorToTargetPosition(createdTimeTag);
+                        lyricEditorStateManager.MoveRecordCursorToTargetPosition(createdTimeTag);
                     return createdTimeTag != null;
 
                 case Key.Delete:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -32,6 +32,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         {
             BindableFastEditMode.Value = fastEditMode;
         }
+
+        public bool MoveCursor(CursorAction action)
+        {
+            switch (Mode)
+            {
+                case Mode.RecordMode:
+                    return moveRecordCursor(action);
+                case Mode.EditMode:
+                case Mode.TimeTagEditMode:
+                    return moveCursor(action);
+                default:
+                    return false;
+            }
+        }
     }
 
     public enum Mode

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -1,21 +1,14 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
-    public class LyricEditorStateManager
+    public partial class LyricEditorStateManager
     {
         private EditorBeatmap beatmap { get; set; }
-
-        public Bindable<Lyric> BindableSplitLyric { get; } = new Bindable<Lyric>();
-        public Bindable<TimeTagIndex> BindableSplitPosition { get; } = new Bindable<TimeTagIndex>();
 
         public Bindable<Mode> BindableMode { get; } = new Bindable<Mode>();
 
@@ -25,136 +18,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public LyricFastEditMode FastEditMode => BindableFastEditMode.Value;
 
-        public Bindable<TimeTag> BindableCursorPosition { get; } = new Bindable<TimeTag>();
-
         public LyricEditorStateManager(EditorBeatmap beatmap)
         {
             this.beatmap = beatmap;
         }
-
-        #region Cursor position by time-tag
-
-        public void UpdateSplitCursorPosition(Lyric lyric, TimeTagIndex index)
-        {
-            BindableSplitLyric.Value = lyric;
-            BindableSplitPosition.Value = index;
-        }
-
-        public void ClearSplitCursorPosition()
-        {
-            BindableSplitLyric.Value = null;
-        }
-
-        #endregion
-
-        #region Cursor position by lyric
-
-        public bool MoveCursor(CursorAction action)
-        {
-            var currentTimeTag = BindableCursorPosition.Value;
-
-            TimeTag nextTimeTag = null;
-
-            switch (action)
-            {
-                case CursorAction.MoveUp:
-                    nextTimeTag = getPreviousLyricTimeTag(currentTimeTag);
-                    break;
-
-                case CursorAction.MoveDown:
-                    nextTimeTag = getNextLyricTimeTag(currentTimeTag);
-                    break;
-
-                case CursorAction.MoveLeft:
-                    nextTimeTag = getPreviousTimeTag(currentTimeTag);
-                    break;
-
-                case CursorAction.MoveRight:
-                    nextTimeTag = getNextTimeTag(currentTimeTag);
-                    break;
-
-                case CursorAction.First:
-                    nextTimeTag = getFirstTimeTag(currentTimeTag);
-                    break;
-
-                case CursorAction.Last:
-                    nextTimeTag = getLastTimeTag(currentTimeTag);
-                    break;
-            }
-
-            if (nextTimeTag == null)
-                return false;
-
-            moveCursorTo(nextTimeTag);
-            return true;
-        }
-
-        public bool MoveCursorToTargetPosition(TimeTag timeTag)
-        {
-            if (timeTagInLyric(timeTag) == null)
-                return false;
-
-            moveCursorTo(timeTag);
-            return true;
-        }
-
-        private Lyric timeTagInLyric(TimeTag timeTag)
-        {
-            if (timeTag == null)
-                return null;
-
-            return beatmap.HitObjects.OfType<Lyric>().FirstOrDefault(x => x.TimeTags?.Contains(timeTag) ?? false);
-        }
-
-        private TimeTag getPreviousLyricTimeTag(TimeTag timeTag)
-        {
-            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
-            var currentLyric = timeTagInLyric(timeTag);
-            return lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
-        }
-
-        private TimeTag getNextLyricTimeTag(TimeTag timeTag)
-        {
-            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
-            var currentLyric = timeTagInLyric(timeTag);
-            return lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
-        }
-
-        private TimeTag getPreviousTimeTag(TimeTag timeTag)
-        {
-            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetPrevious(timeTag);
-        }
-
-        private TimeTag getNextTimeTag(TimeTag timeTag)
-        {
-            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetNext(timeTag);
-        }
-
-        private TimeTag getFirstTimeTag(TimeTag timeTag)
-        {
-            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.FirstOrDefault();
-        }
-
-        private TimeTag getLastTimeTag(TimeTag timeTag)
-        {
-            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.LastOrDefault();
-        }
-
-        private void moveCursorTo(TimeTag timeTag)
-        {
-            if (timeTag == null)
-                return;
-
-            BindableCursorPosition.Value = timeTag;
-        }
-
-        #endregion
-
-        #region Mode
 
         public void SetMode(Mode mode)
         {
@@ -165,8 +32,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         {
             BindableFastEditMode.Value = fastEditMode;
         }
-
-        #endregion
     }
 
     public enum Mode

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -26,6 +26,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public void SetMode(Mode mode)
         {
             BindableMode.Value = mode;
+            switch (mode)
+            {
+                case Mode.RecordMode:
+                    MoveCursor(CursorAction.First);
+                    return;
+            }
         }
 
         public void SetFastEditMode(LyricFastEditMode fastEditMode)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public partial class LyricEditorStateManager
     {
-        private EditorBeatmap beatmap { get; set; }
+        private EditorBeatmap beatmap { get; }
 
         public Bindable<Mode> BindableMode { get; } = new Bindable<Mode>();
 
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public void SetMode(Mode mode)
         {
             BindableMode.Value = mode;
+
             switch (mode)
             {
                 case Mode.RecordMode:
@@ -45,9 +46,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 case Mode.RecordMode:
                     return moveRecordCursor(action);
+
                 case Mode.EditMode:
                 case Mode.TimeTagEditMode:
                     return moveCursor(action);
+
                 default:
                     return false;
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private EditorBeatmap beatmap { get; set; }
 
         public Bindable<Lyric> BindableSplitLyric { get; } = new Bindable<Lyric>();
-        public Bindable<int> BindableSplitPosition { get; } = new Bindable<int>();
+        public Bindable<TimeTagIndex> BindableSplitPosition { get; } = new Bindable<TimeTagIndex>();
 
         public Bindable<Mode> BindableMode { get; } = new Bindable<Mode>();
 
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         #region Cursor position by time-tag
 
-        public void UpdateSplitCursorPosition(Lyric lyric, int index)
+        public void UpdateSplitCursorPosition(Lyric lyric, TimeTagIndex index)
         {
             BindableSplitLyric.Value = lyric;
             BindableSplitPosition.Value = index;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
+{
+    public partial class LyricEditorStateManager
+    {
+        public Bindable<CursorPosition> BindableCursorHoverPosition { get; } = new Bindable<CursorPosition>();
+
+        public Bindable<CursorPosition> BindableCursorPosition { get; } = new Bindable<CursorPosition>();
+
+        public void UpdateSplitCursorPosition(Lyric lyric, TimeTagIndex index)
+        {
+            BindableCursorPosition.Value = new CursorPosition(lyric, index);
+        }
+
+        public void ClearSplitCursorPosition()
+        {
+            BindableCursorPosition.Value = new CursorPosition();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -13,14 +16,160 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public Bindable<CursorPosition> BindableCursorPosition { get; } = new Bindable<CursorPosition>();
 
-        public void UpdateSplitCursorPosition(Lyric lyric, TimeTagIndex index)
+        public void MoveCursorToTargetPosition(Lyric lyric, TimeTagIndex index)
         {
-            BindableCursorPosition.Value = new CursorPosition(lyric, index);
+            movePositionTo(new CursorPosition(lyric, index));
         }
 
         public void ClearSplitCursorPosition()
         {
             BindableCursorPosition.Value = new CursorPosition();
+        }
+
+        private bool moveCursor(CursorAction action)
+        {
+            var currentPosition = BindableCursorPosition.Value;
+
+            CursorPosition position = new CursorPosition();
+
+            switch (action)
+            {
+                case CursorAction.MoveUp:
+                    position = getPreviousLyricCursorPosition(currentPosition);
+                    break;
+
+                case CursorAction.MoveDown:
+                    position = getNextLyricCursorPosition(currentPosition);
+                    break;
+
+                case CursorAction.MoveLeft:
+                    position = getPreviousCursorPosition(currentPosition);
+                    break;
+
+                case CursorAction.MoveRight:
+                    position = getNextCursorPosition(currentPosition);
+                    break;
+
+                case CursorAction.First:
+                    position = getFirstCursorPosition();
+                    break;
+
+                case CursorAction.Last:
+                    position = getLastCursorPosition();
+                    break;
+            }
+
+            if (position.Lyric == null)
+                return false;
+
+            movePositionTo(position);
+            return true;
+        }
+
+        private CursorPosition getPreviousLyricCursorPosition(CursorPosition position)
+        {
+            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
+            var lyric = lyrics.GetPrevious(position.Lyric);
+            if (lyric == null)
+                return new CursorPosition();
+
+            var lyricTextLength = lyric.Text?.Length ?? 0;
+            var index = Math.Min(position.Index.Index, lyricTextLength - 1);
+            var state = position.Index.State;
+
+            return new CursorPosition(lyric, new TimeTagIndex(index, state));
+        }
+
+        private CursorPosition getNextLyricCursorPosition(CursorPosition position)
+        {
+            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
+            var lyric = lyrics.GetNext(position.Lyric);
+            if (lyric == null)
+                return new CursorPosition();
+
+            var lyricTextLength = lyric.Text?.Length ?? 0;
+            var index = Math.Min(position.Index.Index, lyricTextLength - 1);
+            var state = position.Index.State;
+
+            return new CursorPosition(lyric, new TimeTagIndex(index, state));
+        }
+
+        private CursorPosition getPreviousCursorPosition(CursorPosition position)
+        {
+            // get previous cursor and make a check is need to change line.
+            var previousTimeTag = getPreviousTag(Mode, position.Index);
+            if (previousTimeTag.Index < 0)
+            {
+                getNextLyricCursorPosition(new CursorPosition(position.Lyric, new TimeTagIndex(int.MaxValue)));
+            }
+
+            return new CursorPosition(position.Lyric, previousTimeTag);
+
+            static TimeTagIndex getPreviousTag(Mode mode, TimeTagIndex currentTimeTag)
+            {
+                switch (mode)
+                {
+                    case Mode.EditMode:
+                        return new TimeTagIndex(currentTimeTag.Index - 1, currentTimeTag.State);
+                    case Mode.TimeTagEditMode:
+                        var nextIndex = currentTimeTag.Index + (currentTimeTag.State == TimeTagIndex.IndexState.End ? 1 : 0);
+                        var nextState = currentTimeTag.State == TimeTagIndex.IndexState.End ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
+                        return new TimeTagIndex(nextIndex, nextState);
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(mode));
+                }
+            }
+        }
+
+        private CursorPosition getNextCursorPosition(CursorPosition position)
+        {
+            var textLength = position.Lyric?.Text?.Length ?? 0;
+
+            // get next cursor and make a check is need to change line.
+            var nextTimeTag = getNextTag(Mode, position.Index);
+            if (nextTimeTag.Index >= textLength) {
+                getNextLyricCursorPosition(new CursorPosition(position.Lyric, new TimeTagIndex(int.MinValue)));
+            }
+
+            return new CursorPosition(position.Lyric, nextTimeTag);
+
+            static TimeTagIndex getNextTag(Mode mode, TimeTagIndex currentTimeTag)
+            {
+                switch (mode)
+                {
+                    case Mode.EditMode:
+                        return new TimeTagIndex(currentTimeTag.Index + 1, currentTimeTag.State);
+                    case Mode.TimeTagEditMode:
+                        var nextIndex = currentTimeTag.Index + (currentTimeTag.State == TimeTagIndex.IndexState.End ? 1 : 0);
+                        var nextState = currentTimeTag.State == TimeTagIndex.IndexState.End ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
+                        return new TimeTagIndex(nextIndex, nextState);
+                    default:
+                            throw new ArgumentOutOfRangeException(nameof(mode));
+                    }
+            }
+        }
+
+        private CursorPosition getFirstCursorPosition()
+        {
+            var lyric = beatmap.HitObjects.OfType<Lyric>().FirstOrDefault();
+            var index = new TimeTagIndex();
+            return new CursorPosition(lyric, index);
+        }
+
+        private CursorPosition getLastCursorPosition()
+        {
+            var lyric = beatmap.HitObjects.OfType<Lyric>().LastOrDefault();
+            var textLength = lyric?.Text.Length ?? 0;
+            var index = new TimeTagIndex(textLength - 1, TimeTagIndex.IndexState.End);
+            return new CursorPosition(lyric, index);
+        }
+
+        private void movePositionTo(CursorPosition position)
+        {
+            if (position.Lyric == null)
+                return;
+
+            BindableCursorPosition.Value = position;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
@@ -117,8 +118,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case Mode.EditMode:
                         return new TimeTagIndex(currentTimeTag.Index - 1, currentTimeTag.State);
                     case Mode.TimeTagEditMode:
-                        var nextIndex = currentTimeTag.Index + (currentTimeTag.State == TimeTagIndex.IndexState.End ? 1 : 0);
-                        var nextState = currentTimeTag.State == TimeTagIndex.IndexState.End ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
+                        var nextIndex = TimeTagIndexUtils.ToLyricIndex(currentTimeTag) - 1;
+                        var nextState = TimeTagIndexUtils.ReverseState(currentTimeTag.State);
                         return new TimeTagIndex(nextIndex, nextState);
                     default:
                         throw new ArgumentOutOfRangeException(nameof(mode));
@@ -145,8 +146,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case Mode.EditMode:
                         return new TimeTagIndex(currentTimeTag.Index + 1, currentTimeTag.State);
                     case Mode.TimeTagEditMode:
-                        var nextIndex = currentTimeTag.Index + (currentTimeTag.State == TimeTagIndex.IndexState.End ? 1 : 0);
-                        var nextState = currentTimeTag.State == TimeTagIndex.IndexState.End ? TimeTagIndex.IndexState.Start : TimeTagIndex.IndexState.End;
+                        var nextIndex = TimeTagIndexUtils.ToLyricIndex(currentTimeTag);
+                        var nextState = TimeTagIndexUtils.ReverseState(currentTimeTag.State);
                         return new TimeTagIndex(nextIndex, nextState);
                     default:
                             throw new ArgumentOutOfRangeException(nameof(mode));

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         {
             // get previous cursor and make a check is need to change line.
             var previousTimeTag = getPreviousTag(Mode, position.Index);
+
             if (previousTimeTag.Index < 0)
             {
                 getNextLyricCursorPosition(new CursorPosition(position.Lyric, new TimeTagIndex(int.MaxValue)));
@@ -117,10 +118,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 {
                     case Mode.EditMode:
                         return new TimeTagIndex(currentTimeTag.Index - 1, currentTimeTag.State);
+
                     case Mode.TimeTagEditMode:
                         var nextIndex = TimeTagIndexUtils.ToLyricIndex(currentTimeTag) - 1;
                         var nextState = TimeTagIndexUtils.ReverseState(currentTimeTag.State);
                         return new TimeTagIndex(nextIndex, nextState);
+
                     default:
                         throw new ArgumentOutOfRangeException(nameof(mode));
                 }
@@ -133,7 +136,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             // get next cursor and make a check is need to change line.
             var nextTimeTag = getNextTag(Mode, position.Index);
-            if (nextTimeTag.Index >= textLength) {
+
+            if (nextTimeTag.Index >= textLength)
+            {
                 getNextLyricCursorPosition(new CursorPosition(position.Lyric, new TimeTagIndex(int.MinValue)));
             }
 
@@ -145,13 +150,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 {
                     case Mode.EditMode:
                         return new TimeTagIndex(currentTimeTag.Index + 1, currentTimeTag.State);
+
                     case Mode.TimeTagEditMode:
                         var nextIndex = TimeTagIndexUtils.ToLyricIndex(currentTimeTag);
                         var nextState = TimeTagIndexUtils.ReverseState(currentTimeTag.State);
                         return new TimeTagIndex(nextIndex, nextState);
+
                     default:
-                            throw new ArgumentOutOfRangeException(nameof(mode));
-                    }
+                        throw new ArgumentOutOfRangeException(nameof(mode));
+                }
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public partial class LyricEditorStateManager
     {
-        public Bindable<CursorPosition> BindableCursorHoverPosition { get; } = new Bindable<CursorPosition>();
+        public Bindable<CursorPosition> BindableHoverCursorPosition { get; } = new Bindable<CursorPosition>();
 
         public Bindable<CursorPosition> BindableCursorPosition { get; } = new Bindable<CursorPosition>();
 
@@ -21,9 +21,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             movePositionTo(new CursorPosition(lyric, index));
         }
 
-        public void ClearSplitCursorPosition()
+        public void MoveHoverCursorToTargetPosition(Lyric lyric, TimeTagIndex index)
         {
-            BindableCursorPosition.Value = new CursorPosition();
+            moveHoverPositionTo(new CursorPosition(lyric, index));
+        }
+
+        public void ClearHoverCursorPosition()
+        {
+            BindableHoverCursorPosition.Value = new CursorPosition();
         }
 
         private bool moveCursor(CursorAction action)
@@ -169,7 +174,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             if (position.Lyric == null)
                 return;
 
+            BindableHoverCursorPosition.Value = new CursorPosition();
             BindableCursorPosition.Value = position;
+        }
+
+        private void moveHoverPositionTo(CursorPosition position)
+        {
+            if (position.Lyric == null)
+                return;
+
+            BindableHoverCursorPosition.Value = position;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -10,17 +10,31 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public partial class LyricEditorStateManager
     {
-        public Bindable<TimeTag> BindableRecordCursorHoverPosition { get; } = new Bindable<TimeTag>();
+        public Bindable<TimeTag> BindableHoverRecordCursorPosition { get; } = new Bindable<TimeTag>();
 
         public Bindable<TimeTag> BindableRecordCursorPosition { get; } = new Bindable<TimeTag>();
 
-        public bool MoveCursorToTargetPosition(TimeTag timeTag)
+        public bool MoveRecordCursorToTargetPosition(TimeTag timeTag)
         {
             if (timeTagInLyric(timeTag) == null)
                 return false;
 
             moveCursorTo(timeTag);
             return true;
+        }
+
+        public bool MoveHoverRecordCursorToTargetPosition(TimeTag timeTag)
+        {
+            if (timeTagInLyric(timeTag) == null)
+                return false;
+
+            moveHoverCursorTo(timeTag);
+            return true;
+        }
+
+        public void ClearHoverRecordCursorPosition()
+        {
+            BindableHoverRecordCursorPosition.Value = null;
         }
 
         private bool moveRecordCursor(CursorAction action)
@@ -114,7 +128,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             if (timeTag == null)
                 return;
 
+            BindableHoverRecordCursorPosition.Value = null;
             BindableRecordCursorPosition.Value = timeTag;
+        }
+
+        private void moveHoverCursorTo(TimeTag timeTag)
+        {
+            if (timeTag == null)
+                return;
+
+            BindableHoverRecordCursorPosition.Value = timeTag;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
+{
+    public partial class LyricEditorStateManager
+    {
+        public Bindable<TimeTag> BindableRecordCursorHoverPosition { get; } = new Bindable<TimeTag>();
+
+        public Bindable<TimeTag> BindableRecordCursorPosition { get; } = new Bindable<TimeTag>();
+
+        public bool MoveCursor(CursorAction action)
+        {
+            var currentTimeTag = BindableRecordCursorPosition.Value;
+
+            TimeTag nextTimeTag = null;
+
+            switch (action)
+            {
+                case CursorAction.MoveUp:
+                    nextTimeTag = getPreviousLyricTimeTag(currentTimeTag);
+                    break;
+
+                case CursorAction.MoveDown:
+                    nextTimeTag = getNextLyricTimeTag(currentTimeTag);
+                    break;
+
+                case CursorAction.MoveLeft:
+                    nextTimeTag = getPreviousTimeTag(currentTimeTag);
+                    break;
+
+                case CursorAction.MoveRight:
+                    nextTimeTag = getNextTimeTag(currentTimeTag);
+                    break;
+
+                case CursorAction.First:
+                    nextTimeTag = getFirstTimeTag(currentTimeTag);
+                    break;
+
+                case CursorAction.Last:
+                    nextTimeTag = getLastTimeTag(currentTimeTag);
+                    break;
+            }
+
+            if (nextTimeTag == null)
+                return false;
+
+            moveCursorTo(nextTimeTag);
+            return true;
+        }
+
+        public bool MoveCursorToTargetPosition(TimeTag timeTag)
+        {
+            if (timeTagInLyric(timeTag) == null)
+                return false;
+
+            moveCursorTo(timeTag);
+            return true;
+        }
+
+        private Lyric timeTagInLyric(TimeTag timeTag)
+        {
+            if (timeTag == null)
+                return null;
+
+            return beatmap.HitObjects.OfType<Lyric>().FirstOrDefault(x => x.TimeTags?.Contains(timeTag) ?? false);
+        }
+
+        private TimeTag getPreviousLyricTimeTag(TimeTag timeTag)
+        {
+            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
+            var currentLyric = timeTagInLyric(timeTag);
+            return lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
+        }
+
+        private TimeTag getNextLyricTimeTag(TimeTag timeTag)
+        {
+            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
+            var currentLyric = timeTagInLyric(timeTag);
+            return lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
+        }
+
+        private TimeTag getPreviousTimeTag(TimeTag timeTag)
+        {
+            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
+            return timeTags.GetPrevious(timeTag);
+        }
+
+        private TimeTag getNextTimeTag(TimeTag timeTag)
+        {
+            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
+            return timeTags.GetNext(timeTag);
+        }
+
+        private TimeTag getFirstTimeTag(TimeTag timeTag)
+        {
+            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
+            return timeTags.FirstOrDefault();
+        }
+
+        private TimeTag getLastTimeTag(TimeTag timeTag)
+        {
+            var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
+            return timeTags.LastOrDefault();
+        }
+
+        private void moveCursorTo(TimeTag timeTag)
+        {
+            if (timeTag == null)
+                return;
+
+            BindableRecordCursorPosition.Value = timeTag;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -14,7 +14,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public Bindable<TimeTag> BindableRecordCursorPosition { get; } = new Bindable<TimeTag>();
 
-        public bool MoveCursor(CursorAction action)
+        public bool MoveCursorToTargetPosition(TimeTag timeTag)
+        {
+            if (timeTagInLyric(timeTag) == null)
+                return false;
+
+            moveCursorTo(timeTag);
+            return true;
+        }
+
+        private bool moveRecordCursor(CursorAction action)
         {
             var currentTimeTag = BindableRecordCursorPosition.Value;
 
@@ -39,11 +48,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     break;
 
                 case CursorAction.First:
-                    nextTimeTag = getFirstTimeTag(currentTimeTag);
+                    nextTimeTag = getFirstTimeTag();
                     break;
 
                 case CursorAction.Last:
-                    nextTimeTag = getLastTimeTag(currentTimeTag);
+                    nextTimeTag = getLastTimeTag();
                     break;
             }
 
@@ -51,15 +60,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 return false;
 
             moveCursorTo(nextTimeTag);
-            return true;
-        }
-
-        public bool MoveCursorToTargetPosition(TimeTag timeTag)
-        {
-            if (timeTagInLyric(timeTag) == null)
-                return false;
-
-            moveCursorTo(timeTag);
             return true;
         }
 
@@ -97,13 +97,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             return timeTags.GetNext(timeTag);
         }
 
-        private TimeTag getFirstTimeTag(TimeTag timeTag)
+        private TimeTag getFirstTimeTag()
         {
             var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
             return timeTags.FirstOrDefault();
         }
 
-        private TimeTag getLastTimeTag(TimeTag timeTag)
+        private TimeTag getLastTimeTag()
         {
             var timeTags = beatmap.HitObjects.OfType<Lyric>().SelectMany(x => x.TimeTags).ToArray();
             return timeTags.LastOrDefault();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Languages;
 using osu.Game.Rulesets.Karaoke.Objects;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
@@ -10,7 +10,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 {
-    public class DrawableLyricSplitterCursor : CompositeDrawable
+    public class DrawableLyricSplitterCursor : CompositeDrawable, IDrawableCursor
     {
         public DrawableLyricSplitterCursor()
         {
@@ -44,5 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours) => Colour = colours.Red;
+
+        public bool Preview { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
@@ -12,39 +12,55 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 {
     public class DrawableLyricSplitterCursor : CompositeDrawable, IDrawableCursor
     {
+        private readonly Container splitter;
         public DrawableLyricSplitterCursor()
         {
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;
-            InternalChildren = new Drawable[]
+            InternalChild = splitter = new Container
             {
-                new Triangle
+                RelativeSizeAxes = Axes.Y,
+                AutoSizeAxes = Axes.X,
+                Children = new Drawable[]
                 {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.BottomCentre,
-                    Scale = new Vector2(1, -1),
-                    Size = new Vector2(10, 5),
-                },
-                new Triangle
-                {
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
-                    Size = new Vector2(10, 5)
-                },
-                new Box
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Y,
-                    Width = 2,
-                    EdgeSmoothness = new Vector2(1, 0)
+                    new Triangle
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.BottomCentre,
+                        Scale = new Vector2(1, -1),
+                        Size = new Vector2(10, 5),
+                    },
+                    new Triangle
+                    {
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                        Size = new Vector2(10, 5)
+                    },
+                    new Box
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Y,
+                        Width = 2,
+                        EdgeSmoothness = new Vector2(1, 0)
+                    }
                 }
             };
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours) => Colour = colours.Red;
+        private void load(OsuColour colours) => splitter.Colour = colours.Red;
 
-        public bool Preview { get; set; }
+        private bool preview;
+
+        public bool Preview
+        {
+            get => preview;
+            set
+            {
+                preview = value;
+                splitter.Alpha = preview ? 0.5f : 1;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableLyricSplitterCursor.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
     public class DrawableLyricSplitterCursor : CompositeDrawable, IDrawableCursor
     {
         private readonly Container splitter;
+
         public DrawableLyricSplitterCursor()
         {
             RelativeSizeAxes = Axes.Y;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTag.cs
@@ -43,11 +43,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
             };
         }
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            return stateManager?.MoveRecordCursorToTargetPosition(timeTag) ?? false;
-        }
-
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -56,13 +51,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 
         protected override bool OnHover(HoverEvent e)
         {
+            if (!isTrigger(stateManager.Mode))
+                return false;
+
             return stateManager?.MoveHoverRecordCursorToTargetPosition(timeTag) ?? false;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
+            if (!isTrigger(stateManager.Mode))
+                return;
+
             stateManager?.ClearHoverRecordCursorPosition();
             base.OnHoverLost(e);
         }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (!isTrigger(stateManager.Mode))
+                return false;
+
+            return stateManager.MoveRecordCursorToTargetPosition(timeTag);
+        }
+
+        private bool isTrigger(Mode mode)
+            => mode == Mode.RecordMode;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTag.cs
@@ -45,13 +45,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 
         protected override bool OnClick(ClickEvent e)
         {
-            return stateManager?.MoveCursorToTargetPosition(timeTag) ?? false;
+            return stateManager?.MoveRecordCursorToTargetPosition(timeTag) ?? false;
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             InternalChild.Colour = timeTag.Time.HasValue ? colours.Yellow : colours.Gray7;
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            return stateManager?.MoveHoverRecordCursorToTargetPosition(timeTag) ?? false;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            stateManager?.ClearHoverRecordCursorPosition();
+            base.OnHoverLost(e);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagCursor.cs
@@ -7,39 +7,47 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 {
-    public class DrawableTimeTagCursor : CompositeDrawable
+    public class DrawableTimeTagCursor : CompositeDrawable, IDrawableCursor, IHasCursorPosition
     {
-        /// <summary>
-        /// Height of major bar line triangles.
-        /// </summary>
         private const float triangle_width = 8;
 
-        private readonly TimeTag timeTag;
+        [Resolved]
+        private OsuColour colours { get; set; }
 
-        public DrawableTimeTagCursor(TimeTag timeTag)
+        private readonly RightTriangle drawableTimeTag;
+
+        public DrawableTimeTagCursor()
         {
-            this.timeTag = timeTag;
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = new RightTriangle
+            InternalChild = drawableTimeTag = new RightTriangle
             {
                 Name = "Time tag triangle",
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(triangle_width),
-                Scale = new Vector2(timeTag.Index.State == TimeTagIndex.IndexState.Start ? 1 : -1, 1)
             };
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private CursorPosition position;
+
+        public CursorPosition CursorPosition
         {
-            InternalChild.Colour = timeTag.Time.HasValue ? colours.YellowDarker : colours.Gray3;
+            get => position;
+            set
+            {
+                position = value;
+                drawableTimeTag.Scale = new Vector2(position.Index.State == TimeTagIndex.IndexState.Start ? 1 : -1, 1);
+
+                // todo : color is by has time-tag here?
+                // drawableTimeTag.Colour = position.Time.HasValue ? colours.YellowDarker : colours.Gray3;
+            }
         }
+
+        public bool Preview { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagEditCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagEditCursor.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
+{
+    public class DrawableTimeTagEditCursor : CompositeDrawable, IDrawableCursor, IHasCursorPosition
+    {
+        private const float triangle_width = 8;
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private readonly RightTriangle drawableTimeTag;
+
+        public DrawableTimeTagEditCursor()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChild = drawableTimeTag = new RightTriangle
+            {
+                Name = "Time tag triangle",
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(triangle_width),
+            };
+        }
+
+        private CursorPosition position;
+
+        public CursorPosition CursorPosition
+        {
+            get => position;
+            set
+            {
+                position = value;
+                drawableTimeTag.Scale = new Vector2(position.Index.State == TimeTagIndex.IndexState.Start ? 1 : -1, 1);
+
+                // todo : color is by has time-tag here?
+                // drawableTimeTag.Colour = position.Time.HasValue ? colours.YellowDarker : colours.Gray3;
+            }
+        }
+
+        private bool preview;
+
+        public bool Preview
+        {
+            get => preview;
+            set
+            {
+                preview = value;
+                drawableTimeTag.Alpha = preview ? 0.5f : 1;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagRecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/DrawableTimeTagRecordCursor.cs
@@ -7,11 +7,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 {
-    public class DrawableTimeTagCursor : CompositeDrawable, IDrawableCursor, IHasCursorPosition
+    public class DrawableTimeTagRecordCursor : CompositeDrawable, IDrawableCursor, IHasTimeTag
     {
         private const float triangle_width = 8;
 
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
 
         private readonly RightTriangle drawableTimeTag;
 
-        public DrawableTimeTagCursor()
+        public DrawableTimeTagRecordCursor()
         {
             AutoSizeAxes = Axes.Both;
 
@@ -33,21 +34,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
             };
         }
 
-        private CursorPosition position;
+        private TimeTag timeTag;
 
-        public CursorPosition CursorPosition
+        public TimeTag TimeTag
         {
-            get => position;
+            get => timeTag;
             set
             {
-                position = value;
-                drawableTimeTag.Scale = new Vector2(position.Index.State == TimeTagIndex.IndexState.Start ? 1 : -1, 1);
-
-                // todo : color is by has time-tag here?
-                // drawableTimeTag.Colour = position.Time.HasValue ? colours.YellowDarker : colours.Gray3;
+                timeTag = value;
+                drawableTimeTag.Scale = new Vector2(timeTag.Index.State == TimeTagIndex.IndexState.Start ? 1 : -1, 1);
+                drawableTimeTag.Colour = timeTag.Time.HasValue ? colours.YellowDarker : colours.Gray3;
             }
         }
 
-        public bool Preview { get; set; }
+        private bool preview;
+
+        public bool Preview
+        {
+            get => preview;
+            set
+            {
+                preview = value;
+                drawableTimeTag.Alpha = preview ? 0.5f : 1;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IDrawableCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IDrawableCursor.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
+{
+    public interface IDrawableCursor : IDrawable
+    {
+        /// <summary>
+        /// Is previewing cursor
+        /// </summary>
+        bool Preview { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IHasCursorPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IHasCursorPosition.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
+{
+    public interface IHasCursorPosition
+    {
+        CursorPosition CursorPosition { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IHasTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/Components/IHasTimeTag.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.ions.Generic;
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components
+{
+    public interface IHasTimeTag
+    {
+        TimeTag TimeTag { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/DrawableEditorLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/DrawableEditorLyric.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Skinning.Components;
@@ -52,19 +53,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
         public float GetPercentageWidth(int startIndex, int endIndex, float percentage = 0)
             => KaraokeText.GetPercentageWidth(startIndex, endIndex, percentage);
 
-        public int GetHoverIndex(float position)
+        public TimeTagIndex GetHoverIndex(float position)
         {
             var text = KaraokeText.Text;
             if (string.IsNullOrEmpty(text))
-                return 0;
+                return new TimeTagIndex();
 
             for (int i = 0; i < text.Length; i++)
             {
                 if (GetPercentageWidth(i, i + 1, 0.5f) > position)
-                    return i;
+                    return new TimeTagIndex(i, TimeTagIndex.IndexState.Start);
+
+                if (GetPercentageWidth(i, i + 1, 1f) > position)
+                    return new TimeTagIndex(i, TimeTagIndex.IndexState.End);
             }
 
-            return text.Length;
+            return new TimeTagIndex(text.Length - 1, TimeTagIndex.IndexState.End);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/DrawableEditorLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/DrawableEditorLyric.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
             for (int i = 0; i < text.Length; i++)
             {
                 if (GetPercentageWidth(i, i + 1, 0.5f) > position)
-                    return new TimeTagIndex(i, TimeTagIndex.IndexState.Start);
+                    return new TimeTagIndex(i);
 
                 if (GetPercentageWidth(i, i + 1, 1f) > position)
                     return new TimeTagIndex(i, TimeTagIndex.IndexState.End);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -94,10 +94,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 
         protected override bool OnClick(ClickEvent e)
         {
-            var index = stateManager.BindableSplitPosition.Value;
+            var timeTagIndex = stateManager.BindableSplitPosition.Value;
+            var splitPosition = timeTagIndex.Index + timeTagIndex.State == TimeTagIndex.IndexState.End ? 1 : 0;
 
             // get index then cut.
-            lyricManager?.SplitLyric(Lyric, index);
+            lyricManager?.SplitLyric(Lyric, splitPosition);
             return base.OnClick(e);
         }
 
@@ -162,7 +163,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
             if (lyric != Lyric)
                 return;
 
-            var spacing = textIndexPosition(index);
+            var spacing = timeTagIndexPosition(index) - 10;
             splitCursorContainer.Add(new DrawableLyricSplitterCursor
             {
                 Anchor = Anchor.CentreLeft,
@@ -170,9 +171,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
                 X = spacing,
             });
         }
-
-        private float textIndexPosition(int index)
-            => timeTagIndexPosition(new TimeTagIndex(index)) - 10;
 
         private float timeTagIndexPosition(TimeTagIndex timeTagIndex)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -112,15 +112,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 
             // split or set time-tag by double click
             var timeTagIndex = stateManager.BindableHoverCursorPosition.Value.Index;
+
             switch (stateManager.Mode)
             {
                 case Mode.EditMode:
                     var splitPosition = TimeTagIndexUtils.ToLyricIndex(timeTagIndex);
                     lyricManager?.SplitLyric(Lyric, splitPosition);
                     return true;
+
                 case Mode.TimeTagEditMode:
                     // todo : might add or remove time-tag in here.
                     return false;
+
                 default:
                     return base.OnDoubleClick(e);
             }
@@ -179,7 +182,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
                     drawableCursor.Preview = isPreview;
 
                 cursorContainer.Add(cursor);
-            };
+            }
 
             static Drawable createCursor(Mode mode)
             {
@@ -187,12 +190,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
                 {
                     case Mode.ViewMode:
                         return null;
+
                     case Mode.EditMode:
                         return new DrawableLyricSplitterCursor();
+
                     case Mode.RecordMode:
                         return new DrawableTimeTagRecordCursor();
+
                     case Mode.TimeTagEditMode:
                         return new DrawableTimeTagEditCursor();
+
                     default:
                         throw new IndexOutOfRangeException(nameof(mode));
                 }
@@ -263,6 +270,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 
                 drawableCursor.X = timeTagIndexPosition(index) + offset;
             }
+
             if (cursor is IHasCursorPosition cursorPosition)
             {
                 cursorPosition.CursorPosition = position;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
             // todo : get real index.
             var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
             var index = drawableLyric.GetHoverIndex(position);
-            stateManager.UpdateSplitCursorPosition(Lyric, index);
+            stateManager.MoveCursorToTargetPosition(Lyric, index);
             return base.OnMouseMove(e);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 {
@@ -114,7 +115,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
             switch (stateManager.Mode)
             {
                 case Mode.EditMode:
-                    var splitPosition = timeTagIndex.Index + timeTagIndex.State == TimeTagIndex.IndexState.End ? 1 : 0;
+                    var splitPosition = TimeTagIndexUtils.ToLyricIndex(timeTagIndex);
                     lyricManager?.SplitLyric(Lyric, splitPosition);
                     return true;
                 case Mode.TimeTagEditMode:
@@ -252,8 +253,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 
             if (cursor is Drawable drawableCursor)
             {
-                var spacing = timeTagIndexPosition(position.Index) - 10;
-                drawableCursor.X = spacing;
+                var index = position.Index;
+                if (stateManager.Mode == Mode.EditMode)
+                    index = new TimeTagIndex(TimeTagIndexUtils.ToLyricIndex(index));
+
+                var offset = 0;
+                if (stateManager.Mode == Mode.EditMode)
+                    offset = -10;
+
+                drawableCursor.X = timeTagIndexPosition(index) + offset;
             }
             if (cursor is IHasCursorPosition cursorPosition)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
 
         protected override bool OnClick(ClickEvent e)
         {
-            var timeTagIndex = stateManager.BindableSplitPosition.Value;
+            var timeTagIndex = stateManager.BindableCursorPosition.Value.Index;
             var splitPosition = timeTagIndex.Index + timeTagIndex.State == TimeTagIndex.IndexState.End ? 1 : 0;
 
             // get index then cut.
@@ -106,15 +106,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
         private void load(IFrameBasedClock framedClock, TimeTagManager timeTagManager)
         {
             drawableLyric.Clock = framedClock;
-            stateManager.BindableCursorPosition.BindValueChanged(e =>
+            stateManager.BindableRecordCursorPosition.BindValueChanged(e =>
             {
                 UpdateTimeTagCursor(e.NewValue);
             }, true);
-            stateManager.BindableSplitLyric.BindValueChanged(e =>
-            {
-                UpdateSplitter();
-            });
-            stateManager.BindableSplitPosition.BindValueChanged(e =>
+            stateManager.BindableCursorPosition.BindValueChanged(e =>
             {
                 UpdateSplitter();
             });
@@ -158,12 +154,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
         protected void UpdateSplitter()
         {
             splitCursorContainer.Clear();
-            var lyric = stateManager.BindableSplitLyric.Value;
-            var index = stateManager.BindableSplitPosition.Value;
-            if (lyric != Lyric)
+            var position = stateManager.BindableCursorPosition.Value;
+            if (position.Lyric != Lyric)
                 return;
 
-            var spacing = timeTagIndexPosition(index) - 10;
+            var spacing = timeTagIndexPosition(position.Index) - 10;
             splitCursorContainer.Add(new DrawableLyricSplitterCursor
             {
                 Anchor = Anchor.CentreLeft,

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -82,13 +82,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
             // todo : get real index.
             var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
             var index = drawableLyric.GetHoverIndex(position);
-            stateManager.MoveCursorToTargetPosition(Lyric, index);
+            stateManager.MoveHoverCursorToTargetPosition(Lyric, index);
             return base.OnMouseMove(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            stateManager.ClearSplitCursorPosition();
+            // lost hover cursor and time-tag cursor
+            stateManager.ClearHoverCursorPosition();
             base.OnHoverLost(e);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagIndexUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagIndexUtils.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Game.Rulesets.Karaoke.Utils
+{
+    public static class TimeTagIndexUtils
+    {
+        public static int ToLyricIndex(TimeTagIndex index)
+        {
+            if (index.State == TimeTagIndex.IndexState.Start)
+                return index.Index;
+
+            return index.Index + 1;
+        }
+
+        public static TimeTagIndex.IndexState ReverseState(TimeTagIndex.IndexState state)
+        {
+            if (state == TimeTagIndex.IndexState.Start)
+                return TimeTagIndex.IndexState.End;
+
+            return TimeTagIndex.IndexState.Start;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
             return new TimeTag(index, time);
 
-            int getTimeCalculationIndex(TimeTagIndex calculationIndex)
-                => calculationIndex.Index + (calculationIndex.State == TimeTagIndex.IndexState.End ? 1 : 0);
+            static int getTimeCalculationIndex(TimeTagIndex calculationIndex)
+                => TimeTagIndexUtils.ToLyricIndex(calculationIndex);
         }
 
         public static TimeTag GenerateCenterTimeTag(TimeTag startTimeTag, TimeTag endTimeTag, int index)


### PR DESCRIPTION
Implement remain issue in pull request #316 (issue #315).
Also planning in #323.

What's add in this pr:
- [x] Separate state into several file using partial.
- [x] Create hover cursor.
- [x] Deal with view mode.
- [x] Deal with edit mode.
- [x] Deal with record mode.
- [x] Deal with time tag edit mode.