### PR TITLE
Implement base preview component.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableFontUsage.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableFontUsage.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Framework.Bindables;
@@ -26,6 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Bindables
 
             var regex = new Regex(@"\b(?<key>font|family|weight|size|italics|fixedWidth)(?<op>[=]+)(?<value>("".*"")|(\S*))", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             var dictionary = regex.Matches(str).ToDictionary(k => k.Groups["key"].Value.ToLower(), v => v.Groups["value"].Value);
+
             if (dictionary.ContainsKey("font"))
             {
                 var font = dictionary["font"];

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Header.cs
@@ -12,9 +12,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
-using osu.Game.Screens;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Config

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
@@ -21,10 +22,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
         [Cached]
         private Bindable<SettingsSection> selectedSection = new Bindable<SettingsSection>();
 
+        [Cached]
+        private Bindable<SettingsSubsection> selectedSubsection = new Bindable<SettingsSubsection>();
+
         private readonly KaraokeConfigWaveContainer waves;
         private readonly Box background;
         private readonly KaraokeSettingsPanel settingsPanel;
         private readonly Header header;
+        private readonly Container previewArea;
 
         public KaraokeConfigScreen()
         {
@@ -45,6 +50,11 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                     {
                         Padding = new MarginPadding{ Left = SettingsPanel.WIDTH },
                     },
+                    previewArea = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Top = Header.HEIGHT, Left = SettingsPanel.WIDTH }
+                    }
                 }
             };
 
@@ -56,6 +66,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                 // prevent trigger secoll by config section.
                 if (settingsPanel.SectionsContainer.SelectedSection.Value != newSection)
                     settingsPanel.SectionsContainer.ScrollTo(newSection);
+            });
+
+            selectedSubsection.BindValueChanged(e =>
+            {
+                if (e.NewValue is KaraokeSettingsSubsection settingsSubsection)
+                {
+                    // todo : place preview component into here.
+                }
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
             {
                 if (e.NewValue is KaraokeSettingsSubsection settingsSubsection)
                 {
-                    // todo : place preview component into here.
+                    previewArea.Child = settingsSubsection.CreatePreview();
                 }
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                     settingsPanel = new KaraokeSettingsPanel(),
                     header = new Header
                     {
-                        Padding = new MarginPadding{ Left = SettingsPanel.WIDTH },
+                        Padding = new MarginPadding { Left = SettingsPanel.WIDTH },
                     },
                     previewArea = new Container
                     {
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                 var newSection = e.NewValue;
                 background.Delay(200).Then().FadeColour(colourProvider.GetBackgroundColour(newSection), 500);
 
-                // prevent trigger secoll by config section.
+                // prevent trigger scroll by config section.
                 if (settingsPanel.SectionsContainer.SelectedSection.Value != newSection)
                     settingsPanel.SectionsContainer.ScrollTo(newSection);
             });

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeConfigScreen.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Settings;
 using osu.Game.Screens;
@@ -72,6 +73,12 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
         {
             base.LoadComplete();
             waves.Show();
+        }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            // Prevent scroll event cause volume control appear.
+            return true;
         }
 
         private class KaraokeConfigWaveContainer : WaveContainer

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 
                 selectedSubsection.BindValueChanged(x =>
                 {
-                    var offset = 20;
+                    const int offset = 20;
                     var position = scrollContainer.GetChildPosInContent(x.NewValue);
                     background.MoveToY(position + offset, 50);
                     background.ResizeHeightTo(x.NewValue.DrawHeight, 100);

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 {
     public class KaraokeSettingsPanel : SettingsPanel
     {
+        public new KaraokeSettingsSectionsContainer SectionsContainer => (KaraokeSettingsSectionsContainer)base.SectionsContainer;
+
         protected override IEnumerable<SettingsSection> CreateSections() => new SettingsSection[]
         {
             new ConfigSection(),
@@ -83,6 +85,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                     background.Y = position + offset;
                     background.Height = x.NewValue.DrawHeight;
                 });
+            }
+
+            public new void ScrollTo(Drawable section)
+            {
+                base.ScrollTo(section);
+
+                // re-scroll to target place, not with weird spacing.
+                scrollContainer.ScrollTo(scrollContainer.GetChildPosInContent(section) - (FixedHeader?.BoundingBox.Height ?? 0));
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
@@ -6,6 +6,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Screens.Config.Sections;
 
@@ -19,6 +21,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
             new StyleSection(),
             new ScoringSection()
         };
+
+        protected override SettingsSectionsContainer CreateSettingsSections() => new KaraokeSettingsSectionsContainer();
 
         protected override Drawable CreateFooter() => new Container
         {
@@ -44,6 +48,42 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                 var colour = colourProvider.GetBackground3Colour(x.NewValue);
                 Background.Delay(200).Then().FadeColour(colour, 500);
             });
+        }
+
+        public class KaraokeSettingsSectionsContainer : SettingsSectionsContainer
+        {
+            private UserTrackingScrollContainer scrollContainer;
+            private Box background;
+
+            protected override UserTrackingScrollContainer CreateScrollContainer()
+                => scrollContainer = base.CreateScrollContainer();
+
+            [BackgroundDependencyLoader]
+            private void load(ConfigColourProvider colourProvider, Bindable<SettingsSection> selectedSection, Bindable<SettingsSubsection> selectedSubsection)
+            {
+                // create hove background.
+                scrollContainer.Add(background = new Box
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Colour = Colour4.Red,
+                    Depth = 1,
+                    Alpha = 0.3f
+                });
+
+                selectedSection.BindValueChanged(x =>
+                {
+                    var colour = colourProvider.GetBackgroundColour(x.NewValue);
+                    background.Delay(200).Then().FadeColour(colour, 500);
+                });
+
+                selectedSubsection.BindValueChanged(x =>
+                {
+                    var offset = 20;
+                    var position = scrollContainer.GetChildPosInContent(x.NewValue);
+                    background.Y = position + offset;
+                    background.Height = x.NewValue.DrawHeight;
+                });
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsPanel.cs
@@ -67,9 +67,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                 scrollContainer.Add(background = new Box
                 {
                     RelativeSizeAxes = Axes.X,
-                    Colour = Colour4.Red,
                     Depth = 1,
-                    Alpha = 0.3f
+                    Alpha = 0.6f
                 });
 
                 selectedSection.BindValueChanged(x =>
@@ -82,8 +81,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                 {
                     var offset = 20;
                     var position = scrollContainer.GetChildPosInContent(x.NewValue);
-                    background.Y = position + offset;
-                    background.Height = x.NewValue.DrawHeight;
+                    background.MoveToY(position + offset, 50);
+                    background.ResizeHeightTo(x.NewValue.DrawHeight, 100);
                 });
             }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSection.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
     {
         private const int margin = 20;
 
-        public KaraokeSettingsSection()
+        protected KaraokeSettingsSection()
         {
             Margin = new MarginPadding { Bottom = margin };
         }
@@ -25,7 +25,10 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 
             // set header box and text to target color.
             var headerBox = InternalChildren.FirstOrDefault();
-            var title = (InternalChildren.LastOrDefault() as Container).Children?.FirstOrDefault();
+            var title = (InternalChildren.LastOrDefault() as Container)?.Children?.FirstOrDefault();
+            if (headerBox == null || title == null)
+                return;
+
             headerBox.Colour = colour;
             title.Colour = colour;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSection.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Settings;
 
@@ -10,6 +11,13 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 {
     public abstract class KaraokeSettingsSection : SettingsSection
     {
+        private const int margin = 20;
+
+        public KaraokeSettingsSection()
+        {
+            Margin = new MarginPadding { Bottom = margin };
+        }
+
         [BackgroundDependencyLoader]
         private void load(ConfigColourProvider colourProvider)
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSubsection.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Screens.Config.Previews;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Config
 {
@@ -16,6 +17,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 
         [Resolved]
         private Bindable<SettingsSubsection> selectedSubsection { get; set; }
+
+        public virtual SettingsSubsectionPreview CreatePreview() => new UnderConstructionMessage("Oops");
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/KaraokeSettingsSubsection.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Input.Events;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Configuration;
 
@@ -11,5 +13,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
     {
         [Resolved]
         protected KaraokeRulesetConfigManager Config { get; private set; }
+
+        [Resolved]
+        private Bindable<SettingsSubsection> selectedSubsection { get; set; }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            selectedSubsection.Value = this;
+            return base.OnHover(e);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Input/MicrophoneDevicePreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Input/MicrophoneDevicePreview.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Input
+{
+    public class MicrophoneDevicePreview : SettingsSubsectionPreview
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/SettingsSubsectionPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/SettingsSubsectionPreview.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews
+{
+    public class SettingsSubsectionPreview : CompositeDrawable
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/UnderConstructionPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/UnderConstructionPreview.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews
+{
+    public class UnderConstructionMessage : SettingsSubsectionPreview
+    {
+        private const double transition_time = 1000;
+
+        public FillFlowContainer TextContainer { get; }
+
+        private readonly Container boxContainer;
+
+        public UnderConstructionMessage(string name)
+        {
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(0.3f);
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            var colour = getColourFor(name);
+
+            InternalChildren = new Drawable[]
+            {
+                boxContainer = new Container
+                {
+                    CornerRadius = 20,
+                    Masking = true,
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+
+                            Colour = colour,
+                            Alpha = 0.2f,
+                            Blending = BlendingParameters.Additive,
+                        },
+                        TextContainer = new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Direction = FillDirection.Vertical,
+                            Children = new Drawable[]
+                            {
+                                new SpriteIcon
+                                {
+                                    Icon = FontAwesome.Solid.UniversalAccess,
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Size = new Vector2(50),
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Text = name,
+                                    Colour = colour.Lighten(0.8f),
+                                    Font = OsuFont.GetFont(size: 36),
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Text = "this preview is not yet ready for use!",
+                                    Font = OsuFont.GetFont(size: 20),
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Text = "please check back a bit later.",
+                                    Font = OsuFont.GetFont(size: 14),
+                                },
+                            }
+                        },
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TextContainer.Position = new Vector2(DrawSize.X / 16, 0);
+
+            boxContainer.Hide();
+            boxContainer.ScaleTo(0.2f);
+            boxContainer.RotateTo(-20);
+
+            using (BeginDelayedSequence(300, true))
+            {
+                boxContainer.ScaleTo(1, transition_time, Easing.OutElastic);
+                boxContainer.RotateTo(0, transition_time / 2, Easing.OutQuint);
+
+                TextContainer.MoveTo(Vector2.Zero, transition_time, Easing.OutExpo);
+                boxContainer.FadeIn(transition_time, Easing.OutExpo);
+            }
+        }
+
+        private static Color4 getColourFor(object type)
+        {
+            int hash = type.GetHashCode();
+            byte r = (byte)Math.Clamp(((hash & 0xFF0000) >> 16) * 0.8f, 20, 255);
+            byte g = (byte)Math.Clamp(((hash & 0x00FF00) >> 8) * 0.8f, 20, 255);
+            byte b = (byte)Math.Clamp((hash & 0x0000FF) * 0.8f, 20, 255);
+            return new Color4(r, g, b, 255);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsFont.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsFont.cs
@@ -11,7 +11,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
-using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Config
 {
@@ -48,6 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 
                         // Should only has one instance.
                         var dialog = displayContainer.Children.OfType<FontSelectionDialog>().FirstOrDefault();
+
                         if (dialog == null)
                         {
                             displayContainer.Add(dialog = new FontSelectionDialog());

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsLanguage.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsLanguage.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
     {
         protected override Drawable CreateControl() => new LanguageSelectionButton
         {
-            Padding = new MarginPadding { Top = 5},
+            Padding = new MarginPadding { Top = 5 },
             RelativeSizeAxes = Axes.X,
         };
 
@@ -47,13 +47,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
 
                         // Should only has one instance.
                         var dialog = displayContainer.Children.OfType<LanguageSelectionDialog>().FirstOrDefault();
+
                         if (dialog == null)
                         {
                             displayContainer.Add(dialog = new LanguageSelectionDialog());
                         }
 
                         dialog.Current = Current;
-                        dialog?.Show();
+                        dialog.Show();
                     }
                     catch
                     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsPanel.cs
@@ -71,7 +71,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                         Colour = OsuColour.Gray(0.05f),
                         Alpha = 1,
                     },
-                    SectionsContainer = CreateSettingsSections().With(x => {
+                    SectionsContainer = CreateSettingsSections().With(x =>
+                    {
                         x.Masking = true;
                         x.RelativeSizeAxes = Axes.Both;
                         x.ExpandableHeader = CreateHeader();

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/SettingsPanel.cs
@@ -71,12 +71,11 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                         Colour = OsuColour.Gray(0.05f),
                         Alpha = 1,
                     },
-                    SectionsContainer = new SettingsSectionsContainer
-                    {
-                        Masking = true,
-                        RelativeSizeAxes = Axes.Both,
-                        ExpandableHeader = CreateHeader(),
-                        FixedHeader = searchTextBox = new SeekLimitedSearchTextBox
+                    SectionsContainer = CreateSettingsSections().With(x => {
+                        x.Masking = true;
+                        x.RelativeSizeAxes = Axes.Both;
+                        x.ExpandableHeader = CreateHeader();
+                        x.FixedHeader = searchTextBox = new SeekLimitedSearchTextBox
                         {
                             RelativeSizeAxes = Axes.X,
                             Origin = Anchor.TopCentre,
@@ -87,9 +86,9 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
                                 Top = 20,
                                 Bottom = 20
                             },
-                        },
-                        Footer = CreateFooter()
-                    },
+                        };
+                        x.Footer = CreateFooter();
+                    }),
                 }
             };
 
@@ -104,6 +103,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config
         }
 
         protected virtual Drawable CreateHeader() => new Container();
+
+        protected virtual SettingsSectionsContainer CreateSettingsSections() => new SettingsSectionsContainer();
 
         protected virtual Drawable CreateFooter() => new Container();
 


### PR DESCRIPTION
Implementation of #542 
What's new in this PR:
- Implement base API for letting setting subscription can has its own component.
- Implement hover background effect for letting user know what is the preview area.
- Implement not implement component hint for default preview component.
- Adjust style.
- Prevent scroll event cause volume control appear.