### PR TITLE
Show alert checker in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Checker/Lyrics/LyricCheckerConfigTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Checker/Lyrics/LyricCheckerConfigTest.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Checker.Lyrics
+{
+    /// <summary>
+    /// Test all the lyric check result and invalid type
+    /// </summary>
+    [TestFixture]
+    public class LyricCheckerConfigTest
+    {
+        [TestCase("[1000,3000]:カラオケ", new[] { "[0,start]:1000", "[3,end]:3000" }, new TimeInvalid[] { })]
+        [TestCase("[3000,1000]:カラオケ", new string[] { }, new [] { TimeInvalid.Overlapping })]
+        [TestCase("[2000,3000]:カラオケ", new[] { "[0,start]:1000", "[3,end]:3000" }, new [] { TimeInvalid.StartTimeInvalid })]
+        [TestCase("[1000,2000]:カラオケ", new[] { "[0,start]:1000", "[3,end]:3000" }, new[] { TimeInvalid.EndTimeInvalid })]
+        public void TestCheckInvalidLyricTime(string lyricText, string[] timeTags, TimeInvalid[] invalid)
+        {
+            var lyric = TestCaseTagHelper.ParseLyric(lyricText);
+            lyric.TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags);
+
+            var checker = createChecker();
+            var result = checker.CheckInvalidLyricTime(lyric);
+            Assert.AreEqual(result, invalid);
+        }
+
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new TimeTagInvalid[] { })]
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,end]:5000" }, new TimeTagInvalid[] { })]
+        [TestCase("カラオケ", new[] { "[-1,start]:1000" }, new [] { TimeTagInvalid.OutOfRange })]
+        [TestCase("カラオケ", new[] { "[4,start]:4000" }, new[] { TimeTagInvalid.OutOfRange })]
+        [TestCase("カラオケ", new[] { "[0,start]:5000", "[3,end]:1000" }, new [] { TimeTagInvalid.Overlapping })]
+        public void TestCheckInvalidTimeTags(string text, string[] timeTags, TimeTagInvalid[] invalids)
+        {
+            var lyric = new Lyric
+            {
+                Text = text,
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+
+            var checker = createChecker();
+            var result = checker.CheckInvalidTimeTags(lyric);
+            Assert.AreEqual(result.Keys.ToArray(), invalids);
+        }
+
+        [TestCase("カラオケ", new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }, new RubyTagInvalid[] { })]
+        [TestCase("カラオケ", new[] { "[0,4]:からおけ" }, new RubyTagInvalid[] { })]
+        [TestCase("カラオケ", new[] { "[-1,1]:か" }, new[] { RubyTagInvalid.OutOfRange })]
+        [TestCase("カラオケ", new[] { "[4,5]:け" }, new[] { RubyTagInvalid.OutOfRange })]
+        [TestCase("カラオケ", new[] { "[0,1]:か", "[0,1]:ら" }, new[] { RubyTagInvalid.Overlapping })]
+        [TestCase("カラオケ", new[] { "[0,3]:か", "[1,2]:ら" }, new[] { RubyTagInvalid.Overlapping })]
+        public void TestCheckInvalidRubyTags(string text, string[] rubies, RubyTagInvalid[] invalids)
+        {
+            var lyric = new Lyric
+            {
+                Text = text,
+                RubyTags = TestCaseTagHelper.ParseRubyTags(rubies)
+            };
+
+            var checker = createChecker();
+            var result = checker.CheckInvalidRubyTags(lyric);
+            Assert.AreEqual(result.Keys.ToArray(), invalids);
+        }
+
+        [TestCase("karaoke", new[] { "[0,2]:ka", "[2,4]:ra", "[4,5]:o", "[5,7]:ke" }, new RomajiTagInvalid[] { })]
+        [TestCase("karaoke", new[] { "[0,7]:karaoke" }, new RomajiTagInvalid[] { })]
+        [TestCase("karaoke", new[] { "[-1,2]:ka" }, new [] { RomajiTagInvalid.OutOfRange })]
+        [TestCase("karaoke", new[] { "[7,8]:ke" }, new[] { RomajiTagInvalid.OutOfRange })]
+        [TestCase("karaoke", new[] { "[0,2]:ka", "[1,3]:ra" }, new[] { RomajiTagInvalid.Overlapping })]
+        [TestCase("karaoke", new[] { "[0,3]:ka", "[1,2]:ra" }, new[] { RomajiTagInvalid.Overlapping })]
+        public void TestCheckInvalidRomajiTags(string text, string[] romajies, RomajiTagInvalid[] invalids)
+        {
+            var lyric = new Lyric
+            {
+                Text = text,
+                RomajiTags = TestCaseTagHelper.ParseRomajiTags(romajies)
+            };
+
+            var checker = createChecker();
+            var result = checker.CheckInvalidRomajiTags(lyric);
+            Assert.AreEqual(result.Keys.ToArray(), invalids);
+        }
+
+        // create checker with default config.
+        // config change is not test scope so use default it ok.
+        private static LyricChecker createChecker()
+            => new LyricChecker(new LyricCheckerConfig().CreateDefaultConfig()); 
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -274,5 +274,40 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         }
 
         #endregion
+
+        #region Check
+
+        [TestCase("[1000,3000]:karaoke", false)]
+        [TestCase("[1000,1000]:karaoke", false)] // it's ok to let it pass(for no reason now).
+        [TestCase("[1000,0]:karaoke", true)]
+        public void TestCheckIsTimeOverlapping(string lyricText, bool actual)
+        {
+            var lyric = TestCaseTagHelper.ParseLyric(lyricText);
+            Assert.AreEqual(LyricUtils.CheckIsTimeOverlapping(lyric), actual);
+        }
+
+        [TestCase("[1000,5000]:karaoke", new[] { "[0,start]:1000", "[2,start]:2000", "[4,start]:3000", "[5,start]:4000", "[7,end]:5000" }, false)]
+        [TestCase("[1000,5000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, false)]
+        [TestCase("[1000,2000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, false)] // not check end time now.
+        [TestCase("[2000,5000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, true)]
+        public void TestCheckIsStartTimeInvalid(string lyricText, string[] timeTags, bool actual)
+        {
+            var lyric = TestCaseTagHelper.ParseLyric(lyricText);
+            lyric.TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags);
+            Assert.AreEqual(LyricUtils.CheckIsStartTimeInvalid(lyric), actual);
+        }
+
+        [TestCase("[1000,5000]:karaoke", new[] { "[0,start]:1000", "[2,start]:2000", "[4,start]:3000", "[5,start]:4000", "[7,end]:5000" }, false)]
+        [TestCase("[1000,5000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, false)]
+        [TestCase("[2000,5000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, false)] // not check start time now.
+        [TestCase("[1000,2000]:karaoke", new[] { "[0,start]:1000", "[7,end]:5000" }, true)]  
+        public void TestCheckIsEndTimeInvalid(string lyricText, string[] timeTags, bool actual)
+        {
+            var lyric = TestCaseTagHelper.ParseLyric(lyricText);
+            lyric.TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags);
+            Assert.AreEqual(LyricUtils.CheckIsEndTimeInvalid(lyric), actual);
+        }
+
+        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
     [TestFixture]
     public class TextTagsUtilsTest
     {
-        private const string lyric = "Test lyric";
-
         [TestCase(nameof(ValidTextTagWithSorted), TextTagsUtils.Sorting.Asc, new[] { 0, 1, 1, 2, 2, 3 })]
         [TestCase(nameof(ValidTextTagWithSorted), TextTagsUtils.Sorting.Desc, new[] { 2, 3, 1, 2, 0, 1 })]
         [TestCase(nameof(ValidTextTagWithUnsorted), TextTagsUtils.Sorting.Asc, new[] { 0, 1, 1, 2, 2, 3 })]
@@ -45,12 +43,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(nameof(InvalidTextTagWithWrapNextTextTag), TextTagsUtils.Sorting.Desc, new[] { 1 })]
         [TestCase(nameof(InvalidTextTagWithSandwichTextTag), TextTagsUtils.Sorting.Asc, new[] { 1 })]
         [TestCase(nameof(InvalidTextTagWithSandwichTextTag), TextTagsUtils.Sorting.Desc, new[] { 1 })]
-        public void TestFindInvalid(string testCase, TextTagsUtils.Sorting sorting, int[] errorIndex)
+        public void TestFindOverlapping(string testCase, TextTagsUtils.Sorting sorting, int[] errorIndex)
         {
             var textTags = getValueByMethodName(testCase);
 
             // run all and find invalid indexes.
-            var invalidTextTag = TextTagsUtils.FindInvalid(textTags, lyric, sorting);
+            var invalidTextTag = TextTagsUtils.FindOverlapping(textTags, sorting);
             var invalidIndexes = invalidTextTag.Select(v => textTags.IndexOf(v)).ToArray();
             Assert.AreEqual(invalidIndexes, errorIndex);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
@@ -14,43 +14,39 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
     [TestFixture]
     public class TextTagsUtilsTest
     {
-        [TestCase(nameof(ValidTextTagWithSorted), TextTagsUtils.Sorting.Asc, new[] { 0, 1, 1, 2, 2, 3 })]
-        [TestCase(nameof(ValidTextTagWithSorted), TextTagsUtils.Sorting.Desc, new[] { 2, 3, 1, 2, 0, 1 })]
-        [TestCase(nameof(ValidTextTagWithUnsorted), TextTagsUtils.Sorting.Asc, new[] { 0, 1, 1, 2, 2, 3 })]
-        [TestCase(nameof(ValidTextTagWithUnsorted), TextTagsUtils.Sorting.Desc, new[] { 2, 3, 1, 2, 0, 1 })]
-        public void TestSort(string testCase, TextTagsUtils.Sorting sorting, int[] results)
+        [TestCase(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" }, TextTagsUtils.Sorting.Asc, new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" })]
+        [TestCase(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" }, TextTagsUtils.Sorting.Desc, new[] { "[2,3]:o", "[1,2]:ra", "[0,1]:ka", })]
+        [TestCase(new[] { "[0,1]:ka", "[2,3]:o", "[1,2]:ra" }, TextTagsUtils.Sorting.Asc, new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" })]
+        [TestCase(new[] { "[0,1]:ka", "[2,3]:o", "[1,2]:ra" }, TextTagsUtils.Sorting.Desc, new[] { "[2,3]:o", "[1,2]:ra", "[0,1]:ka", })]
+        public void TestSort(string[] textTags, TextTagsUtils.Sorting sorting, string[] actualTextTags)
         {
-            var textTags = getValueByMethodName(testCase);
-
-            var sortedTextTags = TextTagsUtils.Sort(textTags, sorting);
-
-            for (int i = 0; i < sortedTextTags.Length; i++)
-            {
-                // result would be start, end, start, end...
-                Assert.AreEqual(sortedTextTags[i].StartIndex, results[i * 2]);
-                Assert.AreEqual(sortedTextTags[i].EndIndex, results[i * 2 + 1]);
-            }
+            var sortedTextTags = TextTagsUtils.Sort(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
+            Assert.AreEqual(sortedTextTags, TestCaseTagHelper.ParseRubyTags(actualTextTags));
         }
 
-        [TestCase(nameof(ValidTextTagWithSorted), TextTagsUtils.Sorting.Asc, new int[] { })]
-        [TestCase(nameof(ValidTextTagWithUnsorted), TextTagsUtils.Sorting.Asc, new int[] { })]
-        [TestCase(nameof(InvalidTextTagWithSameStartAndEndIndex), TextTagsUtils.Sorting.Asc, new[] { 0 })]
-        [TestCase(nameof(InvalidTextTagWithWrongIndex), TextTagsUtils.Sorting.Asc, new[] { 0 })]
-        [TestCase(nameof(InvalidTextTagWithNegativeIndex), TextTagsUtils.Sorting.Asc, new[] { 0 })]
-        [TestCase(nameof(InvalidTextTagWithEndLargerThenNextStart), TextTagsUtils.Sorting.Asc, new[] { 1 })]
-        [TestCase(nameof(InvalidTextTagWithEndLargerThenNextStart), TextTagsUtils.Sorting.Desc, new[] { 0 })]
-        [TestCase(nameof(InvalidTextTagWithWrapNextTextTag), TextTagsUtils.Sorting.Asc, new[] { 1 })]
-        [TestCase(nameof(InvalidTextTagWithWrapNextTextTag), TextTagsUtils.Sorting.Desc, new[] { 1 })]
-        [TestCase(nameof(InvalidTextTagWithSandwichTextTag), TextTagsUtils.Sorting.Asc, new[] { 1 })]
-        [TestCase(nameof(InvalidTextTagWithSandwichTextTag), TextTagsUtils.Sorting.Desc, new[] { 1 })]
-        public void TestFindOverlapping(string testCase, TextTagsUtils.Sorting sorting, int[] errorIndex)
+        [TestCase(new[] { "[0,7]:ka" }, "karaoke", new string[] { })]
+        [TestCase(new[] { "[-1,0]:ka" }, "karaoke", new[] { "[-1,0]:ka" })]
+        [TestCase(new[] { "[7,8]:ka" }, "karaoke", new[] { "[7,8]:ka" })]
+        public void TestFindOutOfRange(string[] textTags, string lyric, string[] actualTextTags)
         {
-            var textTags = getValueByMethodName(testCase);
+            var invalidTextTag = TextTagsUtils.FindOutOfRange(TestCaseTagHelper.ParseRubyTags(textTags), lyric);
+            Assert.AreEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
+        }
 
-            // run all and find invalid indexes.
-            var invalidTextTag = TextTagsUtils.FindOverlapping(textTags, sorting);
-            var invalidIndexes = invalidTextTag.Select(v => textTags.IndexOf(v)).ToArray();
-            Assert.AreEqual(invalidIndexes, errorIndex);
+        [TestCase(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" }, TextTagsUtils.Sorting.Asc, new string[] { })]
+        [TestCase(new[] { "[0,1]:ka", "[2,3]:o", "[1,2]:ra" }, TextTagsUtils.Sorting.Asc, new string[] { })]
+        [TestCase(new[] { "[0,0]:ka" }, TextTagsUtils.Sorting.Asc, new[] { "[0,0]:ka" })]
+        [TestCase(new[] { "[1,0]:ka" }, TextTagsUtils.Sorting.Asc, new[] { "[1,0]:ka" })]
+        [TestCase(new[] { "[0,2]:ka", "[1,3]:ra" }, TextTagsUtils.Sorting.Asc, new[] { "[1,3]:ra" })]
+        [TestCase(new[] { "[0,2]:ka", "[1,3]:ra" }, TextTagsUtils.Sorting.Desc, new[] { "[0,2]:ka" })]
+        [TestCase(new[] { "[0,3]:ka", "[1,2]:ra" }, TextTagsUtils.Sorting.Asc, new[] { "[1,2]:ra" })]
+        [TestCase(new[] { "[0,3]:ka", "[1,2]:ra" }, TextTagsUtils.Sorting.Desc, new[] { "[1,2]:ra" })]
+        [TestCase(new[] { "[0,2]:ka", "[1,3]:ra", "[2,4]:o" }, TextTagsUtils.Sorting.Asc, new[] { "[1,3]:ra" })]
+        [TestCase(new[] { "[0,2]:ka", "[1,3]:ra", "[2,4]:o" }, TextTagsUtils.Sorting.Desc, new[] { "[1,3]:ra" })]
+        public void TestFindOverlapping(string[] textTags, TextTagsUtils.Sorting sorting, string[] actualTextTags)
+        {
+            var invalidTextTag = TextTagsUtils.FindOverlapping(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
+            Assert.AreEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
         }
 
         [TestCase(new[] { "[0,1]:ka" }, "[0,1]:ka")]
@@ -61,91 +57,5 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTextTag);
             Assert.AreEqual(TextTagsUtils.Combine(rubyTags), actualRubyTag);
         }
-
-        private RubyTag[] getValueByMethodName(string methodName)
-        {
-            Type thisType = GetType();
-            var theMethod = thisType.GetMethod(methodName);
-            if (theMethod == null)
-                throw new MissingMethodException("Test method is not exist.");
-
-            return theMethod.Invoke(this, null) as RubyTag[];
-        }
-
-        #region valid source
-
-        public static RubyTag[] ValidTextTagWithSorted()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 1 },
-                new RubyTag { StartIndex = 1, EndIndex = 2 },
-                new RubyTag { StartIndex = 2, EndIndex = 3 }
-            };
-
-        public static RubyTag[] ValidTextTagWithUnsorted()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 1 },
-                new RubyTag { StartIndex = 2, EndIndex = 3 },
-                new RubyTag { StartIndex = 1, EndIndex = 2 }
-            };
-
-        #endregion
-
-        #region invalid source
-
-        public static RubyTag[] InvalidTextTagWithWrongIndex()
-            => new[]
-            {
-                new RubyTag { StartIndex = 1, EndIndex = 0 },
-            };
-
-        public static RubyTag[] InvalidTextTagWithNegativeIndex()
-            => new[]
-            {
-                new RubyTag { StartIndex = -1, EndIndex = 0 },
-            };
-
-        public static RubyTag[] InvalidTextTagWithSameStartAndEndIndex()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 0 }, // Same number.
-            };
-
-        public static RubyTag[] InvalidTextTagWithStartTimeExceedLyricSize()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = lyric.Length + 1 }, // Same number.
-            };
-
-        public static RubyTag[] InvalidTextTagWithEndTimeExceedLyricSize()
-            => new[]
-            {
-                new RubyTag { StartIndex = lyric.Length + 1, EndIndex = lyric.Length + 2 }, // Same number.
-            };
-
-        public static RubyTag[] InvalidTextTagWithEndLargerThenNextStart()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 2 }, // End is larger than second start.
-                new RubyTag { StartIndex = 1, EndIndex = 3 }
-            };
-
-        public static RubyTag[] InvalidTextTagWithWrapNextTextTag()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 3 }, // Wrap second text tag.
-                new RubyTag { StartIndex = 1, EndIndex = 2 }
-            };
-
-        public static RubyTag[] InvalidTextTagWithSandwichTextTag()
-            => new[]
-            {
-                new RubyTag { StartIndex = 0, EndIndex = 2 },
-                new RubyTag { StartIndex = 1, EndIndex = 3 },
-                new RubyTag { StartIndex = 2, EndIndex = 4 }
-            };
-
-        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
@@ -59,6 +60,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             // run all then using time(nullable double) to check.
             var sortedTimeTag = TimeTagsUtils.Sort(timeTags);
             Assert.AreEqual(getSortedTime(sortedTimeTag), results);
+        }
+
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new string[] { })]
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,end]:5000" }, new string[] { })]
+        [TestCase("カラオケ", new[] { "[-1,start]:1000" }, new[] { "[-1,start]:1000" })]
+        [TestCase("カラオケ", new[] { "[4,start]:4000" }, new[] { "[4,start]:4000" })]
+        public void TestFindOutOfRange(string text, string[] timeTags, string[] invalidTimeTags)
+        {
+            var outOfRangeTimeTags = TimeTagsUtils.FindOutOfRange(TestCaseTagHelper.ParseTimeTags(timeTags), text);
+            TimeTagAssert.AreEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
         }
 
         [TestCase(nameof(InvalidTimeTagWithStartLargerThenEnd), GroupCheck.Asc, SelfCheck.BasedOnStart, new[] { 1 })]

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditCheckerConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditCheckerConfigManager.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Configuration
+{
+    public class KaraokeRulesetEditCheckerConfigManager : InMemoryConfigManager<KaraokeRulesetEditCheckerSetting>
+    {
+        protected override void InitialiseDefaults()
+        {
+            base.InitialiseDefaults();
+
+            // Lyric
+            Set(KaraokeRulesetEditCheckerSetting.Lyric, CreateDefaultConfig<LyricCheckerConfig>());
+        }
+
+        protected static T CreateDefaultConfig<T>() where T : IHasConfig<T>, new()
+            => new T().CreateDefaultConfig();
+    }
+
+    public enum KaraokeRulesetEditCheckerSetting
+    {
+        Lyric
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
@@ -30,12 +30,6 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // Lock
             Set(KaraokeRulesetEditSetting.ClickToLockLyricState, LockState.Partial);
-
-            // Checker
-            Set(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeGroupCheck, GroupCheck.Asc);
-            Set(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeSelfCheck, SelfCheck.BasedOnStart);
-            Set(KaraokeRulesetEditSetting.CheckRubyPositionSorting, TextTagsUtils.Sorting.Asc);
-            Set(KaraokeRulesetEditSetting.CheckRomajiPositionSorting, TextTagsUtils.Sorting.Asc);
         }
     }
 
@@ -57,11 +51,5 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
         // Lock
         ClickToLockLyricState,
-
-        // Checker
-        CheckInvalidTimeTagTimeGroupCheck,
-        CheckInvalidTimeTagTimeSelfCheck,
-        CheckRubyPositionSorting,
-        CheckRomajiPositionSorting
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
@@ -5,7 +5,6 @@ using osu.Game.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
-using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Configuration
 {

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditConfigManager.cs
@@ -5,6 +5,7 @@ using osu.Game.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Configuration
 {
@@ -29,6 +30,12 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // Lock
             Set(KaraokeRulesetEditSetting.ClickToLockLyricState, LockState.Partial);
+
+            // Checker
+            Set(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeGroupCheck, GroupCheck.Asc);
+            Set(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeSelfCheck, SelfCheck.BasedOnStart);
+            Set(KaraokeRulesetEditSetting.CheckRubyPositionSorting, TextTagsUtils.Sorting.Asc);
+            Set(KaraokeRulesetEditSetting.CheckRomajiPositionSorting, TextTagsUtils.Sorting.Asc);
         }
     }
 
@@ -50,5 +57,11 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
         // Lock
         ClickToLockLyricState,
+
+        // Checker
+        CheckInvalidTimeTagTimeGroupCheck,
+        CheckInvalidTimeTagTimeSelfCheck,
+        CheckRubyPositionSorting,
+        CheckRomajiPositionSorting
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckProperty.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
         Time = 1,
 
         /// <summary>
-        /// Check tim-tag is overlaggping or not.
+        /// Check tim-tag is overlapping or not.
         /// </summary>
         TimeTag = 2,
 
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
         Ruby = 4,
 
         /// <summary>
-        /// Check ropmaji is out of range or overlapping.
+        /// Check romaji is out of range or overlapping.
         /// </summary>
         Romaji = 8,
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckProperty.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
+{
+    public enum LyricCheckProperty
+    {
+        /// <summary>
+        /// Check start time and end time is valid.
+        /// </summary>
+        Time = 1,
+
+        /// <summary>
+        /// Check tim-tag is overlaggping or not.
+        /// </summary>
+        TimeTag = 2,
+
+        /// <summary>
+        /// Check ruby is out of range or overlapping.
+        /// </summary>
+        Ruby = 4,
+
+        /// <summary>
+        /// Check ropmaji is out of range or overlapping.
+        /// </summary>
+        Romaji = 8,
+
+        /// <summary>
+        /// Check all property in lyric.
+        /// </summary>
+        All = Time | TimeTag | Ruby | Romaji,
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
@@ -39,8 +39,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 
     public enum TimeInvalid
     {
-        None,
-
         Overlapping,
 
         StartTimeInvalid,

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 {
     public class LyricCheckReport
     {
-        public TimeInvalid TimeInvalid { get; set; }
+        public TimeInvalid[] TimeInvalid { get; set; }
 
         public Dictionary<TimeTagInvalid, TimeTag[]> InvalidTimeTags { get; set; }
 
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
         {
             get
             {
-                if (TimeInvalid != TimeInvalid.None)
+                if (TimeInvalid.Length > 0)
                     return false;
 
                 if (InvalidTimeTags?.Count > 0)
@@ -43,9 +43,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 
         Overlapping,
 
-        LargerThanTimeTag,
+        StartTimeInvalid,
 
-        SmallerThanTimeTag
+        EndTimeInvalid
     }
 
     public enum TimeTagInvalid

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
@@ -1,38 +1,71 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 {
-    public struct LyricCheckReport
+    public class LyricCheckReport
     {
-        public bool TimeInvalid { get; set; }
+        public TimeInvalid TimeInvalid { get; set; }
 
-        public TimeTag[] InvalidTimeTag { get; set; }
+        public Dictionary<TimeTagInvalid, TimeTag[]> InvalidTimeTags { get; set; }
 
-        public RubyTag[] InvalidRubyTag { get; set; }
+        public Dictionary<RubyTagInvalid, RubyTag[]> InvalidRubyTags { get; set; }
 
-        public RomajiTag[] InvalidRomajiTag { get; set; }
+        public Dictionary<RomajiTagInvalid, RomajiTag[]> InvalidRomajiTags { get; set; }
 
         public bool IsValid
         {
             get
             {
-                if (TimeInvalid)
+                if (TimeInvalid != TimeInvalid.None)
                     return false;
 
-                if (InvalidTimeTag?.Length > 0)
+                if (InvalidTimeTags?.Count > 0)
                     return false;
 
-                if (InvalidRubyTag?.Length > 0)
+                if (InvalidRubyTags?.Count > 0)
                     return false;
 
-                if (InvalidRomajiTag?.Length > 0)
+                if (InvalidRomajiTags?.Count > 0)
                     return false;
 
                 return true;
             }
         }
+    }
+
+    public enum TimeInvalid
+    {
+        None,
+
+        Overlapping,
+
+        LargerThanTimeTag,
+
+        SmallerThanTimeTag
+    }
+
+    public enum TimeTagInvalid
+    {
+        OutOfRange,
+
+        Overlapping,
+    }
+
+    public enum RubyTagInvalid
+    {
+        OutOfRange,
+
+        Overlapping
+    }
+
+    public enum RomajiTagInvalid
+    {
+        OutOfRange,
+
+        Overlapping
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckReport.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
+{
+    public struct LyricCheckReport
+    {
+        public bool TimeInvalid { get; set; }
+
+        public TimeTag[] InvalidTimeTag { get; set; }
+
+        public RubyTag[] InvalidRubyTag { get; set; }
+
+        public RomajiTag[] InvalidRomajiTag { get; set; }
+
+        public bool IsValid
+        {
+            get
+            {
+                if (TimeInvalid)
+                    return false;
+
+                if (InvalidTimeTag?.Length > 0)
+                    return false;
+
+                if (InvalidRubyTag?.Length > 0)
+                    return false;
+
+                if (InvalidRomajiTag?.Length > 0)
+                    return false;
+
+                return true;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
@@ -26,53 +27,73 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
                 report.TimeInvalid = invalidLyricTime(lyric);
 
             if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidTimeTag = checkInvalidTimeTagTime(lyric);
+                report.InvalidTimeTags = checkInvalidTimeTags(lyric);
 
             if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidRubyTag = checkInvalidRubyRange(lyric);
+                report.InvalidRubyTags = checkInvalidRubyTags(lyric);
 
             if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidRomajiTag = checkInvalidRomajiRange(lyric);
+                report.InvalidRomajiTags = checkInvalidRomajiTags(lyric);
 
             return report;
         }
 
-
-        private bool invalidLyricTime(Lyric lyric)
+        private TimeInvalid invalidLyricTime(Lyric lyric)
         {
             // todo : apply utils with enum key.
-            return false;
+            return TimeInvalid.None;
         }
 
-        private TimeTag[] checkInvalidTimeTagTime(Lyric lyric)
+        private Dictionary<TimeTagInvalid, TimeTag[]> checkInvalidTimeTags(Lyric lyric)
         {
+            var result = new Dictionary<TimeTagInvalid, TimeTag[]>();
+
+            // todo : check out of range.
+
+            // Check overlapping.
             var groupCheck = config.TimeTagTimeGroupCheck;
             var selfCheck = config.TimeTagTimeSelfCheck;
-            return TimeTagsUtils.FindInvalid(lyric.TimeTags, groupCheck, selfCheck);
+            var invalidTimeTags = TimeTagsUtils.FindInvalid(lyric.TimeTags, groupCheck, selfCheck);
+            if (invalidTimeTags?.Length > 0)
+                result.Add(TimeTagInvalid.Overlapping, invalidTimeTags);
+
+            return result;
         }
 
-        private RubyTag[] checkInvalidRubyRange(Lyric lyric)
+        private Dictionary<RubyTagInvalid, RubyTag[]> checkInvalidRubyTags(Lyric lyric)
         {
-            return TextTagsUtils.FindOutOfRange(lyric.RubyTags, lyric.Text);
-        }
+            var result = new Dictionary<RubyTagInvalid, RubyTag[]>();
 
-        // todo : will use in future
-        private RubyTag[] checkOverlappingRubyPosition(Lyric lyric)
-        {
-            var sorting = config.RubyPositionSorting;
-            return TextTagsUtils.FindOverlapping(lyric.RubyTags, sorting);
-        }
+            // Checking out of range tags.
+            var outOfRangeTags = TextTagsUtils.FindOutOfRange(lyric.RubyTags, lyric.Text);
+            if (outOfRangeTags?.Length > 0)
+                result.Add(RubyTagInvalid.OutOfRange, outOfRangeTags);
 
-        private RomajiTag[] checkInvalidRomajiRange(Lyric lyric)
-        {
-            return TextTagsUtils.FindOutOfRange(lyric.RomajiTags, lyric.Text);
-        }
-
-        // todo : will use in future
-        private RomajiTag[] checkOverlappingRomajiPosition(Lyric lyric)
-        {
+            // Checking overlapping.
             var sorting = config.RomajiPositionSorting;
-            return TextTagsUtils.FindOverlapping(lyric.RomajiTags, sorting);
+            var overlappingTags = TextTagsUtils.FindOverlapping(lyric.RubyTags, sorting);
+            if (overlappingTags?.Length > 0)
+                result.Add(RubyTagInvalid.Overlapping, overlappingTags);
+
+            return result;
+        }
+
+        private Dictionary<RomajiTagInvalid, RomajiTag[]> checkInvalidRomajiTags(Lyric lyric)
+        {
+            var result = new Dictionary<RomajiTagInvalid, RomajiTag[]>();
+
+            // Checking out of range tags.
+            var outOfRangeTags = TextTagsUtils.FindOutOfRange(lyric.RomajiTags, lyric.Text);
+            if (outOfRangeTags?.Length > 0)
+                result.Add(RomajiTagInvalid.OutOfRange, outOfRangeTags);
+
+            // Checking overlapping.
+            var sorting = config.RomajiPositionSorting;
+            var overlappingTags = TextTagsUtils.FindOverlapping(lyric.RomajiTags, sorting);
+            if (overlappingTags?.Length > 0)
+                result.Add(RomajiTagInvalid.Overlapping, overlappingTags);
+
+            return result;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
@@ -8,9 +8,9 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 {
-    public class LyricInvalidChecker : Component
+    public class LyricChecker : Component
     {
         [Resolved]
         private KaraokeRulesetEditConfigManager configManager { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
@@ -19,36 +19,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
             this.config = config;
         }
 
-        public LyricCheckReport CheckLyric(Lyric lyric, LyricCheckProperty checkProperty = LyricCheckProperty.All)
+        public TimeInvalid[] CheckInvalidLyricTime(Lyric lyric)
         {
-            var report = new LyricCheckReport();
+            var result = new List<TimeInvalid>();
 
-            if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.TimeInvalid = invalidLyricTime(lyric);
+            if (LyricUtils.CheckIsTimeOverlapping(lyric))
+                result.Add(TimeInvalid.Overlapping);
 
-            if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidTimeTags = checkInvalidTimeTags(lyric);
+            if (LyricUtils.CheckIsStartTimeInvalid(lyric))
+                result.Add(TimeInvalid.StartTimeInvalid);
 
-            if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidRubyTags = checkInvalidRubyTags(lyric);
+            if (LyricUtils.CheckIsEndTimeInvalid(lyric))
+                result.Add(TimeInvalid.EndTimeInvalid);
 
-            if (checkProperty.HasFlag(LyricCheckProperty.Time))
-                report.InvalidRomajiTags = checkInvalidRomajiTags(lyric);
-
-            return report;
+            return result.ToArray();
         }
 
-        private TimeInvalid invalidLyricTime(Lyric lyric)
-        {
-            // todo : apply utils with enum key.
-            return TimeInvalid.None;
-        }
-
-        private Dictionary<TimeTagInvalid, TimeTag[]> checkInvalidTimeTags(Lyric lyric)
+        public Dictionary<TimeTagInvalid, TimeTag[]> CheckInvalidTimeTags(Lyric lyric)
         {
             var result = new Dictionary<TimeTagInvalid, TimeTag[]>();
 
             // todo : check out of range.
+            var outOfRangeTags = TimeTagsUtils.FindOutOfRange(lyric.TimeTags, lyric.Text);
+            if (outOfRangeTags?.Length > 0)
+                result.Add(TimeTagInvalid.OutOfRange, outOfRangeTags);
 
             // Check overlapping.
             var groupCheck = config.TimeTagTimeGroupCheck;
@@ -60,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
             return result;
         }
 
-        private Dictionary<RubyTagInvalid, RubyTag[]> checkInvalidRubyTags(Lyric lyric)
+        public Dictionary<RubyTagInvalid, RubyTag[]> CheckInvalidRubyTags(Lyric lyric)
         {
             var result = new Dictionary<RubyTagInvalid, RubyTag[]>();
 
@@ -78,7 +72,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
             return result;
         }
 
-        private Dictionary<RomajiTagInvalid, RomajiTag[]> checkInvalidRomajiTags(Lyric lyric)
+        public Dictionary<RomajiTagInvalid, RomajiTag[]> CheckInvalidRomajiTags(Lyric lyric)
         {
             var result = new Dictionary<RomajiTagInvalid, RomajiTag[]>();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricChecker.cs
@@ -1,61 +1,77 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 {
-    public class LyricChecker : Component
+    /// <summary>
+    /// This checker is focus on checking and give report, and should be testable.
+    /// </summary>
+    public class LyricChecker
     {
-        [Resolved]
-        private KaraokeRulesetEditConfigManager configManager { get; set; }
+        private readonly LyricCheckerConfig config;
 
-        [Resolved]
-        private EditorBeatmap beatmap { get; set; }
-
-        public Lyric[] InvalidTimeLyrics()
+        public LyricChecker(LyricCheckerConfig config)
         {
-            // todo : implement.
-            return null;
+            this.config = config;
         }
 
-        public bool InvalidLyricTime(Lyric lyric)
+        public LyricCheckReport CheckLyric(Lyric lyric, LyricCheckProperty checkProperty = LyricCheckProperty.All)
+        {
+            var report = new LyricCheckReport();
+
+            if (checkProperty.HasFlag(LyricCheckProperty.Time))
+                report.TimeInvalid = invalidLyricTime(lyric);
+
+            if (checkProperty.HasFlag(LyricCheckProperty.Time))
+                report.InvalidTimeTag = checkInvalidTimeTagTime(lyric);
+
+            if (checkProperty.HasFlag(LyricCheckProperty.Time))
+                report.InvalidRubyTag = checkInvalidRubyRange(lyric);
+
+            if (checkProperty.HasFlag(LyricCheckProperty.Time))
+                report.InvalidRomajiTag = checkInvalidRomajiRange(lyric);
+
+            return report;
+        }
+
+
+        private bool invalidLyricTime(Lyric lyric)
         {
             // todo : apply utils with enum key.
             return false;
         }
 
-        public TimeTag[] CheckInvalidTimeTagTime(Lyric lyric)
+        private TimeTag[] checkInvalidTimeTagTime(Lyric lyric)
         {
-            var groupCheck = configManager.Get<GroupCheck>(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeGroupCheck);
-            var selfCheck = configManager.Get<SelfCheck>(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeSelfCheck);
+            var groupCheck = config.TimeTagTimeGroupCheck;
+            var selfCheck = config.TimeTagTimeSelfCheck;
             return TimeTagsUtils.FindInvalid(lyric.TimeTags, groupCheck, selfCheck);
         }
 
-        public RubyTag[] CheckInvalidRubyRange(Lyric lyric)
+        private RubyTag[] checkInvalidRubyRange(Lyric lyric)
         {
             return TextTagsUtils.FindOutOfRange(lyric.RubyTags, lyric.Text);
         }
 
-        public RubyTag[] CheckOverlappingRubyPosition(Lyric lyric)
+        // todo : will use in future
+        private RubyTag[] checkOverlappingRubyPosition(Lyric lyric)
         {
-            var sorting = configManager.Get<TextTagsUtils.Sorting>(KaraokeRulesetEditSetting.CheckRubyPositionSorting);
+            var sorting = config.RubyPositionSorting;
             return TextTagsUtils.FindOverlapping(lyric.RubyTags, sorting);
         }
 
-        public RomajiTag[] CheckInvalidRomajiRange(Lyric lyric)
+        private RomajiTag[] checkInvalidRomajiRange(Lyric lyric)
         {
             return TextTagsUtils.FindOutOfRange(lyric.RomajiTags, lyric.Text);
         }
 
-        public RomajiTag[] CheckOverlappingRomajiPosition(Lyric lyric)
+        // todo : will use in future
+        private RomajiTag[] checkOverlappingRomajiPosition(Lyric lyric)
         {
-            var sorting = configManager.Get<TextTagsUtils.Sorting>(KaraokeRulesetEditSetting.CheckRomajiPositionSorting);
+            var sorting = config.RomajiPositionSorting;
             return TextTagsUtils.FindOverlapping(lyric.RomajiTags, sorting);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerConfig.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
+{
+    public class LyricCheckerConfig : IHasConfig<LyricCheckerConfig>
+    {
+        public GroupCheck TimeTagTimeGroupCheck { get; set; }
+
+        public SelfCheck TimeTagTimeSelfCheck { get; set; }
+
+        public TextTagsUtils.Sorting RubyPositionSorting { get; set; }
+
+        public TextTagsUtils.Sorting RomajiPositionSorting { get; set; }
+
+        public LyricCheckerConfig CreateDefaultConfig()
+        {
+            return new LyricCheckerConfig
+            {
+                TimeTagTimeGroupCheck = GroupCheck.Asc,
+                TimeTagTimeSelfCheck = SelfCheck.BasedOnStart,
+                RubyPositionSorting = TextTagsUtils.Sorting.Asc,
+                RomajiPositionSorting = TextTagsUtils.Sorting.Asc,
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
@@ -14,7 +14,7 @@ using osu.Game.Screens.Edit;
 namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
 {
     /// <summary>
-    /// This manager is for regist and able to get invalid change by bindable.
+    /// This manager is for register and able to get invalid change by bindable.
     /// </summary>
     public class LyricCheckerManager : Component
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
                 if (!BindableReports.Contains(lyric))
                     BindableReports.Add(lyric, new LyricCheckReport());
 
-
                 var report = BindableReports[lyric];
                 if (checkProperty.HasFlag(LyricCheckProperty.Time))
                     report.TimeInvalid = lyricChecker.CheckInvalidLyricTime(lyric);

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
@@ -33,16 +33,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
             // re-calculate and add
             foreach (var lyric in lyrics)
             {
-                var report = lyricChecker.CheckLyric(lyric);
+                // create report record if not have.
+                if (!BindableReports.Contains(lyric))
+                    BindableReports.Add(lyric, new LyricCheckReport());
 
-                if (BindableReports.Contains(lyric))
-                {
-                    BindableReports[lyric] = report;
-                }
-                else
-                {
-                    BindableReports.Add(lyric, report);
-                }
+
+                var report = BindableReports[lyric];
+                if (checkProperty.HasFlag(LyricCheckProperty.Time))
+                    report.TimeInvalid = lyricChecker.CheckInvalidLyricTime(lyric);
+
+                if (checkProperty.HasFlag(LyricCheckProperty.TimeTag))
+                    report.InvalidTimeTags = lyricChecker.CheckInvalidTimeTags(lyric);
+
+                if (checkProperty.HasFlag(LyricCheckProperty.Ruby))
+                    report.InvalidRubyTags = lyricChecker.CheckInvalidRubyTags(lyric);
+
+                if (checkProperty.HasFlag(LyricCheckProperty.Romaji))
+                    report.InvalidRomajiTags = lyricChecker.CheckInvalidRomajiTags(lyric);
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Lyrics/LyricCheckerManager.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Bindables;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics
+{
+    /// <summary>
+    /// This manager is for regist and able to get invalid change by bindable.
+    /// </summary>
+    public class LyricCheckerManager : Component
+    {
+        public BindableDictionary<Lyric, LyricCheckReport> BindableReports = new BindableDictionary<Lyric, LyricCheckReport>();
+
+        private LyricChecker lyricChecker;
+
+        public void CheckLyrics(List<Lyric> lyrics, LyricCheckProperty checkProperty = LyricCheckProperty.All)
+        {
+            if (lyrics == null)
+                throw new ArgumentNullException(nameof(lyrics));
+
+            if (lyricChecker == null)
+                throw new NullReferenceException(nameof(lyricChecker));
+
+            // re-calculate and add
+            foreach (var lyric in lyrics)
+            {
+                var report = lyricChecker.CheckLyric(lyric);
+
+                if (BindableReports.Contains(lyric))
+                {
+                    BindableReports[lyric] = report;
+                }
+                else
+                {
+                    BindableReports.Add(lyric, report);
+                }
+            }
+        }
+
+        public void CheckLyric(Lyric lyric, LyricCheckProperty checkProperty = LyricCheckProperty.All)
+            => CheckLyrics(new List<Lyric> { lyric }, checkProperty);
+
+        protected void RemoveFromCheckList(Lyric lyric)
+            => BindableReports.Remove(lyric);
+
+        [BackgroundDependencyLoader]
+        private void load(EditorBeatmap beatmap, KaraokeRulesetEditCheckerConfigManager rulesetEditCheckerConfigManager)
+        {
+            var config = rulesetEditCheckerConfigManager.Get<LyricCheckerConfig>(KaraokeRulesetEditCheckerSetting.Lyric);
+            lyricChecker = new LyricChecker(config);
+
+            // load lyric in here
+            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
+            CheckLyrics(lyrics);
+
+            // need to check is there any lyric added or removed.
+            beatmap.HitObjectAdded += e =>
+            {
+                if (e is Lyric lyric)
+                    CheckLyric(lyric);
+            };
+            beatmap.HitObjectRemoved += e =>
+            {
+                if (e is Lyric lyric)
+                    RemoveFromCheckList(lyric);
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/Types/IHasConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/Types/IHasConfig.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checker.Types
+{
+    public interface IHasConfig<out T> where T : new()
+    {
+        public T CreateDefaultConfig();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
+{
+    public class InvalidLyricToolTip : BackgroundToolTip
+    {
+        private readonly OsuTextFlowContainer invalidMessage;
+
+        [Resolved]
+        private LyricInvalidChecker lyricInvalidChecker { get; set; }
+
+        public InvalidLyricToolTip()
+        {
+            AutoSizeAxes = Axes.Y;
+            Width = 300;
+
+            Child = invalidMessage = new OsuTextFlowContainer(s => s.Font = s.Font.With(size: 14))
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Colour = Color4.White.Opacity(0.75f),
+                Name = "Invalid message",
+            };
+        }
+
+        public override bool SetContent(object content)
+        {
+            if (!(content is Lyric lyric))
+                return false;
+
+            // clear exist warning.
+            invalidMessage.Text = "";
+
+            // Check time
+            if (lyricInvalidChecker.InvalidLyricTime(lyric))
+                invalidMessage.AddParagraph("Invalid lyric time");
+
+            // Check time-tag
+            if (lyricInvalidChecker.CheckInvalidTimeTagTime(lyric).Any())
+                invalidMessage.AddParagraph("Invalid time-tag");
+
+            // Check ruby
+            if (lyricInvalidChecker.CheckInvalidRubyRange(lyric).Any())
+                invalidMessage.AddParagraph("Invalid ruby position.");
+            if (lyricInvalidChecker.CheckOverlappingRubyPosition(lyric).Any())
+                invalidMessage.AddParagraph("Invalid ruby overlapping.");
+
+            // romaji
+            if (lyricInvalidChecker.CheckInvalidRomajiRange(lyric).Any())
+                invalidMessage.AddParagraph("Invalid romaji position.");
+            if (lyricInvalidChecker.CheckOverlappingRomajiPosition(lyric).Any())
+                invalidMessage.AddParagraph("Invalid romaji overlapping.");
+
+            // show no problem message
+            if(!invalidMessage.FlowingChildren.Any())
+                invalidMessage.AddParagraph("Seems no issue in this lyric.");
+
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -2,13 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
@@ -16,9 +14,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
     public class InvalidLyricToolTip : BackgroundToolTip
     {
         private readonly OsuTextFlowContainer invalidMessage;
-
-        [Resolved]
-        private LyricChecker lyricChecker { get; set; }
 
         public InvalidLyricToolTip()
         {
@@ -36,31 +31,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
         public override bool SetContent(object content)
         {
-            if (!(content is Lyric lyric))
+            if (!(content is LyricCheckReport report))
                 return false;
 
             // clear exist warning.
             invalidMessage.Text = "";
 
             // Check time
-            if (lyricChecker.InvalidLyricTime(lyric))
+            if (report.TimeInvalid)
                 invalidMessage.AddParagraph("Invalid lyric time");
 
             // Check time-tag
-            if (lyricChecker.CheckInvalidTimeTagTime(lyric).Any())
+            if (report.InvalidTimeTag?.Any() ?? false)
                 invalidMessage.AddParagraph("Invalid time-tag");
 
             // Check ruby
-            if (lyricChecker.CheckInvalidRubyRange(lyric).Any())
+            if (report.InvalidRubyTag?.Any() ?? false)
                 invalidMessage.AddParagraph("Invalid ruby position.");
-            if (lyricChecker.CheckOverlappingRubyPosition(lyric).Any())
-                invalidMessage.AddParagraph("Invalid ruby overlapping.");
 
             // romaji
-            if (lyricChecker.CheckInvalidRomajiRange(lyric).Any())
+            if (report.InvalidRomajiTag?.Any() ?? false)
                 invalidMessage.AddParagraph("Invalid romaji position.");
-            if (lyricChecker.CheckOverlappingRomajiPosition(lyric).Any())
-                invalidMessage.AddParagraph("Invalid romaji overlapping.");
 
             // show no problem message
             if(!invalidMessage.FlowingChildren.Any())

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
@@ -37,27 +37,72 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             // clear exist warning.
             invalidMessage.Text = "";
 
-            // Check time
-            if (report.TimeInvalid)
-                invalidMessage.AddParagraph("Invalid lyric time");
+            // Print time invalid message
+            createTimeInvalidMessage(report.TimeInvalid);
 
-            // Check time-tag
-            if (report.InvalidTimeTag?.Any() ?? false)
-                invalidMessage.AddParagraph("Invalid time-tag");
+            // Print time-tag invalid message
+            foreach (var invalidTimeTags in report.InvalidTimeTags)
+            {
+                createTimeTagInvalidMessage(invalidTimeTags.Key, invalidTimeTags.Value);
+            }
 
-            // Check ruby
-            if (report.InvalidRubyTag?.Any() ?? false)
-                invalidMessage.AddParagraph("Invalid ruby position.");
+            // Print ruby invalid message
+            foreach (var invalidRubyTags in report.InvalidRubyTags)
+            {
+                createRubyInvalidMessage(invalidRubyTags.Key, invalidRubyTags.Value);
+            }
 
-            // romaji
-            if (report.InvalidRomajiTag?.Any() ?? false)
-                invalidMessage.AddParagraph("Invalid romaji position.");
+            // Print romaji invalid message
+            foreach (var invalidRomajiTags in report.InvalidRomajiTags)
+            {
+                createRomajiInvalidMessage(invalidRomajiTags.Key, invalidRomajiTags.Value);
+            }
 
             // show no problem message
-            if(!invalidMessage.FlowingChildren.Any())
+            if(report.IsValid)
                 invalidMessage.AddParagraph("Seems no issue in this lyric.");
 
             return true;
+
+            void createTimeInvalidMessage(TimeInvalid timeInvalid)
+            {
+                switch (timeInvalid)
+                {
+                    case TimeInvalid.Overlapping:
+                        invalidMessage.AddParagraph("Invalid lyric time");
+                        break;
+                }
+            }
+
+            void createTimeTagInvalidMessage(TimeTagInvalid invalid, TimeTag[] timeTags)
+            {
+                switch (invalid)
+                {
+                    case TimeTagInvalid.OutOfRange:
+                        invalidMessage.AddParagraph("Invalid time-tag");
+                        break;
+                }
+            }
+
+            void createRubyInvalidMessage(RubyTagInvalid invalid, RubyTag[] rubyTags)
+            {
+                switch (invalid)
+                {
+                    case RubyTagInvalid.OutOfRange:
+                        invalidMessage.AddParagraph("Invalid ruby-tag");
+                        break;
+                }
+            }
+
+            void createRomajiInvalidMessage(RomajiTagInvalid invalid, RomajiTag[] romajiTags)
+            {
+                switch (invalid)
+                {
+                    case RomajiTagInvalid.OutOfRange:
+                        invalidMessage.AddParagraph("Invalid tiromajime-tag");
+                        break;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -72,7 +72,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
                 switch (timeInvalid)
                 {
                     case TimeInvalid.Overlapping:
-                        invalidMessage.AddParagraph("Invalid lyric time");
+                        invalidMessage.AddParagraph("Check is start time larger then end time in lyric.");
+                        break;
+
+                    case TimeInvalid.StartTimeInvalid:
+                        invalidMessage.AddParagraph("Check start time is larger than minimux time tag's time.");
+                        break;
+
+                    case TimeInvalid.EndTimeInvalid:
+                        invalidMessage.AddParagraph("Check end time is smaller than maximum time tag's time.");
                         break;
                 }
             }
@@ -82,7 +90,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
                 switch (invalid)
                 {
                     case TimeTagInvalid.OutOfRange:
-                        invalidMessage.AddParagraph("Invalid time-tag");
+                        invalidMessage.AddParagraph("Seems some time tag is out of lyric text size.");
+                        break;
+
+                    case TimeTagInvalid.Overlapping:
+                        invalidMessage.AddParagraph("Seems some time tag is invalid.");
                         break;
                 }
             }
@@ -92,7 +104,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
                 switch (invalid)
                 {
                     case RubyTagInvalid.OutOfRange:
-                        invalidMessage.AddParagraph("Invalid ruby-tag");
+                        invalidMessage.AddParagraph("Seems some ruby tag is out of lyric text size.");
+                        break;
+
+                    case RubyTagInvalid.Overlapping:
+                        invalidMessage.AddParagraph("Seems some ruby tag is overlapping to others.");
                         break;
                 }
             }
@@ -102,7 +118,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
                 switch (invalid)
                 {
                     case RomajiTagInvalid.OutOfRange:
-                        invalidMessage.AddParagraph("Invalid tiromajime-tag");
+                        invalidMessage.AddParagraph("Seems some romaji tag is out of lyric text size.");
+                        break;
+
+                    case RomajiTagInvalid.Overlapping:
+                        invalidMessage.AddParagraph("Seems some romaji tag is overlapping to others.");
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -38,7 +38,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             invalidMessage.Text = "";
 
             // Print time invalid message
-            createTimeInvalidMessage(report.TimeInvalid);
+            foreach (var invalid in report.TimeInvalid)
+            {
+                createTimeInvalidMessage(invalid);
+            }
 
             // Print time-tag invalid message
             foreach (var invalidTimeTags in report.InvalidTimeTags)

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -6,7 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
         private readonly OsuTextFlowContainer invalidMessage;
 
         [Resolved]
-        private LyricInvalidChecker lyricInvalidChecker { get; set; }
+        private LyricChecker lyricChecker { get; set; }
 
         public InvalidLyricToolTip()
         {
@@ -43,23 +43,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             invalidMessage.Text = "";
 
             // Check time
-            if (lyricInvalidChecker.InvalidLyricTime(lyric))
+            if (lyricChecker.InvalidLyricTime(lyric))
                 invalidMessage.AddParagraph("Invalid lyric time");
 
             // Check time-tag
-            if (lyricInvalidChecker.CheckInvalidTimeTagTime(lyric).Any())
+            if (lyricChecker.CheckInvalidTimeTagTime(lyric).Any())
                 invalidMessage.AddParagraph("Invalid time-tag");
 
             // Check ruby
-            if (lyricInvalidChecker.CheckInvalidRubyRange(lyric).Any())
+            if (lyricChecker.CheckInvalidRubyRange(lyric).Any())
                 invalidMessage.AddParagraph("Invalid ruby position.");
-            if (lyricInvalidChecker.CheckOverlappingRubyPosition(lyric).Any())
+            if (lyricChecker.CheckOverlappingRubyPosition(lyric).Any())
                 invalidMessage.AddParagraph("Invalid ruby overlapping.");
 
             // romaji
-            if (lyricInvalidChecker.CheckInvalidRomajiRange(lyric).Any())
+            if (lyricChecker.CheckInvalidRomajiRange(lyric).Any())
                 invalidMessage.AddParagraph("Invalid romaji position.");
-            if (lyricInvalidChecker.CheckOverlappingRomajiPosition(lyric).Any())
+            if (lyricChecker.CheckOverlappingRomajiPosition(lyric).Any())
                 invalidMessage.AddParagraph("Invalid romaji overlapping.");
 
             // show no problem message

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -47,6 +47,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly KaraokeRulesetEditGeneratorConfigManager generatorConfigManager;
 
         [Cached]
+        private readonly KaraokeRulesetEditCheckerConfigManager checkerConfigManager;
+
+        [Cached]
         private readonly ExportLyricManager exportLyricManager;
 
         [Cached]
@@ -56,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly LyricManager lyricManager;
 
         [Cached]
-        private readonly LyricChecker lyricChecker;
+        private readonly LyricCheckerManager lyricCheckerManager;
 
         [Cached]
         private readonly SingerManager singerManager;
@@ -74,11 +77,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             positionCalculator = new PositionCalculator(9);
             editConfigManager = new KaraokeRulesetEditConfigManager();
             generatorConfigManager = new KaraokeRulesetEditGeneratorConfigManager();
+            checkerConfigManager = new KaraokeRulesetEditCheckerConfigManager();
 
             AddInternal(exportLyricManager = new ExportLyricManager());
             AddInternal(noteManager = new NoteManager());
             AddInternal(lyricManager = new LyricManager());
-            AddInternal(lyricChecker = new LyricChecker());
+            AddInternal(lyricCheckerManager = new LyricCheckerManager());
             AddInternal(singerManager = new SingerManager());
             LayerBelowRuleset.Add(new KaraokeLyricEditor(ruleset)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -55,6 +55,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly LyricManager lyricManager;
 
         [Cached]
+        private readonly LyricInvalidChecker lyricInvalidChecker;
+
+        [Cached]
         private readonly SingerManager singerManager;
 
         [Cached]
@@ -74,6 +77,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(exportLyricManager = new ExportLyricManager());
             AddInternal(noteManager = new NoteManager());
             AddInternal(lyricManager = new LyricManager());
+            AddInternal(lyricInvalidChecker = new LyricInvalidChecker());
             AddInternal(singerManager = new SingerManager());
             LayerBelowRuleset.Add(new KaraokeLyricEditor(ruleset)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Menu;
 using osu.Game.Rulesets.Karaoke.Edit.Export;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
@@ -55,7 +56,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly LyricManager lyricManager;
 
         [Cached]
-        private readonly LyricInvalidChecker lyricInvalidChecker;
+        private readonly LyricChecker lyricChecker;
 
         [Cached]
         private readonly SingerManager singerManager;
@@ -77,7 +78,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(exportLyricManager = new ExportLyricManager());
             AddInternal(noteManager = new NoteManager());
             AddInternal(lyricManager = new LyricManager());
-            AddInternal(lyricInvalidChecker = new LyricInvalidChecker());
+            AddInternal(lyricChecker = new LyricChecker());
             AddInternal(singerManager = new SingerManager());
             LayerBelowRuleset.Add(new KaraokeLyricEditor(ruleset)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -56,10 +56,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
                         Icon = FontAwesome.Solid.TimesCircle;
                         Colour = colours.Red;
                         break;
+
                     default:
                         throw new IndexOutOfRangeException(nameof(report.IsValid));
                 }
-
             }, true);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
 
                     case false:
                         Icon = FontAwesome.Solid.TimesCircle;
-                        Colour = colours.Green;
+                        Colour = colours.Red;
                         break;
                     default:
                         throw new IndexOutOfRangeException(nameof(report.IsValid));

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
+{
+    public class InvalidInfo : SpriteIcon, IHasContextMenu, IHasCustomTooltip
+    {
+        [Resolved]
+        private LyricInvalidChecker lyricInvalidChecker { get; set; }
+
+        // todo : might able to have auto-fix option by right-click
+        public MenuItem[] ContextMenuItems => null;
+
+        public object TooltipContent => lyric;
+
+        private readonly Lyric lyric;
+
+        public InvalidInfo(Lyric lyric)
+        {
+            this.lyric = lyric;
+
+            Size = new Vector2(12);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            // todo : should be able to get bindable state by 
+            Icon = FontAwesome.Solid.CheckCircle;
+            Colour = colours.Green;
+        }
+
+        public ITooltip GetCustomTooltip()
+            => new InvalidLyricToolTip();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Checker.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
     public class InvalidInfo : SpriteIcon, IHasContextMenu, IHasCustomTooltip
     {
         [Resolved]
-        private LyricInvalidChecker lyricInvalidChecker { get; set; }
+        private LyricChecker lyricChecker { get; set; }
 
         // todo : might able to have auto-fix option by right-click
         public MenuItem[] ContextMenuItems => null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
@@ -90,6 +90,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos
                                         Spacing = new Vector2(5),
                                         Children = new Drawable[]
                                         {
+                                            new InvalidInfo(lyric),
                                             new OrderInfo(lyric),
                                             new LockInfo(lyric),
                                         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Configuration;
@@ -21,6 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public Lyric[] InvalidTimeLyrics()
         {
+            // todo : implement.
             return null;
         }
 
@@ -30,11 +30,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             return false;
         }
 
-        public TimeTag[] FindInvalidTimeTagTime(Lyric lyric)
+        public TimeTag[] CheckInvalidTimeTagTime(Lyric lyric)
         {
-            // todo : apply config
-            var groupCheck = GroupCheck.Asc;
-            var selfCheck = SelfCheck.BasedOnStart;
+            var groupCheck = configManager.Get<GroupCheck>(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeGroupCheck);
+            var selfCheck = configManager.Get<SelfCheck>(KaraokeRulesetEditSetting.CheckInvalidTimeTagTimeSelfCheck);
             return TimeTagsUtils.FindInvalid(lyric.TimeTags, groupCheck, selfCheck);
         }
 
@@ -45,8 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public RubyTag[] CheckOverlappingRubyPosition(Lyric lyric)
         {
-            // todo : apply config
-            var sorting = TextTagsUtils.Sorting.Asc;
+            var sorting = configManager.Get<TextTagsUtils.Sorting>(KaraokeRulesetEditSetting.CheckRubyPositionSorting);
             return TextTagsUtils.FindOverlapping(lyric.RubyTags, sorting);
         }
 
@@ -57,8 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public RomajiTag[] CheckOverlappingRomajiPosition(Lyric lyric)
         {
-            // todo : apply config
-            var sorting = TextTagsUtils.Sorting.Asc;
+            var sorting = configManager.Get<TextTagsUtils.Sorting>(KaraokeRulesetEditSetting.CheckRomajiPositionSorting);
             return TextTagsUtils.FindOverlapping(lyric.RomajiTags, sorting);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
@@ -25,32 +26,40 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public bool InvalidLyricTime(Lyric lyric)
         {
+            // todo : apply utils with enum key.
             return false;
         }
 
-        public KeyValuePair<TimeTag, double>[] FindInvalidTimeTagTime(Lyric lyric)
+        public TimeTag[] FindInvalidTimeTagTime(Lyric lyric)
         {
-            return null;
+            // todo : apply config
+            var groupCheck = GroupCheck.Asc;
+            var selfCheck = SelfCheck.BasedOnStart;
+            return TimeTagsUtils.FindInvalid(lyric.TimeTags, groupCheck, selfCheck);
         }
 
         public RubyTag[] CheckInvalidRubyRange(Lyric lyric)
         {
-            return null;
+            return TextTagsUtils.FindOutOfRange(lyric.RubyTags, lyric.Text);
         }
 
-        public RubyTag[] CheckDuplicatedRubyPosition(Lyric lyric)
+        public RubyTag[] CheckOverlappingRubyPosition(Lyric lyric)
         {
-            return null;
+            // todo : apply config
+            var sorting = TextTagsUtils.Sorting.Asc;
+            return TextTagsUtils.FindOverlapping(lyric.RubyTags, sorting);
         }
 
         public RomajiTag[] CheckInvalidRomajiRange(Lyric lyric)
         {
-            return null;
+            return TextTagsUtils.FindOutOfRange(lyric.RomajiTags, lyric.Text);
         }
 
-        public RomajiTag[] CheckDuplicatedRomajiPosition(Lyric lyric)
+        public RomajiTag[] CheckOverlappingRomajiPosition(Lyric lyric)
         {
-            return null;
+            // todo : apply config
+            var sorting = TextTagsUtils.Sorting.Asc;
+            return TextTagsUtils.FindOverlapping(lyric.RomajiTags, sorting);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricInvalidChecker.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
+{
+    public class LyricInvalidChecker : Component
+    {
+        [Resolved]
+        private KaraokeRulesetEditConfigManager configManager { get; set; }
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
+
+        public Lyric[] InvalidTimeLyrics()
+        {
+            return null;
+        }
+
+        public bool InvalidLyricTime(Lyric lyric)
+        {
+            return false;
+        }
+
+        public KeyValuePair<TimeTag, double>[] FindInvalidTimeTagTime(Lyric lyric)
+        {
+            return null;
+        }
+
+        public RubyTag[] CheckInvalidRubyRange(Lyric lyric)
+        {
+            return null;
+        }
+
+        public RubyTag[] CheckDuplicatedRubyPosition(Lyric lyric)
+        {
+            return null;
+        }
+
+        public RomajiTag[] CheckInvalidRomajiRange(Lyric lyric)
+        {
+            return null;
+        }
+
+        public RomajiTag[] CheckDuplicatedRomajiPosition(Lyric lyric)
+        {
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
@@ -13,8 +13,15 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             Time = time;
         }
 
+        /// <summary>
+        /// Time tag's index.
+        /// Notice that this index means index of characters.
+        /// </summary>
         public TextIndex Index { get; }
 
+        /// <summary>
+        /// Time
+        /// </summary>
         public double? Time { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/ITextTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/ITextTag.cs
@@ -5,8 +5,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Types
 {
     public interface ITextTag : IHasText
     {
+        /// <summary>
+        /// Start index, this index means gap index between characters.
+        /// </summary>
         int StartIndex { get; set; }
 
+        /// <summary>
+        /// End index, this index means gap index between characters.
+        /// </summary>
         int EndIndex { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/ITextTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/ITextTag.cs
@@ -6,12 +6,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Types
     public interface ITextTag : IHasText
     {
         /// <summary>
-        /// Start index, this index means gap index between characters.
+        /// Start index.
+        /// Notice that this index means gap index between characters.
         /// </summary>
         int StartIndex { get; set; }
 
         /// <summary>
-        /// End index, this index means gap index between characters.
+        /// End index
+        /// Notice this this index means gap index between characters.
         /// </summary>
         int EndIndex { get; set; }
     }

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -254,5 +254,45 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         #endregion
+
+        #region Check
+
+        /// <summary>
+        /// Check start time is larger than end time.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        public static bool CheckIsTimeOverlapping(Lyric lyric)
+        {
+            return lyric.StartTime > lyric.EndTime;
+        }
+
+        /// <summary>
+        /// Start time should be smaller than any time-tag.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        public static bool CheckIsStartTimeInvalid(Lyric lyric)
+        {
+            if (lyric.TimeTags == null || lyric.TimeTags.Length == 0)
+                return false;
+
+            return lyric.StartTime > lyric.TimeTags.Min(x => x.Time);
+        }
+
+        /// <summary>
+        /// End time should be larger than any time-tag.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        public static bool CheckIsEndTimeInvalid(Lyric lyric)
+        {
+            if (lyric.TimeTags == null || lyric.TimeTags.Length == 0)
+                return false;
+
+            return lyric.EndTime < lyric.TimeTags.Max(x => x.Time);
+        }
+
+        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagsUtils.cs
@@ -25,7 +25,12 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             }
         }
 
-        public static T[] FindInvalid<T>(T[] textTags, string lyric, Sorting sorting = Sorting.Asc) where T : ITextTag
+        public static T[] FindOutOfRange<T>(T[] textTags, string lyric) where T : ITextTag
+        {
+            return textTags?.Where(x => x.StartIndex < 0 || x.EndIndex > lyric.Length).ToArray();
+        }
+
+        public static T[] FindOverlapping<T>(T[] textTags, Sorting sorting = Sorting.Asc) where T : ITextTag
         {
             // check is null or empty
             if (textTags == null || textTags.Length == 0)
@@ -35,9 +40,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             var sortedTextTags = Sort(textTags, sorting);
 
             var invalidList = new List<T>();
-
-            // check invalid range
-            invalidList.AddRange(sortedTextTags.Where(x => x.StartIndex < 0 || x.EndIndex > lyric.Length));
 
             // check end is less or equal to start index
             invalidList.AddRange(sortedTextTags.Where(x => x.EndIndex <= x.StartIndex));

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -64,6 +64,17 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         /// <summary>
+        /// Find out of range time-tag.
+        /// </summary>
+        /// <param name="timeTags"></param>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        public static TimeTag[] FindOutOfRange(TimeTag[] timeTags, string lyric)
+        {
+            return timeTags?.Where(x => x.Index.Index < 0 || x.Index.Index >= lyric.Length).ToArray();
+        }
+
+        /// <summary>
         /// Find invalid time tags.
         /// </summary>
         /// <param name="timeTags">Time tags</param>


### PR DESCRIPTION
This is the first implementation of #412 

What's been done in this PR:
- [x] Check listed invalid property in #412
- [x] Enable to find invalid reason by flag.
- [x] Has report to record checking result.
- [x] Enable to call for update checking(and support partial update).
- [x] Test case for checking class.
- [x] Have tooltip(alert message in this PR).
- [x] Place this icon into lyric editor. 

What's should be done in next PR:
- Update invalid style in lyric.
- Should trigger update check after lyric property changed(need to think about where to call).
- apply auto-fix by right-click.
- Tooltip should be able to target index.
- Tooltip should be more colorful(might create `InvalidMessageTextFlowContainer` with method to handle that with `OK`, `Warning`, and `Alert` state)
- Adjust check icon position.