### PR TITLE
Remove singer property in note object

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
@@ -46,7 +46,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestSeparateNoteOtherProperty()
         {
             const double percentage = 0.3;
-            var lyric = new Lyric();
+            var lyric = new Lyric
+            {
+                Singers = new[] { 0 },
+            };
 
             var note = new Note
             {
@@ -55,7 +58,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 StartIndex = 1,
                 EndIndex = 2,
                 Text = "ka",
-                Singers = new[] { 0 },
                 Display = false,
                 Tone = new Tone(-1, true),
                 ParentLyric = lyric
@@ -79,12 +81,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 Assert.AreEqual(expect.EndIndex, actual.EndIndex);
                 Assert.AreEqual(expect.Text, actual.Text);
 
-                Assert.AreEqual(expect.Singers, actual.Singers);
-                Assert.AreNotSame(expect.Singers, actual.Singers);
-
                 Assert.AreEqual(expect.Display, actual.Display);
                 Assert.AreEqual(expect.Tone, actual.Tone);
                 Assert.AreEqual(expect.ParentLyric, actual.ParentLyric);
+
+                Assert.AreEqual(expect.ParentLyric.Singers, actual.ParentLyric.Singers);
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -81,9 +81,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
             TextBindable.BindTo(HitObject.TextBindable);
             AlternativeTextBindable.BindTo(HitObject.AlternativeTextBindable);
-            SingersBindable.BindTo(HitObject.SingersBindable);
             DisplayBindable.BindTo(HitObject.DisplayBindable);
             ToneBindable.BindTo(HitObject.ToneBindable);
+
+            if(HitObject.ParentLyric!= null)
+                SingersBindable.BindTo(HitObject.ParentLyric.SingersBindable);
         }
 
         protected override void OnFree()
@@ -92,9 +94,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
             TextBindable.UnbindFrom(HitObject.TextBindable);
             AlternativeTextBindable.UnbindFrom(HitObject.AlternativeTextBindable);
-            SingersBindable.UnbindFrom(HitObject.SingersBindable);
             DisplayBindable.UnbindFrom(HitObject.DisplayBindable);
             ToneBindable.UnbindFrom(HitObject.ToneBindable);
+
+            if (HitObject.ParentLyric != null)
+                SingersBindable.UnbindFrom(HitObject.ParentLyric?.SingersBindable);
         }
 
         protected override void ApplySkin(ISkinSource skin, bool allowFallback)
@@ -107,7 +111,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var noteSkin = skin.GetConfig<KaraokeSkinLookup, NoteSkin>(new KaraokeSkinLookup(KaraokeSkinConfiguration.NoteStyle, HitObject.Singers))?.Value;
+            var noteSkin = skin.GetConfig<KaraokeSkinLookup, NoteSkin>(new KaraokeSkinLookup(KaraokeSkinConfiguration.NoteStyle, HitObject.ParentLyric?.Singers))?.Value;
             if (noteSkin == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -84,8 +84,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             DisplayBindable.BindTo(HitObject.DisplayBindable);
             ToneBindable.BindTo(HitObject.ToneBindable);
 
-            if(HitObject.ParentLyric!= null)
-                SingersBindable.BindTo(HitObject.ParentLyric.SingersBindable);
+            if (HitObject.ParentLyric != null)
+            {
+                HitObject.ParentLyricBindable.BindValueChanged(x =>
+                {
+                    SingersBindable.UnbindAll();
+                    SingersBindable.BindTo(x.NewValue.SingersBindable);
+                }, true);
+            }
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -77,8 +77,19 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public int EndIndex { get; set; }
 
+        [JsonIgnore]
+        public readonly Bindable<Lyric> ParentLyricBindable = new Bindable<Lyric>();
+
+        /// <summary>
+        /// Relative lyric.
+        /// Technically parent lyric will not change after assign, but should not restrict in model layer.
+        /// </summary>
         [JsonProperty(IsReference = true)]
-        public Lyric ParentLyric { get; set; }
+        public Lyric ParentLyric
+        {
+            get => ParentLyricBindable.Value;
+            set => ParentLyricBindable.Value = value;
+        }
 
         public override Judgement CreateJudgement() => new KaraokeNoteJudgement();
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class Note : KaraokeHitObject, IHasDuration, IHasText, IHasSingers
+    public class Note : KaraokeHitObject, IHasDuration, IHasText
     {
         [JsonIgnore]
         public readonly Bindable<string> TextBindable = new Bindable<string>();
@@ -35,18 +35,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         {
             get => AlternativeTextBindable.Value;
             set => AlternativeTextBindable.Value = value;
-        }
-
-        [JsonIgnore]
-        public readonly Bindable<int[]> SingersBindable = new Bindable<int[]>();
-
-        /// <summary>
-        /// Singers
-        /// </summary>
-        public int[] Singers
-        {
-            get => SingersBindable.Value;
-            set => SingersBindable.Value = value;
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 StartIndex = originNote.StartIndex,
                 EndIndex = originNote.EndIndex,
                 Text = originNote.Text,
-                Singers = originNote.Singers?.Clone() as int[],
                 Display = originNote.Display,
                 Tone = originNote.Tone,
                 ParentLyric = originNote.ParentLyric


### PR DESCRIPTION
If drawable note wants to get property from `parent lyric`, instead of copying property
It should directly get the property from `parent lyric` instead.