### PR TITLE
Fix tag and cursor position if contains romaji.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Lyrics/LyricControl.cs
@@ -66,6 +66,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Lyrics
                 }
             };
 
+            drawableLyric.RomajiTagsBindable.BindValueChanged(e =>
+            {
+                var displayRomaji = e?.NewValue?.Any() ?? false;
+                var marginWidth = displayRomaji ? 30 : 15;
+                timeTagContainer.Margin = new MarginPadding { Bottom = marginWidth };
+                cursorContainer.Margin = new MarginPadding { Bottom = marginWidth };
+            }, true);
+
             drawableLyric.TimeTagsBindable.BindValueChanged(e =>
             {
                 ScheduleAfterChildren(UpdateTimeTags);

--- a/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
+++ b/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
@@ -272,6 +272,7 @@
       "name": "Lyric editor's layout",
       "alignment": 9,
       "lyrics_interval": 5,
+      "romaji_margin": 8,
     }
   ]
  }


### PR DESCRIPTION
Fix issue #346 

![image](https://user-images.githubusercontent.com/9100368/103151150-de11d100-47be-11eb-8d0a-2bb1f32609c8.png)
And how it looks like after fixed.
Should also not apply ruby and romaji margin if has no text.