### PR TITLE
Implement editor menu bar

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
@@ -2,10 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Menu;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Tests.Visual;
@@ -15,8 +16,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
     [TestFixture]
     public class TestSceneEditorMenuBar : OsuTestScene
     {
-        public TestSceneEditorMenuBar()
+        [BackgroundDependencyLoader]
+        private void load()
         {
+            var config = new KaraokeRulesetEditConfigManager();
             Add(new Container
             {
                 Anchor = Anchor.TopCentre,
@@ -46,9 +49,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                             {
                                 new EditModeMenu(),
                                 new EditorMenuItemSpacer(),
-                                new LyricEditorEditModeMenu(),
-                                new LyricEditorLeftSideModeMenu(),
-                                new LyricEditorTextSizeMenu(),
+                                new LyricEditorEditModeMenu(config, "Lyric editor mode"),
+                                new LyricEditorLeftSideModeMenu(config, "Lyric editor mode"),
+                                new LyricEditorTextSizeMenu(config, "Text size"),
                             }
                         },
                         new MenuItem("Tools")
@@ -66,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                             Items = new MenuItem[]
                             {
                                 new EditorMenuItem("Lyric editor"),
-                                new GeneratorConfigMenu(),
+                                new GeneratorConfigMenu(config, "Generator"),
                             }
                         }
                     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                             Items = new MenuItem[]
                             {
                                 new EditorMenuItem("Lyric editor"),
-                                new GeneratorConfigMenu(config, "Generator"),
+                                new GeneratorConfigMenu("Generator"),
                             }
                         }
                     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Menu;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Tests.Visual;
 
@@ -32,61 +33,42 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                         {
                             Items = new[]
                             {
-                                new EditorMenuItem("Clear All Notes"),
-                                new EditorMenuItem("Open Difficulty..."),
-                                new EditorMenuItem("Save"),
-                                new EditorMenuItem("Create a new Difficulty..."),
+                                new EditorMenuItem("Import from text"),
+                                new EditorMenuItem("Import from .lrc file"),
                                 new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Revert to Saved"),
-                                new EditorMenuItem("Revert to Saved (Full)"),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Test Beatmap"),
-                                new EditorMenuItem("Open AiMod"),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Upload Beatmap..."),
-                                new EditorMenuItem("Export Package"),
-                                new EditorMenuItem("Export Map Package"),
-                                new EditorMenuItem("Import from..."),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Open Song Folder"),
-                                new EditorMenuItem("Open .osu in Notepad"),
-                                new EditorMenuItem("Open .osb in Notepad"),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Exit"),
+                                new EditorMenuItem("Export to .lrc"),
+                                new EditorMenuItem("Export to text"),
                             }
                         },
-                        new MenuItem("Timing")
+                        new MenuItem("View")
                         {
-                            Items = new[]
+                            Items = new MenuItem[]
                             {
-                                new EditorMenuItem("Time Signature"),
-                                new EditorMenuItem("Metronome Clicks"),
+                                new EditModeMenu(),
                                 new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Add Timing Section"),
-                                new EditorMenuItem("Add Inheriting Section"),
-                                new EditorMenuItem("Reset Current Section"),
-                                new EditorMenuItem("Delete Timing Section"),
-                                new EditorMenuItem("Resnap Current Section"),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Timing Setup"),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Resnap All Notes", MenuItemType.Destructive),
-                                new EditorMenuItem("Move all notes in time...", MenuItemType.Destructive),
-                                new EditorMenuItem("Recalculate Slider Lengths", MenuItemType.Destructive),
-                                new EditorMenuItem("Delete All Timing Sections", MenuItemType.Destructive),
-                                new EditorMenuItemSpacer(),
-                                new EditorMenuItem("Set Current Position as Preview Point"),
+                                new LyricEditorEditModeMenu(),
+                                new LyricEditorLeftSideModeMenu(),
+                                new LyricEditorTextSizeMenu(),
                             }
                         },
-                        new MenuItem("Lyric")
+                        new MenuItem("Tools")
                         {
-                            Items = new[]
+                            Items = new MenuItem[]
                             {
-                                new EditorMenuItem("Item 1"),
-                                new EditorMenuItem("Item 2"),
-                                new EditorMenuItem("Item 3"),
+                                new EditorMenuItem("Singer manager"),
+                                new EditorMenuItem("Translate manager"),
+                                new EditorMenuItem("Layout manager"),
+                                new EditorMenuItem("Style manager"),
                             }
                         },
+                        new MenuItem("Options")
+                        {
+                            Items = new MenuItem[]
+                            {
+                                new EditorMenuItem("Lyric editor"),
+                                new GeneratorConfigMenu(),
+                            }
+                        }
                     }
                 }
             });

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneEditorMenuBar.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Screens.Edit.Components.Menus;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit
+{
+    [TestFixture]
+    public class TestSceneEditorMenuBar : OsuTestScene
+    {
+        public TestSceneEditorMenuBar()
+        {
+            Add(new Container
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = 50,
+                Y = 50,
+                Child = new EditorMenuBar
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Items = new[]
+                    {
+                        new MenuItem("File")
+                        {
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Clear All Notes"),
+                                new EditorMenuItem("Open Difficulty..."),
+                                new EditorMenuItem("Save"),
+                                new EditorMenuItem("Create a new Difficulty..."),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Revert to Saved"),
+                                new EditorMenuItem("Revert to Saved (Full)"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Test Beatmap"),
+                                new EditorMenuItem("Open AiMod"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Upload Beatmap..."),
+                                new EditorMenuItem("Export Package"),
+                                new EditorMenuItem("Export Map Package"),
+                                new EditorMenuItem("Import from..."),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Open Song Folder"),
+                                new EditorMenuItem("Open .osu in Notepad"),
+                                new EditorMenuItem("Open .osb in Notepad"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Exit"),
+                            }
+                        },
+                        new MenuItem("Timing")
+                        {
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Time Signature"),
+                                new EditorMenuItem("Metronome Clicks"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Add Timing Section"),
+                                new EditorMenuItem("Add Inheriting Section"),
+                                new EditorMenuItem("Reset Current Section"),
+                                new EditorMenuItem("Delete Timing Section"),
+                                new EditorMenuItem("Resnap Current Section"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Timing Setup"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Resnap All Notes", MenuItemType.Destructive),
+                                new EditorMenuItem("Move all notes in time...", MenuItemType.Destructive),
+                                new EditorMenuItem("Recalculate Slider Lengths", MenuItemType.Destructive),
+                                new EditorMenuItem("Delete All Timing Sections", MenuItemType.Destructive),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Set Current Position as Preview Point"),
+                            }
+                        },
+                        new MenuItem("Lyric")
+                        {
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Item 1"),
+                                new EditorMenuItem("Item 2"),
+                                new EditorMenuItem("Item 3"),
+                            }
+                        },
+                    }
+                }
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 
@@ -11,22 +13,35 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
         public EditModeMenu()
             : base("Edit mode")
         {
-            Items = new[]
-            {
-                createMenuItem("Lyric mode", EditMode.LyricEditor),
-                createMenuItem("Note", EditMode.Note),
-            };
+            Items = createMenuItems();
         }
 
-        private ToggleMenuItem createMenuItem(string menuName, EditMode mode)
+        private ToggleMenuItem[] createMenuItems()
         {
-            var item = new ToggleMenuItem($"{menuName}", MenuItemType.Standard, _ => updateMode(mode));
-            return item;
+            var enums = (EditMode[])Enum.GetValues(typeof(EditMode));
+            return enums.Select(e =>
+            {
+                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
+                return item;
+            }).ToArray();
+        }
+
+        private string getName(EditMode mode)
+        {
+            switch (mode)
+            {
+                case EditMode.LyricEditor:
+                    return "Lyric editor";
+                case EditMode.Note:
+                    return "Note editor";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
         }
 
         private void updateMode(EditMode mode)
         {
-
+            // todo : implementation
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class EditModeMenu : MenuItem
+    {
+        public EditModeMenu()
+            : base("Edit mode")
+        {
+            Items = new[]
+            {
+                createMenuItem("Lyric mode", EditMode.LyricEditor),
+                createMenuItem("Note", EditMode.Note),
+            };
+        }
+
+        private ToggleMenuItem createMenuItem(string menuName, EditMode mode)
+        {
+            var item = new ToggleMenuItem($"{menuName}", MenuItemType.Standard, _ => updateMode(mode));
+            return item;
+        }
+
+        private void updateMode(EditMode mode)
+        {
+
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/GeneratorConfigMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/GeneratorConfigMenu.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class GeneratorConfigMenu : MenuItem
+    {
+        public GeneratorConfigMenu(string text)
+            : base(text)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -1,9 +1,54 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class LyricEditorEditModeMenu
+    public class LyricEditorEditModeMenu : MenuItem
     {
+        public LyricEditorEditModeMenu()
+           : base("Lyric editor mode")
+        {
+            Items = createMenuItems();
+        }
+
+        private ToggleMenuItem[] createMenuItems()
+        {
+            var enums = (Mode[])Enum.GetValues(typeof(Mode));
+            return enums.Select(e =>
+            {
+                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
+                return item;
+            }).ToArray();
+        }
+
+        private string getName(Mode mode)
+        {
+            switch (mode)
+            {
+                case Mode.ViewMode:
+                    return "View";
+                case Mode.EditMode:
+                    return "Edit";
+                case Mode.TypingMode:
+                    return "Typing";
+                case Mode.RecordMode:
+                    return "Record";
+                case Mode.TimeTagEditMode:
+                    return "Edit time tag";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+        }
+
+        private void updateMode(Mode mode)
+        {
+            // todo : implementation
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -3,16 +3,18 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorEditModeMenu : MenuItem
     {
-        public LyricEditorEditModeMenu()
-           : base("Lyric editor mode")
+        public LyricEditorEditModeMenu(KaraokeRulesetEditConfigManager config, string text)
+           : base(text)
         {
             Items = createMenuItems();
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class LyricEditorEditModeMenu
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
@@ -13,10 +14,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorEditModeMenu : MenuItem
     {
+        private readonly Bindable<Mode> bindableLyricEditorMode = new Bindable<Mode>();
+
         public LyricEditorEditModeMenu(KaraokeRulesetEditConfigManager config, string text)
            : base(text)
         {
             Items = createMenuItems();
+
+            bindableLyricEditorMode.BindTo(config.GetBindable<Mode>(KaraokeRulesetEditSetting.LyricEditorMode));
+            bindableLyricEditorMode.BindValueChanged(e =>
+            {
+                var newSelection = e.NewValue;
+                Items.OfType<ToggleMenuItem>().ForEach(x => {
+                    var match = x.Text.Value == getName(newSelection);
+                    x.State.Value = match;
+                });
+            }, true);
         }
 
         private ToggleMenuItem[] createMenuItems()
@@ -50,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 
         private void updateMode(Mode mode)
         {
-            // todo : implementation
+            bindableLyricEditorMode.Value = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class LyricEditorLeftSideModeMenu
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
@@ -1,9 +1,54 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class LyricEditorLeftSideModeMenu
+    public class LyricEditorLeftSideModeMenu : MenuItem
     {
+        public LyricEditorLeftSideModeMenu()
+           : base("Lyric editor mode")
+        {
+            Items = createMenuItems();
+        }
+
+        private ToggleMenuItem[] createMenuItems()
+        {
+            var enums = (LyricFastEditMode[])Enum.GetValues(typeof(LyricFastEditMode));
+            return enums.Select(e =>
+            {
+                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
+                return item;
+            }).ToArray();
+        }
+
+        private string getName(LyricFastEditMode mode)
+        {
+            switch (mode)
+            {
+                case LyricFastEditMode.None:
+                    return "None";
+                case LyricFastEditMode.Layout:
+                    return "Layout selection";
+                case LyricFastEditMode.Singer:
+                    return "Singer selection";
+                case LyricFastEditMode.Language:
+                    return "Language selection";
+                case LyricFastEditMode.TimeTag:
+                    return "Time tag display";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+        }
+
+        private void updateMode(LyricFastEditMode mode)
+        {
+            // todo : implementation
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
@@ -5,14 +5,15 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorLeftSideModeMenu : MenuItem
     {
-        public LyricEditorLeftSideModeMenu()
-           : base("Lyric editor mode")
+        public LyricEditorLeftSideModeMenu(KaraokeRulesetEditConfigManager config, string text)
+           : base(text)
         {
             Items = createMenuItems();
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
@@ -12,10 +14,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorLeftSideModeMenu : MenuItem
     {
+        private readonly Bindable<LyricFastEditMode> bindableLyricEditorFastEditMode = new Bindable<LyricFastEditMode>();
+
         public LyricEditorLeftSideModeMenu(KaraokeRulesetEditConfigManager config, string text)
            : base(text)
         {
             Items = createMenuItems();
+
+            bindableLyricEditorFastEditMode.BindTo(config.GetBindable<LyricFastEditMode>(KaraokeRulesetEditSetting.LyricEditorFastEditMode));
+            bindableLyricEditorFastEditMode.BindValueChanged(e =>
+            {
+                var newSelection = e.NewValue;
+                Items.OfType<ToggleMenuItem>().ForEach(x => {
+                    var match = x.Text.Value == getName(newSelection);
+                    x.State.Value = match;
+                });
+            }, true);
         }
 
         private ToggleMenuItem[] createMenuItems()
@@ -49,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 
         private void updateMode(LyricFastEditMode mode)
         {
-            // todo : implementation
+            bindableLyricEditorFastEditMode.Value = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
@@ -4,13 +4,14 @@
 using System.Linq;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorTextSizeMenu : MenuItem
     {
-        public LyricEditorTextSizeMenu()
-           : base("Text size")
+        public LyricEditorTextSizeMenu(KaraokeRulesetEditConfigManager config, string text)
+           : base(text)
         {
             Items = createMenuItems();
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
@@ -10,10 +12,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
     public class LyricEditorTextSizeMenu : MenuItem
     {
+        private readonly Bindable<int> bindableFontSize = new Bindable<int>();
+
         public LyricEditorTextSizeMenu(KaraokeRulesetEditConfigManager config, string text)
            : base(text)
         {
             Items = createMenuItems();
+
+            bindableFontSize.BindTo(config.GetBindable<int>(KaraokeRulesetEditSetting.LyricEditorFontSize));
+            bindableFontSize.BindValueChanged(e =>
+            {
+                var newSelection = e.NewValue;
+                Items.OfType<ToggleMenuItem>().ForEach(x => {
+                    var match = x.Text.Value == getName(newSelection);
+                    x.State.Value = match;
+                });
+            }, true);
         }
 
         private ToggleMenuItem[] createMenuItems()
@@ -31,9 +45,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             return $"{size} px";
         }
 
-        private void updateMode(float size)
+        private void updateMode(int size)
         {
-            // todo : implementation
+            bindableFontSize.Value = size;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class LyricEditorTextSizeMenu
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorTextSizeMenu.cs
@@ -1,9 +1,38 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class LyricEditorTextSizeMenu
+    public class LyricEditorTextSizeMenu : MenuItem
     {
+        public LyricEditorTextSizeMenu()
+           : base("Text size")
+        {
+            Items = createMenuItems();
+        }
+
+        private ToggleMenuItem[] createMenuItems()
+        {
+            var enums = new[] { 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 48 };
+            return enums.Select(e =>
+            {
+                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
+                return item;
+            }).ToArray();
+        }
+
+        private string getName(float size)
+        {
+            return $"{size} px";
+        }
+
+        private void updateMode(float size)
+        {
+            // todo : implementation
+        }
     }
 }


### PR DESCRIPTION
Before waiting for lazer to enable customize ruleset to access menu bar, it's a choice to implement some basic feature.
And this is the implementation of #365 
.
What's add in this PR:
- [x] Add all selections listed in #365 
- [x] Enable to read/write settings from `KaraokeRulesetEditConfigManager`.