### PR TITLE
Cursor skip mode in recording time-tag

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneLyricEditor.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
+            OsuDropdown<RecordingMovingCursorMode> recordingModeDropdown = null;
+
             Child = new GridContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -107,6 +109,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                                     x.Current.BindValueChanged(mode =>
                                     {
                                         editor.Mode = mode.NewValue;
+
+                                        if(editor.Mode == Mode.RecordMode)
+                                        {
+                                            recordingModeDropdown.Show();
+                                        }
+                                        else
+                                        {
+                                            recordingModeDropdown.Hide();
+                                        }
                                     });
                                 }),
                                 new OsuDropdown<LyricFastEditMode>
@@ -118,6 +129,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                                     x.Current.BindValueChanged(fastEditMode =>
                                     {
                                         editor.LyricFastEditMode = fastEditMode.NewValue;
+                                    });
+                                }),
+                                recordingModeDropdown = new OsuDropdown<RecordingMovingCursorMode>
+                                {
+                                    Width = 150,
+                                    Items = (RecordingMovingCursorMode[])Enum.GetValues(typeof(RecordingMovingCursorMode))
+                                }.With(x =>
+                                {
+                                    x.Current.BindValueChanged(recordingMovingCursorMode =>
+                                    {
+                                        editor.RecordingMovingCursorMode = recordingMovingCursorMode.NewValue;
                                     });
                                 }),
                                 new OsuButton
@@ -146,6 +168,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                     }
                 }
             };
+
+            recordingModeDropdown.Hide();
         });
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Extensions/TestEnumerableExtensions.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Extensions/TestEnumerableExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Extensions;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Extensions
+{
+    public class TestEnumerableExtensions
+    {
+        [TestCase(new[] { 1, 2, 3, 4, 5, 6}, 1, 3, 3)]
+        [TestCase(new[] { 1, 3, 2, 4, 6, 5 }, 1, 6, 6)]
+        [TestCase(new[] { 1, 2, 3, 4, 5, 6 }, 3, 1, 0)]
+        [TestCase(new[] { 1, 2, 3, 4, 5, 6 }, 1, 7, 0)]
+        public void TestGetNextMatch(int[] values, int startFrom, int matchCondition, int actual)
+        {
+            Assert.AreEqual(values.GetNextMatch(startFrom, x => x == matchCondition), actual);
+        }
+
+        [TestCase(new[] { 1, 2, 3, 4, 5, 6}, 6, 3, 3)]
+        [TestCase(new[] { 1, 3, 2, 4, 6, 5 }, 5, 3, 3)]
+        [TestCase(new[] { 1, 2, 3, 4, 5, 6 }, 3, 6, 0)]
+        [TestCase(new[] { 2, 3, 4, 5, 6 }, 6, 1, 0)]
+        public void TestGetPreviousMatch(int[] values, int startFrom, int matchCondition, int actual)
+        {
+            Assert.AreEqual(values.GetPreviousMatch(startFrom, x => x == matchCondition), actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             Set(KaraokeRulesetEditSetting.LyricEditorFontSize, 28);
             Set(KaraokeRulesetEditSetting.LyricEditorMode, Mode.ViewMode);
             Set(KaraokeRulesetEditSetting.LyricEditorFastEditMode, LyricFastEditMode.None);
+            Set(KaraokeRulesetEditSetting.RecordingMovingCursorMode, RecordingMovingCursorMode.None);
 
             Set(KaraokeRulesetEditSetting.DisplayRuby, true);
             Set(KaraokeRulesetEditSetting.DisplayRomaji, true);
@@ -36,6 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         LyricEditorFontSize,
         LyricEditorMode,
         LyricEditorFastEditMode,
+        RecordingMovingCursorMode,
 
         // Note editor
         DisplayRuby,

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EditModeMenu.cs
@@ -2,49 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
-using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class EditModeMenu : MenuItem
+    public class EditModeMenu : EnumMenuItem<EditMode>
     {
-        private readonly Bindable<EditMode> bindableEditMode = new Bindable<EditMode>();
+        protected override KaraokeRulesetEditSetting Setting => KaraokeRulesetEditSetting.EditMode;
 
         public EditModeMenu(KaraokeRulesetEditConfigManager config, string text)
-            : base(text)
+            : base(config, text)
         {
-            Items = createMenuItems();
-
-            config.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
-            bindableEditMode.BindValueChanged(e =>
-            {
-                var newSelection = e.NewValue;
-                Items.OfType<ToggleMenuItem>().ForEach(x =>
-                {
-                    var match = x.Text.Value == getName(newSelection);
-                    x.State.Value = match;
-                });
-            }, true);
         }
 
-        private ToggleMenuItem[] createMenuItems()
+        protected override string GetName(EditMode selection)
         {
-            var enums = (EditMode[])Enum.GetValues(typeof(EditMode));
-            return enums.Select(e =>
-            {
-                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
-                return item;
-            }).ToArray();
-        }
-
-        private string getName(EditMode mode)
-        {
-            switch (mode)
+            switch (selection)
             {
                 case EditMode.LyricEditor:
                     return "Lyric editor";
@@ -53,13 +26,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                     return "Note editor";
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(mode));
+                    throw new ArgumentOutOfRangeException(nameof(selection));
             }
-        }
-
-        private void updateMode(EditMode mode)
-        {
-            bindableEditMode.Value = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EnumMenuItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/EnumMenuItem.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public abstract class EnumMenuItem<T> : MenuItem
+    {
+        private readonly Bindable<T> bindableEnum = new Bindable<T>();
+
+        protected abstract KaraokeRulesetEditSetting Setting { get; }
+
+        public EnumMenuItem(KaraokeRulesetEditConfigManager config, string text)
+            : base(text)
+        {
+            Items = createMenuItems();
+
+            config.BindWith(Setting, bindableEnum);
+            bindableEnum.BindValueChanged(e =>
+            {
+                var newSelection = e.NewValue;
+                Items.OfType<ToggleMenuItem>().ForEach(x =>
+                {
+                    var match = x.Text.Value == GetName(newSelection);
+                    x.State.Value = match;
+                });
+            }, true);
+        }
+
+        private ToggleMenuItem[] createMenuItems()
+        {
+            var enums = (T[])Enum.GetValues(typeof(T));
+            return enums.Select(e =>
+            {
+                var item = new ToggleMenuItem(GetName(e), MenuItemType.Standard, _ => UpdateSelection(e));
+                return item;
+            }).ToArray();
+        }
+
+        protected abstract string GetName(T selection);
+
+        protected virtual void UpdateSelection(T selection)
+        {
+            bindableEnum.Value = selection;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -5,47 +5,24 @@ using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class LyricEditorEditModeMenu : MenuItem
+    public class LyricEditorEditModeMenu : EnumMenuItem<Mode>
     {
-        private readonly Bindable<Mode> bindableLyricEditorMode = new Bindable<Mode>();
+        protected override KaraokeRulesetEditSetting Setting => KaraokeRulesetEditSetting.LyricEditorMode;
 
         public LyricEditorEditModeMenu(KaraokeRulesetEditConfigManager config, string text)
-            : base(text)
+            : base(config, text)
         {
-            Items = createMenuItems();
-
-            config.BindWith(KaraokeRulesetEditSetting.LyricEditorMode, bindableLyricEditorMode);
-            bindableLyricEditorMode.BindValueChanged(e =>
-            {
-                var newSelection = e.NewValue;
-                Items.OfType<ToggleMenuItem>().ForEach(x =>
-                {
-                    var match = x.Text.Value == getName(newSelection);
-                    x.State.Value = match;
-                });
-            }, true);
         }
 
-        private ToggleMenuItem[] createMenuItems()
+        protected override string GetName(Mode selection)
         {
-            var enums = (Mode[])Enum.GetValues(typeof(Mode));
-            return enums.Select(e =>
-            {
-                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
-                return item;
-            }).ToArray();
-        }
-
-        private string getName(Mode mode)
-        {
-            switch (mode)
+            switch (selection)
             {
                 case Mode.ViewMode:
                     return "View";
@@ -63,13 +40,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                     return "Edit time tag";
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(mode));
+                    throw new ArgumentOutOfRangeException(nameof(selection));
             }
-        }
-
-        private void updateMode(Mode mode)
-        {
-            bindableLyricEditorMode.Value = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorLeftSideModeMenu.cs
@@ -12,40 +12,18 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 {
-    public class LyricEditorLeftSideModeMenu : MenuItem
+    public class LyricEditorLeftSideModeMenu : EnumMenuItem<LyricFastEditMode>
     {
-        private readonly Bindable<LyricFastEditMode> bindableLyricEditorFastEditMode = new Bindable<LyricFastEditMode>();
+        protected override KaraokeRulesetEditSetting Setting => KaraokeRulesetEditSetting.LyricEditorFastEditMode;
 
         public LyricEditorLeftSideModeMenu(KaraokeRulesetEditConfigManager config, string text)
-            : base(text)
+            : base(config, text)
         {
-            Items = createMenuItems();
-
-            config.BindWith(KaraokeRulesetEditSetting.LyricEditorFastEditMode, bindableLyricEditorFastEditMode);
-            bindableLyricEditorFastEditMode.BindValueChanged(e =>
-            {
-                var newSelection = e.NewValue;
-                Items.OfType<ToggleMenuItem>().ForEach(x =>
-                {
-                    var match = x.Text.Value == getName(newSelection);
-                    x.State.Value = match;
-                });
-            }, true);
         }
 
-        private ToggleMenuItem[] createMenuItems()
+        protected override string GetName(LyricFastEditMode selection)
         {
-            var enums = (LyricFastEditMode[])Enum.GetValues(typeof(LyricFastEditMode));
-            return enums.Select(e =>
-            {
-                var item = new ToggleMenuItem(getName(e), MenuItemType.Standard, _ => updateMode(e));
-                return item;
-            }).ToArray();
-        }
-
-        private string getName(LyricFastEditMode mode)
-        {
-            switch (mode)
+            switch (selection)
             {
                 case LyricFastEditMode.None:
                     return "None";
@@ -66,13 +44,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                     return "Lyric order";
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(mode));
+                    throw new ArgumentOutOfRangeException(nameof(selection));
             }
-        }
-
-        private void updateMode(LyricFastEditMode mode)
-        {
-            bindableLyricEditorFastEditMode.Value = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorMovingCursorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorMovingCursorModeMenu.cs
@@ -23,10 +23,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                 case RecordingMovingCursorMode.None:
                     return "None";
 
-                case RecordingMovingCursorMode.SkipStartTag:
+                case RecordingMovingCursorMode.OnlyStartTag:
                     return "Skip start tag";
 
-                case RecordingMovingCursorMode.SkipEndTag:
+                case RecordingMovingCursorMode.OnlyEndTag:
                     return "Skip end tag";
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorMovingCursorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorMovingCursorModeMenu.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
+{
+    public class LyricEditorMovingCursorModeMenu : EnumMenuItem<RecordingMovingCursorMode>
+    {
+        protected override KaraokeRulesetEditSetting Setting => KaraokeRulesetEditSetting.RecordingMovingCursorMode;
+
+        public LyricEditorMovingCursorModeMenu(KaraokeRulesetEditConfigManager config, string text)
+            : base(config, text)
+        {
+        }
+
+        protected override string GetName(RecordingMovingCursorMode selection)
+        {
+            switch (selection)
+            {
+                case RecordingMovingCursorMode.None:
+                    return "None";
+
+                case RecordingMovingCursorMode.SkipStartTag:
+                    return "Skip start tag";
+
+                case RecordingMovingCursorMode.SkipEndTag:
+                    return "Skip end tag";
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(selection));
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -146,7 +146,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
                             new EditorMenuItemSpacer(),
                             new LyricEditorEditModeMenu(editConfigManager, "Lyric editor mode"),
                             new LyricEditorLeftSideModeMenu(editConfigManager, "Lyric editor left side mode"),
+                            new LyricEditorMovingCursorModeMenu(editConfigManager, "Record cursor moving mode"),
                             new LyricEditorTextSizeMenu(editConfigManager, "Text size"),
+                            new EditorMenuItemSpacer(),
                             new NoteEditorPreviewMenu(editConfigManager, "Note editor"),
                         }
                     },

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeLyricEditor.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly Bindable<int> bindableLyricEditorFontSize = new Bindable<int>();
         private readonly Bindable<Mode> bindableLyricEditorMode = new Bindable<Mode>();
         private readonly Bindable<LyricFastEditMode> bindableLyricEditorFastEditMode = new Bindable<LyricFastEditMode>();
+        private readonly Bindable<RecordingMovingCursorMode> bindableRecordingMovingCursorMode = new Bindable<RecordingMovingCursorMode>();
 
         private readonly LyricEditor lyricEditor;
 
@@ -55,6 +56,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             {
                 lyricEditor.FontSize = e.NewValue;
             });
+            bindableRecordingMovingCursorMode.BindValueChanged(e =>
+            {
+                lyricEditor.RecordingMovingCursorMode = e.NewValue;
+            });
         }
 
         [BackgroundDependencyLoader]
@@ -65,6 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             editConfigManager.BindWith(KaraokeRulesetEditSetting.LyricEditorFontSize, bindableLyricEditorFontSize);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.LyricEditorMode, bindableLyricEditorMode);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.LyricEditorFastEditMode, bindableLyricEditorFastEditMode);
+            editConfigManager.BindWith(KaraokeRulesetEditSetting.RecordingMovingCursorMode, bindableRecordingMovingCursorMode);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             beatmap.HitObjectAdded += addHitObject;
             beatmap.HitObjectRemoved += removeHitObject;
 
-            stateManager.MoveCursor(CursorAction.First);
+            stateManager.MoveCursor(MovingCursorAction.First);
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     // delete single character.
                     var deletedSuccess = lyricManager.DeleteLyricText(position);
                     if (deletedSuccess)
-                        stateManager.MoveCursor(CursorAction.MoveLeft);
+                        stateManager.MoveCursor(MovingCursorAction.Left);
                     return deletedSuccess;
 
                 default:
@@ -140,22 +140,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             switch (action)
             {
                 case KaraokeEditAction.Up:
-                    return stateManager.MoveCursor(CursorAction.MoveUp);
+                    return stateManager.MoveCursor(MovingCursorAction.Up);
 
                 case KaraokeEditAction.Down:
-                    return stateManager.MoveCursor(CursorAction.MoveDown);
+                    return stateManager.MoveCursor(MovingCursorAction.Down);
 
                 case KaraokeEditAction.Left:
-                    return stateManager.MoveCursor(CursorAction.MoveLeft);
+                    return stateManager.MoveCursor(MovingCursorAction.Left);
 
                 case KaraokeEditAction.Right:
-                    return stateManager.MoveCursor(CursorAction.MoveRight);
+                    return stateManager.MoveCursor(MovingCursorAction.Right);
 
                 case KaraokeEditAction.First:
-                    return stateManager.MoveCursor(CursorAction.First);
+                    return stateManager.MoveCursor(MovingCursorAction.First);
 
                 case KaraokeEditAction.Last:
-                    return stateManager.MoveCursor(CursorAction.Last);
+                    return stateManager.MoveCursor(MovingCursorAction.Last);
 
                 default:
                     return false;
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case KaraokeEditAction.SetTime:
                     var setTimeSuccess = timeTagManager.SetTimeTagTime(currentTimeTag);
                     if (setTimeSuccess)
-                        stateManager.MoveCursor(CursorAction.MoveRight);
+                        stateManager.MoveCursor(MovingCursorAction.Next);
                     return setTimeSuccess;
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case KaraokeEditAction.SetTime:
                     var setTimeSuccess = timeTagManager.SetTimeTagTime(currentTimeTag);
                     if (setTimeSuccess)
-                        stateManager.MoveCursor(MovingCursorAction.Next);
+                        stateManager.MoveCursor(MovingCursorAction.Right);
                     return setTimeSuccess;
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -250,5 +250,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             get => stateManager.FastEditMode;
             set => stateManager.SetFastEditMode(value);
         }
+
+        public RecordingMovingCursorMode RecordingMovingCursorMode
+        {
+            get => stateManager.RecordingMovingCursorMode;
+            set => stateManager.SetRecordingMovingCursorMode(value);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -150,11 +150,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// <summary>
         /// Only move to next start tag.
         /// </summary>
-        SkipStartTag,
+        OnlyStartTag,
 
         /// <summary>
         /// Only move to next end tag.
         /// </summary>
-        SkipEndTag,
+        OnlyEndTag,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -139,4 +139,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// </summary>
         Order,
     }
+
+    public enum RecordingMovingCursorMode
+    {
+        /// <summary>
+        /// Move to any tag
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Only move to next start tag.
+        /// </summary>
+        SkipStartTag,
+
+        /// <summary>
+        /// Only move to next end tag.
+        /// </summary>
+        SkipEndTag,
+    }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return;
 
                 case Mode.RecordMode:
-                    MoveCursor(CursorAction.First);
+                    MoveCursor(MovingCursorAction.First);
                     return;
 
                 case Mode.TimeTagEditMode:
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             BindableFastEditMode.Value = fastEditMode;
         }
 
-        public bool MoveCursor(CursorAction action)
+        public bool MoveCursor(MovingCursorAction action)
         {
             switch (Mode)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_Cursor.cs
@@ -32,37 +32,38 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             BindableHoverCursorPosition.Value = new CursorPosition();
         }
 
-        private bool moveCursor(CursorAction action)
+        private bool moveCursor(MovingCursorAction action)
         {
             var currentPosition = BindableCursorPosition.Value;
-
-            CursorPosition position = new CursorPosition();
-
+            CursorPosition position;
             switch (action)
             {
-                case CursorAction.MoveUp:
+                case MovingCursorAction.Up:
                     position = getPreviousLyricCursorPosition(currentPosition);
                     break;
 
-                case CursorAction.MoveDown:
+                case MovingCursorAction.Down:
                     position = getNextLyricCursorPosition(currentPosition);
                     break;
 
-                case CursorAction.MoveLeft:
+                case MovingCursorAction.Left:
                     position = getPreviousCursorPosition(currentPosition);
                     break;
 
-                case CursorAction.MoveRight:
+                case MovingCursorAction.Right:
                     position = getNextCursorPosition(currentPosition);
                     break;
 
-                case CursorAction.First:
+                case MovingCursorAction.First:
                     position = getFirstCursorPosition();
                     break;
 
-                case CursorAction.Last:
+                case MovingCursorAction.Last:
                     position = getLastCursorPosition();
                     break;
+
+                default:
+                    throw new InvalidOperationException(nameof(action));
             }
 
             if (position.Lyric == null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -10,9 +10,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public partial class LyricEditorStateManager
     {
+        public Bindable<RecordingMovingCursorMode> BindableRecordingMovingCursorMode { get; } = new Bindable<RecordingMovingCursorMode>();
+
+        public RecordingMovingCursorMode RecordingMovingCursorMode => BindableRecordingMovingCursorMode.Value;
+
         public Bindable<TimeTag> BindableHoverRecordCursorPosition { get; } = new Bindable<TimeTag>();
 
         public Bindable<TimeTag> BindableRecordCursorPosition { get; } = new Bindable<TimeTag>();
+
+        public void SetRecordingMovingCursorMode(RecordingMovingCursorMode mode)
+        {
+            BindableRecordingMovingCursorMode.Value = mode;
+
+            // todo : might move cursor to valid position.
+        }
 
         public bool MoveRecordCursorToTargetPosition(TimeTag timeTag)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
@@ -102,25 +103,40 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private TimeTag getPreviousLyricTimeTag(TimeTag timeTag)
         {
             var currentLyric = timeTagInLyric(timeTag);
-            return Lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
+            return Lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && match(x));
         }
 
         private TimeTag getNextLyricTimeTag(TimeTag timeTag)
         {
             var currentLyric = timeTagInLyric(timeTag);
-            return Lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index);
+            return Lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && match(x));
         }
 
         private TimeTag getPreviousTimeTag(TimeTag timeTag)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetPrevious(timeTag);
+            return timeTags.GetPreviousMatch(timeTag, match);
         }
 
         private TimeTag getNextTimeTag(TimeTag timeTag)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetNext(timeTag);
+            return timeTags.GetNextMatch(timeTag, match);
+        }
+
+        private bool match(TimeTag timeTag)
+        {
+            switch (RecordingMovingCursorMode)
+            {
+                case RecordingMovingCursorMode.None:
+                    return true;
+                case RecordingMovingCursorMode.OnlyStartTag:
+                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.Start;
+                case RecordingMovingCursorMode.OnlyEndTag:
+                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.End;
+                default:
+                    throw new InvalidOperationException(nameof(RecordingMovingCursorMode));
+            }
         }
 
         private TimeTag getFirstTimeTag()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -48,37 +49,39 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             BindableHoverRecordCursorPosition.Value = null;
         }
 
-        private bool moveRecordCursor(CursorAction action)
+        private bool moveRecordCursor(MovingCursorAction action)
         {
             var currentTimeTag = BindableRecordCursorPosition.Value;
 
-            TimeTag nextTimeTag = null;
-
+            TimeTag nextTimeTag;
             switch (action)
             {
-                case CursorAction.MoveUp:
+                case MovingCursorAction.Up:
                     nextTimeTag = getPreviousLyricTimeTag(currentTimeTag);
                     break;
 
-                case CursorAction.MoveDown:
+                case MovingCursorAction.Down:
                     nextTimeTag = getNextLyricTimeTag(currentTimeTag);
                     break;
 
-                case CursorAction.MoveLeft:
+                case MovingCursorAction.Left:
                     nextTimeTag = getPreviousTimeTag(currentTimeTag);
                     break;
 
-                case CursorAction.MoveRight:
+                case MovingCursorAction.Right:
                     nextTimeTag = getNextTimeTag(currentTimeTag);
                     break;
 
-                case CursorAction.First:
+                case MovingCursorAction.First:
                     nextTimeTag = getFirstTimeTag();
                     break;
 
-                case CursorAction.Last:
+                case MovingCursorAction.Last:
                     nextTimeTag = getLastTimeTag();
                     break;
+
+                default:
+                    throw new InvalidOperationException(nameof(action));
             }
 
             if (nextTimeTag == null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorStateManager_RecordCursor.cs
@@ -50,6 +50,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             BindableHoverRecordCursorPosition.Value = null;
         }
 
+        public bool RecordingCursorMovable(TimeTag timeTag)
+        {
+            switch (RecordingMovingCursorMode)
+            {
+                case RecordingMovingCursorMode.None:
+                    return true;
+                case RecordingMovingCursorMode.OnlyStartTag:
+                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.Start;
+                case RecordingMovingCursorMode.OnlyEndTag:
+                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.End;
+                default:
+                    throw new InvalidOperationException(nameof(RecordingMovingCursorMode));
+            }
+        }
+
         private bool moveRecordCursor(MovingCursorAction action)
         {
             var currentTimeTag = BindableRecordCursorPosition.Value;
@@ -103,40 +118,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private TimeTag getPreviousLyricTimeTag(TimeTag timeTag)
         {
             var currentLyric = timeTagInLyric(timeTag);
-            return Lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && match(x));
+            return Lyrics.GetPrevious(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && RecordingCursorMovable(x));
         }
 
         private TimeTag getNextLyricTimeTag(TimeTag timeTag)
         {
             var currentLyric = timeTagInLyric(timeTag);
-            return Lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && match(x));
+            return Lyrics.GetNext(currentLyric)?.TimeTags?.FirstOrDefault(x => x.Index >= timeTag.Index && RecordingCursorMovable(x));
         }
 
         private TimeTag getPreviousTimeTag(TimeTag timeTag)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetPreviousMatch(timeTag, match);
+            return timeTags.GetPreviousMatch(timeTag, RecordingCursorMovable);
         }
 
         private TimeTag getNextTimeTag(TimeTag timeTag)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            return timeTags.GetNextMatch(timeTag, match);
-        }
-
-        private bool match(TimeTag timeTag)
-        {
-            switch (RecordingMovingCursorMode)
-            {
-                case RecordingMovingCursorMode.None:
-                    return true;
-                case RecordingMovingCursorMode.OnlyStartTag:
-                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.Start;
-                case RecordingMovingCursorMode.OnlyEndTag:
-                    return timeTag.Index.State == Framework.Graphics.Sprites.TextIndex.IndexState.End;
-                default:
-                    throw new InvalidOperationException(nameof(RecordingMovingCursorMode));
-            }
+            return timeTags.GetNextMatch(timeTag, RecordingCursorMovable);
         }
 
         private TimeTag getFirstTimeTag()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/TimeTagManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/TimeTagManager.cs
@@ -204,9 +204,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         Right,
 
-        // notice that this action only available in recording cursor mode.
-        Next,
-
         First,
 
         Last,

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/TimeTagManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/TimeTagManager.cs
@@ -194,15 +194,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         }
     }
 
-    public enum CursorAction
+    public enum MovingCursorAction
     {
-        MoveUp,
+        Up,
 
-        MoveDown,
+        Down,
 
-        MoveLeft,
+        Left,
 
-        MoveRight,
+        Right,
+
+        // notice that this action only available in recording cursor mode.
+        Next,
 
         First,
 

--- a/osu.Game.Rulesets.Karaoke/Extensions/EnumerableExtensions.cs
+++ b/osu.Game.Rulesets.Karaoke/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Retrieves the item after a pivot from an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the items stored in the collection.</typeparam>
+        /// <param name="collection">The collection to iterate on.</param>
+        /// <param name="pivot">The pivot value.</param>
+        /// <param name="action">Metch action</param>
+        /// <returns>The item in <paramref name="collection"/> appearing after <paramref name="pivot"/>, or null if no such item exists.</returns>
+        public static T GetNextMatch<T>(this IEnumerable<T> collection, T pivot, Func<T, bool> action)
+        {
+            return collection.SkipWhile(i => !EqualityComparer<T>.Default.Equals(i, pivot)).Skip(1).SkipWhile(x => !action(x)).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Retrieves the item before a pivot from an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the items stored in the collection.</typeparam>
+        /// <param name="collection">The collection to iterate on.</param>
+        /// <param name="pivot">The pivot value.</param>
+        /// <param name="action">Metch action</param>
+        /// <returns>The item in <paramref name="collection"/> appearing before <paramref name="pivot"/>, or null if no such item exists.</returns>
+        public static T GetPreviousMatch<T>(this IEnumerable<T> collection, T pivot, Func<T, bool> action)
+        {
+            return collection.Reverse().SkipWhile(i => !EqualityComparer<T>.Default.Equals(i, pivot)).Skip(1).SkipWhile(x => !action(x)).FirstOrDefault();
+        }
+    }
+}


### PR DESCRIPTION
Implementation of #430 .
What's should be added in this pull-request:
- [x] Add enum.
- [x] Enable to setting in config and menu.
- [x] Implement moving logic.
- [x] Should be visible which is movingable in lyric editor (might only need to change in recording mode).