### PR TITLE
Implement overlay in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Lyrics/Algorithms/EditNoteCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Lyrics/Algorithms/EditNoteCaretPositionAlgorithmTest.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Algorithms;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Lyrics.Algorithms
+{
+    public class EditNoteCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest<EditNoteCaretPositionAlgorithm, EditNoteCaretPosition>
+    {
+        [TestCase(nameof(singleLyric), 0, true)]
+        [TestCase(nameof(singleLyricWithNoText), 0, true)]
+        public void TestPositionMovable(string sourceName, int lyricIndex, bool movable)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+
+            // Check is movable, will always be true in this algorithm.
+            TestPositionMovable(lyrics, caretPosition, movable);
+        }
+
+        [TestCase(nameof(singleLyric), 0, NOT_EXIST)] // cannot move up if at top index.
+        [TestCase(nameof(singleLyricWithNoText), 0, NOT_EXIST)]
+        [TestCase(nameof(twoLyricsWithText), 1, 0)]
+        [TestCase(nameof(threeLyricsWithSpacing), 2, 1)]
+        public void TestMoveUp(string sourceName, int lyricIndex, int newLyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+            var newCaretPosition = CreateEditNoteCaretPosition(lyrics, newLyricIndex);
+
+            // Check is movable
+            TestMoveUp(lyrics, caretPosition, newCaretPosition);
+        }
+
+        [TestCase(nameof(singleLyric), 0,  NOT_EXIST)] // cannot move down if at bottom index.
+        [TestCase(nameof(singleLyricWithNoText), 0, NOT_EXIST)]
+        [TestCase(nameof(twoLyricsWithText), 0, 1)]
+        [TestCase(nameof(threeLyricsWithSpacing), 0, 1)]
+        public void TestMoveDown(string sourceName, int lyricIndex, int newLyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+            var newCaretPosition = CreateEditNoteCaretPosition(lyrics, newLyricIndex);
+
+            // Check is movable
+            TestMoveDown(lyrics, caretPosition, newCaretPosition);
+        }
+
+        [TestCase(nameof(singleLyric), 0, NOT_EXIST)]
+        [TestCase(nameof(singleLyricWithNoText), 0, NOT_EXIST)]
+        [TestCase(nameof(twoLyricsWithText), 0, NOT_EXIST)]
+        [TestCase(nameof(threeLyricsWithSpacing), 0, NOT_EXIST)]
+        public void TestMoveLeft(string sourceName, int lyricIndex, int newLyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+            var newCaretPosition = CreateEditNoteCaretPosition(lyrics, newLyricIndex);
+
+            // Check is movable
+            TestMoveLeft(lyrics, caretPosition, newCaretPosition);
+        }
+
+        [TestCase(nameof(singleLyric), 0, NOT_EXIST)]
+        [TestCase(nameof(singleLyricWithNoText), 0, NOT_EXIST)]
+        [TestCase(nameof(twoLyricsWithText), 0, NOT_EXIST)]
+        [TestCase(nameof(threeLyricsWithSpacing), 0, NOT_EXIST)]
+        public void TestMoveRight(string sourceName, int lyricIndex, int newLyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+            var newCaretPosition = CreateEditNoteCaretPosition(lyrics, newLyricIndex);
+
+            // Check is movable
+            TestMoveRight(lyrics, caretPosition, newCaretPosition);
+        }
+
+        [TestCase(nameof(singleLyric), 0)]
+        [TestCase(nameof(singleLyricWithNoText), 0)]
+        [TestCase(nameof(twoLyricsWithText), 0)]
+        [TestCase(nameof(threeLyricsWithSpacing), 0)]
+        public void TestMoveToFirst(string sourceName, int lyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+
+            // Check first position
+            TestMoveToFirst(lyrics, caretPosition);
+        }
+
+        [TestCase(nameof(singleLyric), 0)]
+        [TestCase(nameof(singleLyricWithNoText), 0)]
+        [TestCase(nameof(twoLyricsWithText), 1)]
+        [TestCase(nameof(threeLyricsWithSpacing), 2)]
+        public void TestMoveToLast(string sourceName, int lyricIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var caretPosition = CreateEditNoteCaretPosition(lyrics, lyricIndex);
+
+            // Check last position
+            TestMoveToLast(lyrics, caretPosition);
+        }
+
+        protected override void AssertEqual(EditNoteCaretPosition compare, EditNoteCaretPosition actual)
+        {
+            if (compare == null)
+            {
+                Assert.IsNull(actual);
+            }
+            else
+            {
+                Assert.AreEqual(compare.Lyric, actual.Lyric);
+            }
+        }
+
+        protected EditNoteCaretPosition CreateEditNoteCaretPosition(Lyric[] lyrics, int lyricIndex)
+        {
+            if (lyricIndex == NOT_EXIST)
+                return null;
+
+            var lyric = lyrics.ElementAtOrDefault(lyricIndex);
+            return new EditNoteCaretPosition(lyric);
+        }
+
+        #region source
+
+        private Lyric[] singleLyric => new[]
+        {
+            new Lyric
+            {
+                Text = "カラオケ"
+            }
+        };
+
+        private Lyric[] singleLyricWithNoText => new[]
+        {
+            new Lyric()
+        };
+
+        private Lyric[] twoLyricsWithText => new[]
+        {
+            new Lyric
+            {
+                Text = "カラオケ"
+            },
+            new Lyric
+            {
+                Text = "大好き"
+            }
+        };
+
+        private Lyric[] threeLyricsWithSpacing => new[]
+        {
+            new Lyric
+            {
+                Text = "カラオケ"
+            },
+            new Lyric(),
+            new Lyric
+            {
+                Text = "大好き"
+            }
+        };
+
+        #endregion
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorEditModeMenu.cs
@@ -29,6 +29,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                 case Mode.TypingMode:
                     return "Typing";
 
+                case Mode.EditNoteMode:
+                    return "Edit note";
+
                 case Mode.RecordMode:
                     return "Record";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Algorithms/EditNoteCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Algorithms/EditNoteCaretPositionAlgorithm.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Algorithms
+{
+    public class EditNoteCaretPositionAlgorithm : CaretPositionAlgorithm<EditNoteCaretPosition>
+    {
+        public EditNoteCaretPositionAlgorithm(Lyric[] lyrics)
+            : base(lyrics)
+        {
+        }
+
+        public override bool PositionMovable(EditNoteCaretPosition position)
+        {
+            return true;
+        }
+
+        public override EditNoteCaretPosition MoveUp(EditNoteCaretPosition currentPosition)
+        {
+            var lyric = Lyrics.GetPrevious(currentPosition.Lyric);
+            if (lyric == null)
+                return null;
+
+            return new EditNoteCaretPosition(lyric);
+        }
+
+        public override EditNoteCaretPosition MoveDown(EditNoteCaretPosition currentPosition)
+        {
+            var lyric = Lyrics.GetNext(currentPosition.Lyric);
+            if (lyric == null)
+                return null;
+
+            return new EditNoteCaretPosition(lyric);
+        }
+
+        public override EditNoteCaretPosition MoveLeft(EditNoteCaretPosition currentPosition)
+        {
+            return null;
+        }
+
+        public override EditNoteCaretPosition MoveRight(EditNoteCaretPosition currentPosition)
+        {
+            return null;
+        }
+
+        public override EditNoteCaretPosition MoveToFirst()
+        {
+            var lyric = Lyrics.FirstOrDefault();
+            if (lyric == null)
+                return null;
+
+            return new EditNoteCaretPosition(lyric);
+        }
+
+        public override EditNoteCaretPosition MoveToLast()
+        {
+            var lyric = Lyrics.LastOrDefault();
+            if (lyric == null)
+                return null;
+
+            return new EditNoteCaretPosition(lyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/EditNoteCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/EditNoteCaretPosition.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
+{
+    public class EditNoteCaretPosition : ICaretPosition
+    {
+        public EditNoteCaretPosition(Lyric lyric)
+        {
+            Lyric = lyric;
+        }
+
+        public Lyric Lyric { get; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/LyricControl.cs
@@ -203,6 +203,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
                     case Mode.TypingMode:
                         return new DrawableLyricInputCaret();
 
+                    case Mode.EditNoteMode:
+                        return null;
+
                     case Mode.RecordMode:
                         return new DrawableTimeTagRecordCaret();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
@@ -6,7 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
+using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
@@ -43,53 +44,64 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state)
         {
-            // update hover style to child
-            state.BindableHoverCaretPosition.BindValueChanged(e =>
-            {
-                if (e.NewValue == null)
-                    return;
-
-                var listItem = getListItem(e.NewValue.Lyric);
-            });
-
             // update selected style to child
             state.BindableCaretPosition.BindValueChanged(e =>
             {
-                if (e.NewValue == null)
-                    return;
-
-                var listItem = getListItem(e.NewValue.Lyric);
-                if (listItem == null)
+                var oldLyric = e.OldValue?.Lyric;
+                var newLyric = e.NewValue?.Lyric;
+                if (newLyric == null)
                     return;
 
                 // move to target position.
                 if (state.BindableAutoFocusEditLyric.Value)
                 {
                     var skippingRows = state.BindableAutoFocusEditLyricSkipRows.Value;
-                    moveItemToTargetPosition(listItem, listItem.Height * skippingRows);
+                    moveItemToTargetPosition(newLyric, oldLyric, skippingRows);
                 }
             });
-
-            DrawableLyricEditListItem getListItem(Lyric lyric)
-                => ListContainer.Children.FirstOrDefault(x => x.Model == lyric) as DrawableLyricEditListItem;
         }
 
-        private bool moveItemToTargetPosition(DrawableLyricEditListItem item, float spacing)
+        private bool moveItemToTargetPosition(Lyric newLyric, Lyric oldLyric, int skippingRows)
         {
+            var oldItem = getListItem(oldLyric);
+            var newItem = getListItem(newLyric);
+            if (newItem == null)
+                throw new ArgumentNullException(nameof(newItem));
+
+            var spacing = newItem.Height * skippingRows;
+
             // do not scroll if position is smaller then spacing.
-            var scrollPosition = ScrollContainer.GetChildPosInContent(item);
+            var scrollPosition = ScrollContainer.GetChildPosInContent(newItem);
             if (scrollPosition < spacing)
                 return false;
 
             // do not scroll if posiiton is too large and not able to move to target position.
-            var itemHeight = item.Height;
+            var itemHeight = newItem.Height + newItem.OverlayHeight;
             var contentHeight = ScrollContainer.ScrollContent.Height;
             var containerHeight = ScrollContainer.DrawHeight;
             if (contentHeight - scrollPosition + itemHeight < containerHeight - spacing)
                 return false;
 
-            ScrollContainer.ScrollTo(scrollPosition - spacing);
+            ScrollContainer.ScrollTo(scrollPosition - spacing + getOffsetPosition(newItem, oldItem));
             return true;
+
+            DrawableLyricEditListItem getListItem(Lyric lyric)
+                => ListContainer.Children.FirstOrDefault(x => x.Model == lyric) as DrawableLyricEditListItem;
+
+            float getOffsetPosition(DrawableLyricEditListItem newItem, DrawableLyricEditListItem oldItem)
+            {
+                if (oldItem == null)
+                    return 0;
+
+                var neeItemPosition = ScrollContainer.GetChildPosInContent(newItem);
+                var oldItemPosition = ScrollContainer.GetChildPosInContent(oldItem);
+                if (oldItemPosition > scrollPosition)
+                    return 0;
+
+                // if previous lyric is in front of current lyirc row, due to overlay in previous row has been removed.
+                // it will cause offset from previous row overlay.
+                return -newItem.OverlayHeight;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -9,7 +9,9 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
@@ -17,8 +19,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
     public class DrawableLyricEditListItem : OsuRearrangeableListItem<Lyric>
     {
         private Box dragAlert;
+        private FillFlowContainer content;
 
         private readonly Bindable<Mode> bindableMode = new Bindable<Mode>();
+        private readonly Bindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
 
         public DrawableLyricEditListItem(Lyric item)
             : base(item)
@@ -27,7 +31,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 // Only draggable in edit mode.
                 ShowDragHandle.Value = e.NewValue == Mode.EditMode;
+
+                // should remove overlay if mod is not support that.
             }, true);
+
+            bindableCaretPosition.BindValueChanged(e =>
+            {
+                // todo : show extra overlay if hover to current lyric.
+                var editOverlay = new EditNoteOverlay(Model)
+                {
+                    RelativeSizeAxes = Axes.X
+                };
+                content.Add(editOverlay);
+                editOverlay.Show();
+            });
         }
 
         protected override Drawable CreateContent()
@@ -45,9 +62,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                         RelativeSizeAxes = Axes.Both,
                         Alpha = 0
                     },
-                    new EditLyricRow(Model)
+                    content = new FillFlowContainer
                     {
-                        RelativeSizeAxes = Axes.X
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            new EditLyricRow(Model)
+                            {
+                                RelativeSizeAxes = Axes.X
+                            }
+                        }
                     }
                 }
             };
@@ -58,6 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         {
             dragAlert.Colour = colours.YellowDarker;
             bindableMode.BindTo(state.BindableMode);
+            bindableCaretPosition.BindTo(state.BindableCaretPosition);
         }
 
         protected override bool OnDragStart(DragStartEvent e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -75,11 +75,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 }
             }
 
-            EditOverlay getOverlay()
-            {
-                return content?.Children.OfType<EditOverlay>().FirstOrDefault();
-            }
-
             void removeOverlay()
             {
                 var existOverlay = getOverlay();
@@ -90,6 +85,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 content.Remove(existOverlay);
             }
         }
+
+        private EditOverlay getOverlay()
+        {
+            return content?.Children.OfType<EditOverlay>().FirstOrDefault();
+        }
+
+        public float OverlayHeight => getOverlay()?.ContentHeight ?? 0;
 
         protected override Drawable CreateContent()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -32,19 +33,62 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 // Only draggable in edit mode.
                 ShowDragHandle.Value = e.NewValue == Mode.EditMode;
 
-                // should remove overlay if mod is not support that.
+                // should remove overlay when switch mode.
+                removeOverlay();
             }, true);
 
             bindableCaretPosition.BindValueChanged(e =>
             {
-                // todo : show extra overlay if hover to current lyric.
-                var editOverlay = new EditNoteOverlay(Model)
+                if (e.NewValue == null)
+                    return;
+
+                if (e.NewValue.Lyric != Model)
                 {
-                    RelativeSizeAxes = Axes.X
-                };
+                    removeOverlay();
+                    return;
+                }
+
+                // show not create again if contains same overlay.
+                var existOverlay = getOverlay();
+                if (existOverlay != null)
+                    return;
+
+                // show extra overlay if hover to current lyric.
+                var editOverlay = createOverlay(bindableMode.Value, Model);
+                if (editOverlay == null)
+                    return;
+
+                editOverlay.RelativeSizeAxes = Axes.X;
                 content.Add(editOverlay);
                 editOverlay.Show();
             });
+
+            static EditOverlay createOverlay(Mode mode, Lyric lyric)
+            {
+                switch (mode)
+                {
+                    case Mode.EditNoteMode:
+                        return new EditNoteOverlay(lyric);
+
+                    default:
+                        return null;
+                }
+            }
+
+            EditOverlay getOverlay()
+            {
+                return content?.Children.OfType<EditOverlay>().FirstOrDefault();
+            }
+
+            void removeOverlay()
+            {
+                var existOverlay = getOverlay();
+                if (existOverlay == null)
+                    return;
+
+                // todo : might remove component until overlay effect end.
+                content.Remove(existOverlay);
+            }
         }
 
         protected override Drawable CreateContent()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -152,13 +152,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             switch (Mode)
             {
                 case Mode.ViewMode:
-                    return false;
-
                 case Mode.EditMode:
-                    return false;
-
-                case Mode.TypingMode:
-                    // will handle in OnKeyDown
+                case Mode.TypingMode: // will handle in OnKeyDown
+                case Mode.EditNoteMode:
                     return false;
 
                 case Mode.RecordMode:
@@ -278,6 +274,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case Mode.ViewMode:
                     case Mode.EditMode:
                     case Mode.TypingMode:
+                    case Mode.EditNoteMode:
                         return;
 
                     case Mode.RecordMode:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 { Mode.EditMode, new CuttingCaretPositionAlgorithm(lyrics) },
                 { Mode.TypingMode, new TypingCaretPositionAlgorithm(lyrics) },
+                { Mode.EditNoteMode, new EditNoteCaretPositionAlgorithm(lyrics) },
                 { Mode.RecordMode, new TimeTagCaretPositionAlgorithm(lyrics) { Mode = RecordingMovingCaretMode } },
                 { Mode.TimeTagEditMode, new TimeTagIndexCaretPositionAlgorithm(lyrics) }
             };
@@ -132,7 +133,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return new TextCaretPosition(null, 0);
 
                 case Mode.EditNoteMode:
-                    return null;
+                    return new EditNoteCaretPosition(null);
 
                 case Mode.RecordMode:
                     return new TimeTagCaretPosition(null, null);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
@@ -126,9 +126,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 case Mode.ViewMode:
                     return null;
+
                 case Mode.EditMode:
                 case Mode.TypingMode:
                     return new TextCaretPosition(null, 0);
+
+                case Mode.EditNoteMode:
+                    return null;
 
                 case Mode.RecordMode:
                     return new TimeTagCaretPosition(null, null);
@@ -158,6 +162,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// Able to typing lyric.
         /// </summary>
         TypingMode,
+
+        /// <summary>
+        /// Aboe to create/delete/mode/split/combine note.
+        /// </summary>
+        EditNoteMode,
 
         /// <summary>
         /// Click white-space to set current time into time-tag.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/CreateNewLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/CreateNewLyricRow.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows
 {
     public class CreateNewLyricRow : LyricEditorRow
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/EditLyricRow.cs
@@ -2,11 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows
 {
     public class EditLyricRow : LyricEditorRow
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/InvalidInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/InvalidInfo.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.FixedInfo
 {
     public class InvalidInfo : SpriteIcon, IHasContextMenu, IHasCustomTooltip
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/LockInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/LockInfo.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.FixedInfo
 {
     public class LockInfo : SpriteIcon, IHasContextMenu
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/OrderInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/FixedInfo/OrderInfo.cs
@@ -4,7 +4,7 @@
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.FixedInfo
 {
     public class OrderInfo : OsuSpriteText
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/InfoControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/InfoControl.cs
@@ -14,13 +14,13 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.FixedInfo;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.FixedInfo;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos
 {
     public class InfoControl : Container, IHasContextMenu
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/LanguageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/LanguageInfo.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo
 {
     public class LanguageInfo : SubInfo
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/LayoutInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/LayoutInfo.cs
@@ -5,7 +5,7 @@ using osu.Framework.Allocation;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo
 {
     public class LayoutInfo : SubInfo
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/SingerInfo.cs
@@ -12,7 +12,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables.Pieces;
 using osu.Game.Screens.Edit;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo
 {
     public class SingerInfo : Container
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/SubInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/SubInfo.cs
@@ -9,7 +9,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo
 {
     public abstract class SubInfo : Container
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/TimeTagInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Infos/SubInfo/TimeTagInfo.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Infos.SubInfo
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Infos.SubInfo
 {
     public class TimeTagInfo : SubInfo
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/LyricEditorRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/LyricEditorRow.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows
 {
     public abstract class LyricEditorRow : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableLyricInputCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableLyricInputCaret.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public class DrawableLyricInputCaret : Caret, IDrawableCaret
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableLyricSplitterCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableLyricSplitterCaret.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public class DrawableLyricSplitterCaret : CompositeDrawable, IDrawableCaret
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableTimeTagEditCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableTimeTagEditCaret.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public class DrawableTimeTagEditCaret : CompositeDrawable, IDrawableCaret, IHasCaretPosition
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public class DrawableTimeTagRecordCaret : CompositeDrawable, IDrawableCaret, IHasTimeTag
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IDrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IDrawableCaret.cs
@@ -3,7 +3,7 @@
 
 using osu.Framework.Graphics;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public interface IDrawableCaret : IDrawable
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IHasCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IHasCaretPosition.cs
@@ -3,7 +3,7 @@
 
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public interface IHasCaretPosition
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IHasTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Carets/IHasTimeTag.cs
@@ -3,7 +3,7 @@
 
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets
 {
     public interface IHasTimeTag
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/DrawableEditorLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/DrawableEditorLyric.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
 {
     public class DrawableEditLyric : DrawableLyric
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
@@ -9,14 +9,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Parts;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Carets;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Parts;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
 {
     public class LyricControl : Container
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
@@ -87,17 +87,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             if (!isTrigger(state.Mode))
                 return false;
 
-            if (state.Mode == Mode.TimeTagEditMode)
+            var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
+            var index = drawableLyric.GetHoverIndex(position);
+
+            switch (state.Mode)
             {
-                var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
-                var index = drawableLyric.GetHoverIndex(position);
-                state.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(Lyric, index));
-            }
-            else
-            {
-                var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
-                var index = drawableLyric.GetHoverIndex(position);
-                state.MoveHoverCaretToTargetPosition(new TextCaretPosition(Lyric, TextIndexUtils.ToStringIndex(index)));
+                case Mode.EditMode:
+                case Mode.TypingMode:
+                    state.MoveHoverCaretToTargetPosition(new TextCaretPosition(Lyric, TextIndexUtils.ToStringIndex(index)));
+                    break;
+
+                case Mode.TimeTagEditMode:
+                    
+                    state.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(Lyric, index));
+                    break;
+
+                case Mode.EditNoteMode:
+                    state.MoveHoverCaretToTargetPosition(new EditNoteCaretPosition(Lyric));
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(state.Mode));
             }
 
             return base.OnMouseMove(e);
@@ -321,6 +331,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
         }
 
         private bool isTrigger(Mode mode)
-            => mode == Mode.EditMode || mode == Mode.TypingMode || mode == Mode.TimeTagEditMode;
+            => mode == Mode.EditMode || mode == Mode.TypingMode || mode == Mode.EditNoteMode || mode == Mode.TimeTagEditMode;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Parts/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/Parts/DrawableTimeTag.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Screens.Edit;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Parts
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics.Parts
 {
     public class DrawableTimeTag : CompositeDrawable, IHasCustomTooltip
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -3,14 +3,13 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {
     public class EditNoteOverlay : EditOverlay
     {
-        protected override float ContentHeight => 240;
+        public override float ContentHeight => 240;
 
         public EditNoteOverlay(Lyric lyric)
             : base(lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
+{
+    public class EditNoteOverlay : EditOverlay
+    {
+        protected override float ContentHeight => 510;
+
+        public EditNoteOverlay(Lyric lyric)
+            : base(lyric)
+        {
+        }
+
+        protected override Drawable CreateInfo(Lyric lyric)
+        {
+            // todo : waiting for implementation.
+            return new Container();
+        }
+
+        protected override Drawable CreateContent(Lyric lyric)
+        {
+            // todo : waiting for implementation.
+            return new Container();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -3,13 +3,14 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {
     public class EditNoteOverlay : EditOverlay
     {
-        protected override float ContentHeight => 510;
+        protected override float ContentHeight => 240;
 
         public EditNoteOverlay(Lyric lyric)
             : base(lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {
     public class EditNoteOverlay : EditOverlay
     {
-        public override float ContentHeight => 240;
+        public override float ContentHeight => 180;
 
         public EditNoteOverlay(Lyric lyric)
             : base(lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
+{
+    public abstract class EditOverlay : VisibilityContainer
+    {
+        private const int info_part_spacing = 210;
+        private const float transition_duration = 600;
+
+        protected abstract float ContentHeight { get; }
+
+        private readonly Lyric lyric;
+
+        protected EditOverlay(Lyric lyric)
+        {
+            this.lyric = lyric;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.8f,
+                    Colour = Color4.Black
+                },
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.Absolute, info_part_spacing),
+                        new Dimension(GridSizeMode.Distributed)
+                    },
+                    RowDimensions = new[] { new Dimension(GridSizeMode.Relative) },
+                    Content = new[]
+                    {
+                        new[]
+                        {
+                            CreateInfo(lyric),
+                            CreateContent(lyric)
+                        }
+                    }
+                }
+            };
+        }
+
+        protected abstract Drawable CreateInfo(Lyric lyric);
+
+        protected abstract Drawable CreateContent(Lyric lyric);
+
+        protected override void PopIn()
+        {
+            this.ResizeTo(new Vector2(1, ContentHeight), transition_duration, Easing.OutQuint);
+            this.FadeIn(transition_duration, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.ResizeTo(new Vector2(1, 0), transition_duration, Easing.OutQuint);
+            this.FadeOut(transition_duration);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
@@ -73,6 +74,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
         {
             this.ResizeTo(new Vector2(1, 0), transition_duration, Easing.OutQuint);
             this.FadeOut(transition_duration);
+        }
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            // prevent scroll container drag event.
+            return true;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
@@ -18,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
         private const int info_part_spacing = 210;
         private const float transition_duration = 600;
 
-        protected abstract float ContentHeight { get; }
+        public abstract float ContentHeight { get; }
 
         private readonly Lyric lyric;
 
@@ -66,13 +65,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 
         protected override void PopIn()
         {
-            this.ResizeTo(new Vector2(1, ContentHeight), transition_duration, Easing.OutQuint);
+            this.ResizeHeightTo(ContentHeight, transition_duration, Easing.OutQuint);
             this.FadeIn(transition_duration, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
-            this.ResizeTo(new Vector2(1, 0), transition_duration, Easing.OutQuint);
+            this.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
             this.FadeOut(transition_duration);
         }
 


### PR DESCRIPTION
What's changed in this pr:
- add overlay in the lyric editor, if hover to lyric and this mode support overlay, then will have customized overlay under the lyric row.
- implement a new mode to focus edit notes in the lyric.
- implement a new cursor position calculator to let the user select current lyrics by using a keyboard or mouse.
- implement demo overlay for edit note mode(base implementation of #575).