### PR TITLE
Fix cause error if move lyric time. 

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModAutoplay.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModAutoplay.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Replays;
 using osu.Game.Rulesets.Karaoke.UI;
@@ -21,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Mods
 
         public bool MicrophoneEnabled => false;
 
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "osu!7pupu" } },
             Replay = Replay = new KaraokeAutoGenerator((KaraokeBeatmap)beatmap).Generate(),
@@ -29,6 +31,10 @@ namespace osu.Game.Rulesets.Karaoke.Mods
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<KaraokeHitObject> drawableRuleset)
         {
+            // Got no idea why edit ruleset call this shit.
+            if (drawableRuleset is DrawableKaraokeEditRuleset)
+                return;
+
             base.ApplyToDrawableRuleset(drawableRuleset);
 
             if (!(drawableRuleset.Playfield is KaraokePlayfield karaokePlayfield))
@@ -37,6 +43,8 @@ namespace osu.Game.Rulesets.Karaoke.Mods
             var notePlayfield = karaokePlayfield.NotePlayfield;
             var frames = Replay.Frames.OfType<KaraokeReplayFrame>();
 
+            // for safty purpose should clear reply to make sure not cause crash if apply to ruleset runs more then one times.
+            notePlayfield.ClearReplay();
             foreach (var frame in frames)
             {
                 notePlayfield.AddReplay(frame);

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModAutoplayBySinger.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModAutoplayBySinger.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -17,6 +18,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Replays;
 using osu.Game.Rulesets.Karaoke.Resources.Fonts;
 using osu.Game.Rulesets.Karaoke.UI;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Users;
@@ -33,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Mods
 
         private Stream trackData;
 
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "karaoke!singer" } },
             Replay = Replay = new KaraokeAutoGeneratorBySinger((KaraokeBeatmap)beatmap, trackData).Generate(),

--- a/osu.Game.Rulesets.Karaoke/UI/Components/SaitenVisualization.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Components/SaitenVisualization.cs
@@ -131,6 +131,12 @@ namespace osu.Game.Rulesets.Karaoke.UI.Components
             }
         }
 
+        public void Clear()
+        {
+            frames.Clear();
+            ClearInternal();
+        }
+
         private float scrollLength;
 
         protected override void Update()

--- a/osu.Game.Rulesets.Karaoke/UI/NotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/NotePlayfield.cs
@@ -254,6 +254,11 @@ namespace osu.Game.Rulesets.Karaoke.UI
             base.OnNewDrawableHitObject(drawableHitObject);
         }
 
+        public void ClearReplay()
+        {
+            replaySaitenVisualization.Clear();
+        }
+
         public void AddReplay(KaraokeReplayFrame frame)
         {
             replaySaitenVisualization.Add(frame);


### PR DESCRIPTION
It's caused by editor will call `ApplyToDrawableRuleset` in `KaraokeModAutoplay`, which will send duplicated reply frame to editor.
Lazy way to fix issue #396 