### PR TITLE
Implement combine and separate lyric in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Bindables/BindableDictionaryTest.cs
@@ -94,7 +94,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
         public void TestBindCollectionChangedWithRunImmediately()
         {
             var dictionary = new BindableDictionary<int, string>();
@@ -149,7 +148,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
         public void TestSetNotifiesSubscribers()
         {
             bindableStringDictionary.Add(0, "0");
@@ -160,14 +158,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
             bindableStringDictionary[0] = "1";
 
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
-            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo("0".Yield()));
-            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo("1".Yield()));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<int, string>(0, "0").Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<int, string>(0, "1").Yield()));
             Assert.That(triggeredArgs.OldStartingIndex, Is.Zero);
             Assert.That(triggeredArgs.NewStartingIndex, Is.Zero);
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
         public void TestSetNotifiesBoundLists()
         {
             bindableStringDictionary.Add(0, "0");
@@ -181,8 +178,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
             bindableStringDictionary[0] = "1";
 
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
-            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo("0".Yield()));
-            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo("1".Yield()));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<int, string>(0, "0").Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<int, string>(0, "1").Yield()));
             Assert.That(triggeredArgs.OldStartingIndex, Is.Zero);
             Assert.That(triggeredArgs.NewStartingIndex, Is.Zero);
         }
@@ -372,7 +369,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
         public void TestRemoveNotifiesSubscriber()
         {
             const int key = 0;
@@ -385,7 +381,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
             bindableStringDictionary.Remove(key);
 
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
-            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(item));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(new KeyValuePair<int, string>(key, item)));
             Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
@@ -481,7 +477,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
         public void TestRemoveNotifiesBoundListSubscription()
         {
             const int key = 0;
@@ -496,7 +491,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
             bindableStringDictionary.Remove(key);
 
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
-            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(item));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(new KeyValuePair<int, string>(key, item)));
             Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
@@ -891,7 +886,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
         }
 
         [Test]
-        [Ignore("Dictionary does not have index.")]
+        [Ignore("Not sure parse in dictionary should add single or add multi at the same step.")]
         public void TestParseWithItemsNotifiesAddRangeAndClearSubscribers()
         {
             bindableStringDictionary.Add(0, "test123");
@@ -904,7 +899,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Bindables
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(2));
             Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
-            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo("test123".Yield()));
+            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(new KeyValuePair<int, string>(0, "test123").Yield()));
             Assert.That(triggeredArgs.First().OldStartingIndex, Is.EqualTo(0));
             Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
             Assert.That(triggeredArgs.ElementAt(1).NewItems, Is.EquivalentTo(dictionary));

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/OrderUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/OrderUtilsTest.cs
@@ -57,6 +57,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(result, actualOrders);
         }
 
+        [TestCase(new[] { 1, 2, 3, 4 }, 1, new[] { 2, 3, 4, 5 })]
+        [TestCase(new[] { 1, 2, 3, 4 }, -1, new[] { 0, 1, 2, 3 })]
+        [TestCase(new[] { 1, 1, 1, 1 }, 1, new[] { 2, 2, 2, 2 })]
+        [TestCase(new[] { 4, 3, 2, 1 }, 1, new[] { 5, 4, 3, 2 })] // Not care order in objects and just doing shifting job.
+        public void TestShiftingOrder(int[] orders, int shifting, int[] newOrder)
+        {
+            var objects = orders?.Select(x => new TestOrderObject { Order = x }).ToArray();
+            OrderUtils.ShiftingOrder(objects, shifting);
+
+            // convert order result.
+            var result = objects?.Select(x => x.Order).ToArray();
+            Assert.AreEqual(result, newOrder);
+        }
+
         [TestCase(new[] { 1, 2, 3, 4 }, 1, new int[] { }, new[] { 1, 2, 3, 4 })]
         [TestCase(new[] { 1, 2, 3, 4 }, -1, new[] { 1, 2, 3, 4 }, new[] { -1, 0, 1, 2 })]
         [TestCase(new[] { 1, 2, 3, 4 }, 3, new[] { 4, 3, 2, 1 }, new[] { 3, 4, 5, 6 })] // change id should consider will affect exist mapping.
@@ -73,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 movingStepResult.Add(o);
             });
 
-            // change order result.
+            // convert order result.
             var result = objects?.Select(x => x.Order).ToArray();
             Assert.AreEqual(result, newOrder);
 

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
@@ -86,7 +86,9 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, item, lastItem));
+            var oldDictionary = new Dictionary<TKey, TValue> { { index, item } };
+            var newDictionary = new Dictionary<TKey, TValue> { { index, lastItem } };
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, oldDictionary, newDictionary));
         }
 
         /// <summary>
@@ -123,7 +125,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, collection.Count - 1));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new Dictionary<TKey, TValue> { { item.Key, item.Value } }, collection.Count - 1));
         }
 
         /// <summary>
@@ -156,7 +158,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems, 0));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems.ToDictionary(k => k.Key, v => v.Value), 0));
         }
 
         /// <summary>
@@ -208,7 +210,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, listItem));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new Dictionary<TKey, TValue> { { key, listItem } }));
 
             return true;
         }

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
@@ -86,9 +86,10 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            var oldDictionary = new Dictionary<TKey, TValue> { { index, item } };
-            var newDictionary = new Dictionary<TKey, TValue> { { index, lastItem } };
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, oldDictionary, newDictionary));
+            var oldItem = new KeyValuePair<TKey, TValue>(index, item);
+            var newItem = new KeyValuePair<TKey, TValue>(index, lastItem);
+            var keyIndex = Keys.ToList().IndexOf(index);
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, oldItem, newItem, keyIndex));
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new Dictionary<TKey, TValue> { { item.Key, item.Value } }, collection.Count - 1));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(item.Key, item.Value), collection.Count - 1));
         }
 
         /// <summary>
@@ -158,7 +159,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems.ToDictionary(k => k.Key, v => v.Value), 0));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems, 0));
         }
 
         /// <summary>
@@ -196,6 +197,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
             // Removal may have come from an equality comparison.
             // Always return the original reference from the list to other bindings and events.
             var listItem = collection[key];
+            var index = Keys.ToList().IndexOf(key); ;
 
             collection.Remove(key);
 
@@ -210,7 +212,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
                 }
             }
 
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new Dictionary<TKey, TValue> { { key, listItem } }));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new KeyValuePair<TKey, TValue>(key, listItem), index));
 
             return true;
         }
@@ -440,7 +442,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
         {
             CollectionChanged += onChange;
             if (runOnceImmediately)
-                onChange(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection));
+                onChange(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection.ToList()));
         }
 
         private void addWeakReference(WeakReference<BindableDictionary<TKey, TValue>> weakReference)

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableDictionary.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
             // Removal may have come from an equality comparison.
             // Always return the original reference from the list to other bindings and events.
             var listItem = collection[key];
-            var index = Keys.ToList().IndexOf(key); ;
+            var index = Keys.ToList().IndexOf(key);
 
             collection.Remove(key);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
         {
             lyricCheckerManager.BindableReports.BindCollectionChanged((i, args) =>
             {
+                if (args.NewItems == null)
+                    return;
+
                 var dict = args.NewItems.Cast<Dictionary<Lyric, LyricCheckReport>>().FirstOrDefault();
                 if (!dict.ContainsKey(lyric))
                     return;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/FixedInfo/InvalidInfo.cs
@@ -38,10 +38,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
         {
             lyricCheckerManager.BindableReports.BindCollectionChanged((i, args) =>
             {
+                // Ignore remove case
                 if (args.NewItems == null)
                     return;
 
-                var dict = args.NewItems.Cast<Dictionary<Lyric, LyricCheckReport>>().FirstOrDefault();
+                var dict = args.NewItems.Cast<KeyValuePair<Lyric, LyricCheckReport>>().ToDictionary(k => k.Key, v => v.Value);
                 if (!dict.ContainsKey(lyric))
                     return;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos
                     new OsuMenuItem("Create new lyric", MenuItemType.Standard, () =>
                     {
                         // add new lyric with below of current lyric.
-                        var targetOrder = Lyric.Order + 1;
+                        var targetOrder = Lyric.Order;
                         lyricManager.CreateLyric(targetOrder);
                     }),
                     new OsuMenuItem("Delete", MenuItemType.Destructive, () =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
@@ -224,7 +224,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos
                     }
                 }));
 
-
                 return menuItems.ToArray();
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Infos/InfoControl.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -187,31 +188,44 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos
                 if (bindableMode.Value != Mode.EditMode)
                     return null;
 
-                return new MenuItem[]
+                var menuItems = new List<MenuItem>
                 {
                     new OsuMenuItem("Create new lyric", MenuItemType.Standard, () =>
                     {
-                        // add new lyric with below of current lyric.
-                        var targetOrder = Lyric.Order;
+                    // add new lyric with below of current lyric.
+                    var targetOrder = Lyric.Order;
                         lyricManager.CreateLyric(targetOrder);
-                    }),
-                    new OsuMenuItem("Delete", MenuItemType.Destructive, () =>
-                    {
-                        if (dialogOverlay == null)
-                        {
-                            // todo : remove lyric directly in test case because pop-up dialog is not registered.
-                            lyricManager.DeleteLyric(Lyric);
-                        }
-                        else
-                        {
-                            dialogOverlay.Push(new DeleteLyricDialog(isOk =>
-                            {
-                                if (isOk)
-                                    lyricManager.DeleteLyric(Lyric);
-                            }));
-                        }
-                    }),
+                    })
                 };
+
+                // use lazy way to check lyric is not in first
+                if (Lyric.Order > 1)
+                {
+                    menuItems.Add(new OsuMenuItem("Combine with previous lyric", MenuItemType.Standard, () =>
+                    {
+                        lyricManager.CombineWithPreviousLyric(Lyric);
+                    }));
+                }
+
+                menuItems.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () =>
+                {
+                    if (dialogOverlay == null)
+                    {
+                        // todo : remove lyric directly in test case because pop-up dialog is not registered.
+                        lyricManager.DeleteLyric(Lyric);
+                    }
+                    else
+                    {
+                        dialogOverlay.Push(new DeleteLyricDialog(isOk =>
+                        {
+                            if (isOk)
+                                lyricManager.DeleteLyric(Lyric);
+                        }));
+                    }
+                }));
+
+
+                return menuItems.ToArray();
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/LyricControl.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
 
             // todo : not really sure is ok to split time-tag by double click?
             // need to make an ux research.
-            var position = state.BindableHoverCaretPosition.Value;
+            var position = state.BindableCaretPosition.Value;
             if (position is TextCaretPosition textCaretPosition)
             {
                 lyricManager?.SplitLyric(Lyric, textCaretPosition.Index);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -82,7 +82,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 if (e is Lyric lyric)
                 {
-                    BindableLyrics.Add(lyric);
+                    var previousLyric = BindableLyrics.LastOrDefault(x => x.Order < lyric.Order);
+                    if (previousLyric != null)
+                    {
+                        var insertIndex = BindableLyrics.IndexOf(previousLyric) + 1;
+                        BindableLyrics.Insert(insertIndex, lyric);
+                    }
+                    else
+                    {
+                        // insert to first.
+                        BindableLyrics.Insert(0, lyric);
+                    }
+                    
                     createAlgorithmList();
                 }
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
@@ -119,6 +120,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             // Add those tho lyric and remove old one.
             beatmap.Add(secondLyric);
             beatmap.Add(firstLyric);
+            beatmap.Remove(lyric);
+
+            changeHandler?.EndChange();
+        }
+
+        public void CombineWithPreviousLyric(Lyric lyric)
+        {
+            var previousLyric = Lyrics.GetPrevious(lyric);
+            if (previousLyric == null)
+                throw new ArgumentNullException(nameof(previousLyric));
+
+            changeHandler?.BeginChange();
+
+            // Shifting order that order is larger than current lyric 
+            var lyricOrder = previousLyric.Order;
+            OrderUtils.ShiftingOrder(Lyrics.Where(x => x.Order > lyricOrder).ToArray(), -1);
+
+            var newLyric = LyricsUtils.CombineLyric(previousLyric, lyric);
+            newLyric.Order = lyricOrder;
+
+            // Add created lyric and remove old two.
+            beatmap.Add(newLyric);
+            beatmap.Remove(previousLyric);
             beatmap.Remove(lyric);
 
             changeHandler?.EndChange();

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
@@ -51,10 +51,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 
         public void DeleteSinger(Singer singer)
         {
+            // Shifting order that order is larger than current singer 
+            OrderUtils.ShiftingOrder(Singers.Where(x => x.Order > singer.Order).ToArray(), -1);
             Singers.Remove(singer);
-
-            // should re-sort order
-            OrderUtils.ResortOrder(Singers.ToArray());
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/OrderUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/OrderUtils.cs
@@ -64,6 +64,20 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         /// <summary>
+        /// Shifting order.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="objects"></param>
+        /// <param name="shifting"></param>
+        public static void ShiftingOrder<T>(T[] objects, int shifting) where T : IHasOrder
+        {
+            foreach (var processObject in objects)
+            {
+                processObject.Order += shifting;
+            }
+        }
+
+        /// <summary>
         /// Re-generate order number if has gap between two order number
         /// </summary>
         /// <example>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -83,6 +83,9 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <returns>List of invalid time tags</returns>
         public static TimeTag[] FindInvalid(TimeTag[] timeTags, GroupCheck other = GroupCheck.Asc, SelfCheck self = SelfCheck.BasedOnStart)
         {
+            if (timeTags == null)
+                return null;
+
             var sortedTimeTags = Sort(timeTags);
             var groupedTimeTags = sortedTimeTags.GroupBy(x => x.Index.Index);
 


### PR DESCRIPTION
What's done in this pr:
- Change behavior in `BindableDictionary`.
- Fix split lyric issue (need to disable `Add` in `SaitenVisualization`).
- Implement combine lyric (Might have lots of but can ignore now).