### PR TITLE
Add shifting in utils.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -54,19 +54,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             testTimeTags(firstLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(firstTimeTags));
             testTimeTags(secondLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(secondTimeTags));
-
-            static void testTimeTags(IReadOnlyList<TimeTag> expect, IReadOnlyList<TimeTag> actually)
-            {
-                Assert.AreEqual(expect?.Count, actually?.Count);
-                if (expect == null || actually == null)
-                    return;
-
-                for (int i = 0; i < expect.Count; i++)
-                {
-                    Assert.AreEqual(expect[i].Index, actually[i].Index);
-                    Assert.AreEqual(expect[i].Time, actually[i].Time);
-                }
-            }
         }
 
         [TestCase("カラオケ", new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }, 2,
@@ -240,6 +227,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
         }
 
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, 2, new[] { "[0,start]:3000", "[1,start]:4000" })]
+        [TestCase(new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:" }, 0, 2, new[] { "[0,start]:", "[1,start]:" })]
+        [TestCase(new[] { "[0,start]:1000", "[2,start]:3000" }, 1, 2, new[] { "[0,start]:1000" })]
+        public void TestRemoveTextTimeTag(string[] timeTags, int position, int count, string[] actualTimeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
+            };
+            LyricUtils.RemoveText(lyric, position, count);
+            testTimeTags(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
+        }
+
         [TestCase("kake", 2, "rao", "karaoke")]
         [TestCase("オケ", 0, "カラ", "カラオケ")]
         [TestCase("オケ", -1, "カラ", "カラオケ")] // test start position not in the range, but it's valid.
@@ -279,6 +280,23 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             };
             LyricUtils.AddText(lyric, position, addedText);
             Assert.AreEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
+        }
+
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, "karoake", new[] { "[7,start]:1000", "[8,start]:2000", "[9,start]:3000", "[10,start]:4000" })]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 2, "karoake", new[] { "[0,start]:1000", "[1,start]:2000", "[9,start]:3000", "[10,start]:4000" })]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 4, "karoake", new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" })]
+        [TestCase(new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:" }, 0, "karoake", new[] { "[7,start]:", "[8,start]:", "[9,start]:", "[10,start]:" })]
+        [TestCase(new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:" }, 2, "karoake", new[] { "[0,start]:", "[1,start]:", "[9,start]:", "[10,start]:" })]
+        [TestCase(new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:" }, 4, "karoake", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:" })]
+        public void TestAddTextTimeTag(string[] timeTags, int position, string addedText, string[] actualTimeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
+            };
+            LyricUtils.AddText(lyric, position, addedText);
+            testTimeTags(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
         }
 
         #endregion
@@ -446,6 +464,23 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var combineLyric = LyricUtils.CombineLyric(lyric1, lyric2);
             Assert.AreEqual(combineLyric.Language, actualCultureInfo);
+        }
+
+        #endregion
+
+        #region helper
+
+        private void testTimeTags(IReadOnlyList<TimeTag> expect, IReadOnlyList<TimeTag> actually)
+        {
+            Assert.AreEqual(expect?.Count, actually?.Count);
+            if (expect == null || actually == null)
+                return;
+
+            for (int i = 0; i < expect.Count; i++)
+            {
+                Assert.AreEqual(expect[i].Index, actually[i].Index);
+                Assert.AreEqual(expect[i].Time, actually[i].Time);
+            }
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Internal;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
@@ -52,6 +53,23 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             var invalidTextTag = TextTagsUtils.FindInvalid(textTags, lyric, sorting);
             var invalidIndexes = invalidTextTag.Select(v => textTags.IndexOf(v)).ToArray();
             Assert.AreEqual(invalidIndexes, errorIndex);
+        }
+
+        [TestCase("[0,1]:ka", 1, "[1,2]:ka")]
+        [TestCase("[0,1]:", 1, "[1,2]:")]
+        [TestCase("[0,1]:ka", -1, "[-1,0]:ka")] // do not check out of range in here.
+        [TestCase("[1,0]:ka", 1, "[2,1]:ka")] // do not check order in here.
+        public void TestShifting(string textTag, int shifting, string actualTag)
+        {
+            // test ruby tag.
+            var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
+            var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
+            Assert.AreEqual(TextTagsUtils.Shifting(rubyTag, shifting), actualRubyTag);
+
+            // test romaji tag.
+            var romajiTag = TestCaseTagHelper.ParseRubyTag(textTag);
+            var actualRomaji = TestCaseTagHelper.ParseRubyTag(actualTag);
+            Assert.AreEqual(TextTagsUtils.Shifting(romajiTag, shifting), actualRomaji);
         }
 
         private RubyTag[] getValueByMethodName(string methodName)

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagIndexUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagIndexUtilsTest.cs
@@ -26,5 +26,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         {
             Assert.AreEqual(TimeTagIndexUtils.ReverseState(state), actualState);
         }
+
+        [TestCase(0, TimeTagIndex.IndexState.Start, 1, 1, TimeTagIndex.IndexState.Start)]
+        [TestCase(0, TimeTagIndex.IndexState.End, 1, 1, TimeTagIndex.IndexState.End)]
+        [TestCase(0, TimeTagIndex.IndexState.Start, -1, -1, TimeTagIndex.IndexState.Start)]
+        [TestCase(0, TimeTagIndex.IndexState.End, -1, -1, TimeTagIndex.IndexState.End)]
+        public void TestShiftingTimeTagIndex(int index, TimeTagIndex.IndexState state, int shifting, int actualIndex, TimeTagIndex.IndexState actualState)
+        {
+            var timeTagIndex = new TimeTagIndex(index, state);
+            var actualTimeTagIndex = new TimeTagIndex(actualIndex, actualState);
+            Assert.AreEqual(TimeTagIndexUtils.ShiftingTimeTagIndex(timeTagIndex, shifting), actualTimeTagIndex);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -123,6 +123,45 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(getSortedTime(dictionary), results);
         }
 
+        [TestCase(nameof(ValidTimeTagWithSorted), 1100)]
+        [TestCase(nameof(ValidTimeTagWithUnsorted), 1100)]
+        [TestCase(nameof(ValidTimeTagWithUnsortedAndDuplicatedWithNoValue), 1100)]
+        public void TestGetStartTime(string testCase, double? actualStartTime)
+        {
+            var timeTags = getValueByMethodName(testCase);
+
+            var startTime = TimeTagsUtils.GetStartTime(timeTags);
+            Assert.AreEqual(startTime, actualStartTime);
+        }
+
+        [TestCase(nameof(ValidTimeTagWithSorted), 3000)]
+        [TestCase(nameof(ValidTimeTagWithUnsorted), 3000)]
+        [TestCase(nameof(ValidTimeTagWithUnsortedAndDuplicatedWithNoValue), 2000)]
+        public void TestGetEndTime(string testCase, double? actualEndTime)
+        {
+            var timeTags = getValueByMethodName(testCase);
+
+            var endTime = TimeTagsUtils.GetEndTime(timeTags);
+            Assert.AreEqual(endTime, actualEndTime);
+        }
+
+        [TestCase("[1,start]:1000", 2, "[3,start]:1000")]
+        [TestCase("[1,end]:1000", 2, "[3,end]:1000")]
+        [TestCase("[1,start]:", 2, "[3,start]:")]
+        [TestCase("[1,end]:", 2, "[3,end]:")]
+        [TestCase("[1,start]:1000", -2, "[-1,start]:1000")]
+        [TestCase("[1,end]:1000", -2, "[-1,end]:1000")]
+        public void TestShiftingTimeTag(string shiftingTag, int shifting, string actualTag)
+        {
+            var timeTag = TestCaseTagHelper.ParseTimeTag(shiftingTag);
+
+            var shiftingTimeTag = TimeTagsUtils.ShiftingTimeTag(timeTag, shifting);
+            var actualTimeTag = TestCaseTagHelper.ParseTimeTag(actualTag);
+
+            Assert.AreEqual(shiftingTimeTag.Index, actualTimeTag.Index);
+            Assert.AreEqual(shiftingTimeTag.Time, actualTimeTag.Time);
+        }
+
         private double[] getSortedTime(TimeTag[] timeTags)
             => timeTags.Where(x => x.Time != null).Select(x => x.Time ?? 0)
                        .OrderBy(x => x).ToArray();

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagsUtils.cs
@@ -67,6 +67,16 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             return Sort(invalidList.Distinct().ToArray());
         }
 
+        public static T Shifting<T>(T textTag, int shifting) where T : ITextTag, new()
+        {
+            return new T
+            {
+                StartIndex = textTag.StartIndex + shifting,
+                EndIndex = textTag.EndIndex + shifting,
+                Text = textTag.Text
+            };
+        }
+
         public enum Sorting
         {
             /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagIndexUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagIndexUtils.cs
@@ -22,5 +22,10 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
             return TimeTagIndex.IndexState.Start;
         }
+
+        public static TimeTagIndex ShiftingTimeTagIndex(TimeTagIndex originTimeTagIndex, int shifting)
+        {
+            return new TimeTagIndex(originTimeTagIndex.Index + shifting, originTimeTagIndex.State);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -273,6 +273,19 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         {
             return ToDictionary(timeTags).LastOrDefault().Value;
         }
+
+        /// <summary>
+        /// Shifting time-tag.
+        /// </summary>
+        /// <param name="timeTag"></param>
+        /// <param name="shifting"></param>
+        /// <returns></returns>
+        public static TimeTag ShiftingTimeTag(TimeTag timeTag, int shifting)
+        {
+            var timeTagIndex = TimeTagIndexUtils.ShiftingTimeTagIndex(timeTag.Index, shifting);
+            var time = timeTag.Time;
+            return new TimeTag(timeTagIndex, time);
+        }
     }
 
     public enum GroupCheck


### PR DESCRIPTION
What's add in this PR : 
- Add `TimeTagIndex` shifting in utility.
- Add `TimeTag` shifting in utility.
- Add `TextTag`(ruby and romaji tag) shifting in utility.
- Add missing time-tag process while add or delete text in lyric utility.

Also has test case in those utils.