### PR TITLE
Base implement edit note overlay

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
@@ -11,6 +11,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
+using System;
 
 namespace osu.Game.Rulesets.Karaoke.Edit
 {
@@ -51,9 +52,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 
                 case DrawableLyric lyric:
                     return new LyricSelectionBlueprint(lyric);
-            }
 
-            return base.CreateBlueprintFor(hitObject);
+                default:
+                    throw new IndexOutOfRangeException(nameof(hitObject));
+            }
         }
 
         protected override SelectionHandler CreateSelectionHandler() => new KaraokeSelectionHandler();

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Resolved]
         private LyricManager lyricManager { get; set; }
 
+        protected virtual NotePlayfield NotePlayfield => ((KaraokeHitObjectComposer)composer).Playfield.NotePlayfield;
+
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)
         {
             if (selection.All(x => x is LyricSelectionBlueprint))
@@ -131,10 +133,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             if (!(moveEvent.Blueprint is NoteSelectionBlueprint))
                 return;
 
-            var karaokePlayfield = ((KaraokeHitObjectComposer)composer).Playfield;
-
             // top position
-            var dragHeight = karaokePlayfield.NotePlayfield.ToLocalSpace(moveEvent.ScreenSpacePosition).Y;
+            var dragHeight = NotePlayfield.ToLocalSpace(moveEvent.ScreenSpacePosition).Y;
             var lastHeight = convertToneToHeight(lastTone);
             var moveHeight = dragHeight - lastHeight;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -70,6 +70,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case Mode.EditNoteMode:
                         return new EditNoteOverlay(lyric);
 
+                    case Mode.TimeTagEditMode:
+                        return new EditTimeTagOverlay(lyric);
+
                     default:
                         return null;
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
             }
 
             // find time in first note.
-            protected override double CurrentTime => TargetLyric.StartTime;
+            protected override double CurrentTime => TargetLyric.LyricStartTime;
 
             protected override Playfield CreatePlayfield()
                 => new NotePlayfield(9);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {
@@ -63,8 +65,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
                 }
             }
 
+            // find time in first note.
+            protected override double CurrentTime => TargetLyric.StartTime;
+
             protected override Playfield CreatePlayfield()
                 => new NotePlayfield(9);
+
+            protected override ComposeBlueprintContainer CreateBlueprintContainer()
+                => new EditNoteBlueprintContainer(this);
 
             #region IPlacementHandler
 
@@ -84,6 +92,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
             }
 
             #endregion
+
+            internal class EditNoteBlueprintContainer : ComposeBlueprintContainer
+            {
+                public EditNoteBlueprintContainer(HitObjectComposer composer)
+                    : base(composer)
+                {
+                }
+
+                public override OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject)
+                {
+                    switch (hitObject)
+                    {
+                        case DrawableNote note:
+                            return new NoteSelectionBlueprint(note);
+
+                        default:
+                            throw new IndexOutOfRangeException(nameof(hitObject));
+                    }
+                }
+
+                protected override SelectionHandler CreateSelectionHandler() => new EditNoteSelectionHandler();
+
+                internal class EditNoteSelectionHandler : KaraokeSelectionHandler
+                {
+                    [Resolved]
+                    private HitObjectComposer composer { get; set; }
+
+                    protected override NotePlayfield NotePlayfield => (composer as EditNoteHitObjectComposer).Playfield as NotePlayfield;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -1,9 +1,18 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Drawables;
+using osu.Game.Rulesets.Karaoke.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {
@@ -25,7 +34,56 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
         protected override Drawable CreateContent(Lyric lyric)
         {
             // todo : waiting for implementation.
-            return new Container();
+            return new EditNoteHitObjectComposer(lyric)
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 150,
+            };
+        }
+
+        internal class EditNoteHitObjectComposer : OverlayHitObjectComposer
+        {
+            protected Lyric TargetLyric { get; private set; }
+
+            public EditNoteHitObjectComposer(Lyric lyric)
+            {
+                TargetLyric = lyric;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // add all matched notes into playfield
+                var notes = EditorBeatmap.HitObjects.OfType<Note>().Where(x => x.ParentLyric == TargetLyric).ToList();
+                foreach (var note in notes)
+                {
+                    // todo : should support pooling.
+                    var drawableNote = new DrawableNote(note);
+                    Playfield.Add(drawableNote);
+                }
+            }
+
+            protected override Playfield CreatePlayfield()
+                => new NotePlayfield(9);
+
+            #region IPlacementHandler
+
+            public override void BeginPlacement(HitObject hitObject)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override void Delete(HitObject hitObject)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override void EndPlacement(HitObject hitObject, bool commit)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            #endregion
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditNoteOverlay.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
             protected override double CurrentTime => TargetLyric.LyricStartTime;
 
             protected override Playfield CreatePlayfield()
-                => new NotePlayfield(9);
+                => new EditNotePlayfield(9);
 
             protected override ComposeBlueprintContainer CreateBlueprintContainer()
                 => new EditNoteBlueprintContainer(this);
@@ -92,6 +92,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
             }
 
             #endregion
+
+            internal class EditNotePlayfield : NotePlayfield
+            {
+                public EditNotePlayfield(int columns)
+                    : base(columns)
+                {
+                    // todo : remain only needed component.
+                }
+            }
 
             internal class EditNoteBlueprintContainer : ComposeBlueprintContainer
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -34,8 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0.8f,
-                    Colour = Color4.Black
+                    Colour = colours.Gray2,
                 },
                 new GridContainer
                 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditOverlay.cs
@@ -50,7 +50,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
                         new[]
                         {
                             CreateInfo(lyric),
-                            CreateContent(lyric)
+                            new Container
+                            {
+                                Masking = true,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Child = CreateContent(lyric),
+                            }
                         }
                     }
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditTimeTagOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/EditTimeTagOverlay.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
+{
+    public class EditTimeTagOverlay : EditOverlay
+    {
+        public override float ContentHeight => 100;
+
+        public EditTimeTagOverlay(Lyric lyric)
+            : base(lyric)
+        {
+        }
+
+        protected override Drawable CreateInfo(Lyric lyric)
+        {
+            // todo : waiting for implementation.
+            return new Container();
+        }
+
+        protected override Drawable CreateContent(Lyric lyric)
+        {
+            // todo : waiting for implementation.
+            return new Container();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/OverlayHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/OverlayHitObjectComposer.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Timing;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Rulesets.UI.Scrolling.Algorithms;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays
+{
+    public abstract class OverlayHitObjectComposer : HitObjectComposer, IPlacementHandler
+    {
+        [Cached(Type = typeof(IScrollingInfo))]
+        private readonly LocalScrollingInfo scrollingInfo;
+
+        [Resolved]
+        protected EditorClock EditorClock { get; private set; }
+
+        [Resolved]
+        protected EditorBeatmap EditorBeatmap { get; private set; }
+
+        [Resolved]
+        protected IBeatSnapProvider BeatSnapProvider { get; private set; }
+
+        private Playfield playfield;
+
+        protected ComposeBlueprintContainer BlueprintContainer { get; private set; }
+
+        private InputManager inputManager;
+
+        protected OverlayHitObjectComposer()
+        {
+            scrollingInfo = new LocalScrollingInfo();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new Container
+            {
+                Name = "Content",
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    // layers below playfield
+                    playfield = CreatePlayfield(),
+                    // layers above playfield
+                    BlueprintContainer = CreateBlueprintContainer()
+                }
+            };
+
+            // todo : set stop clock and navigation to target time.
+            playfield.Clock = new StopClock(CurrentTime);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager();
+        }
+
+        protected abstract double CurrentTime { get; }
+
+        /// <summary>
+        /// Creates a Playfield.
+        /// </summary>
+        /// <returns>The Playfield.</returns>
+        protected abstract Playfield CreatePlayfield();
+
+        /// <summary>
+        /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.
+        /// </summary>
+        protected virtual ComposeBlueprintContainer CreateBlueprintContainer()
+            => new ComposeBlueprintContainer(this);
+
+        public override Playfield Playfield => playfield;
+
+        public override IEnumerable<DrawableHitObject> HitObjects
+            => Playfield.AllHitObjects;
+
+        public override bool CursorInPlacementArea => Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
+
+        #region IPlacementHandler
+
+        public abstract void BeginPlacement(HitObject hitObject);
+
+        public abstract void EndPlacement(HitObject hitObject, bool commit);
+
+        public abstract void Delete(HitObject hitObject);
+
+        #endregion
+
+        #region IPositionSnapProvider
+
+        /// <summary>
+        /// Retrieve the relevant <see cref="Playfield"/> at a specified screen-space position.
+        /// In cases where a ruleset doesn't require custom logic (due to nested playfields, for example)
+        /// this will return the ruleset's main playfield.
+        /// </summary>
+        /// <param name="screenSpacePosition">The screen-space position to query.</param>
+        /// <returns>The most relevant <see cref="Playfield"/>.</returns>
+        protected virtual Playfield PlayfieldAtScreenSpacePosition(Vector2 screenSpacePosition) => Playfield;
+
+        public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
+        {
+            var playfield = PlayfieldAtScreenSpacePosition(screenSpacePosition);
+            double? targetTime = null;
+
+            if (playfield is ScrollingPlayfield scrollingPlayfield)
+            {
+                targetTime = scrollingPlayfield.TimeAtScreenSpacePosition(screenSpacePosition);
+
+                // apply beat snapping
+                targetTime = BeatSnapProvider.SnapTime(targetTime.Value);
+
+                // convert back to screen space
+                screenSpacePosition = scrollingPlayfield.ScreenSpacePositionAtTime(targetTime.Value);
+            }
+
+            return new SnapResult(screenSpacePosition, targetTime, playfield);
+        }
+
+        public override float GetBeatSnapDistanceAt(double referenceTime)
+        {
+            DifficultyControlPoint difficultyPoint = EditorBeatmap.ControlPointInfo.DifficultyPointAt(referenceTime);
+            return (float)(100 * EditorBeatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier * difficultyPoint.SpeedMultiplier / BeatSnapProvider.BeatDivisor);
+        }
+
+        public override float DurationToDistance(double referenceTime, double duration)
+        {
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
+            return (float)(duration / beatLength * GetBeatSnapDistanceAt(referenceTime));
+        }
+
+        public override double DistanceToDuration(double referenceTime, float distance)
+        {
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
+            return distance / GetBeatSnapDistanceAt(referenceTime) * beatLength;
+        }
+
+        public override double GetSnappedDurationFromDistance(double referenceTime, float distance)
+            => BeatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime) - referenceTime;
+
+        public override float GetSnappedDistanceFromDistance(double referenceTime, float distance)
+        {
+            double actualDuration = referenceTime + DistanceToDuration(referenceTime, distance);
+
+            double snappedEndTime = BeatSnapProvider.SnapTime(actualDuration, referenceTime);
+
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
+
+            // we don't want to exceed the actual duration and snap to a point in the future.
+            // as we are snapping to beat length via SnapTime (which will round-to-nearest), check for snapping in the forward direction and reverse it.
+            if (snappedEndTime > actualDuration + 1)
+                snappedEndTime -= beatLength;
+
+            return DurationToDistance(referenceTime, snappedEndTime - referenceTime);
+        }
+
+        #endregion
+
+        private class LocalScrollingInfo : IScrollingInfo
+        {
+            public IBindable<ScrollingDirection> Direction { get; } = new Bindable<ScrollingDirection>(ScrollingDirection.Left);
+
+            public IBindable<double> TimeRange { get; } = new BindableDouble(1500);
+
+            public IScrollAlgorithm Algorithm { get; set; } = new SequentialScrollAlgorithm(new List<MultiplierControlPoint>());
+        }
+
+        private class StopClock : IFrameBasedClock
+        {
+            public StopClock(double targetTime)
+            {
+                CurrentTime = targetTime;
+            }
+
+            public double ElapsedFrameTime => 0;
+
+            public double FramesPerSecond => 0;
+
+            public FrameTimeInfo TimeInfo => new FrameTimeInfo { Current = CurrentTime, Elapsed = ElapsedFrameTime };
+
+            public double CurrentTime { get; private set; }
+
+            public double Rate => 0;
+
+            public bool IsRunning => false;
+
+            public void ProcessFrame()
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
+++ b/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
@@ -274,5 +274,29 @@
       "lyrics_interval": 5,
       "romaji_margin": 8,
     }
-  ]
+  ],
+  "note_skins": [
+    {
+      "name": "Note-1",
+      "note_color" : {
+        "r": 0.26666668,
+        "g": 0.6666667,
+        "b": 0.8666667,
+        "a": 1.0
+      },
+      "blink_color" : {
+        "r": 1.0,
+        "g": 0.4,
+        "b": 0.6666667,
+        "a": 1.0
+      },
+      "text_color" : {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 1.0
+      },
+      "bold_text" : "true"
+    }
+  ],
  }

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeInternalSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeInternalSkin.cs
@@ -14,6 +14,7 @@ using osu.Game.IO;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts;
+using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Notes;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning
@@ -25,6 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
     {
         protected readonly Bindable<LyricFont> BindableFont;
         protected readonly Bindable<LyricLayout> BindableLayout;
+        protected readonly Bindable<NoteSkin> BindableNote;
 
         protected abstract string ResourceName { get; }
 
@@ -40,6 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
 
                 BindableFont = new Bindable<LyricFont>(skin.Fonts.FirstOrDefault());
                 BindableLayout = new Bindable<LyricLayout>(skin.Layouts.FirstOrDefault());
+                BindableNote = new Bindable<NoteSkin>(skin.NoteSkins.FirstOrDefault());
             }
         }
 
@@ -63,6 +66,9 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
 
                 case KaraokeSkinConfiguration.LyricLayout:
                     return SkinUtils.As<TValue>(BindableLayout);
+
+                case KaraokeSkinConfiguration.NoteStyle:
+                    return SkinUtils.As<TValue>(BindableNote);
 
                 default:
                     throw new NotSupportedException();


### PR DESCRIPTION
Base implement edit note overlay
.
What's add to this PR:
- implement base time-tag overlay.
- fix that internal default skin should contain note.
- add note playfield in overlay and let it movable.
- able to interact with notes, e.g draggable.
.
What might not be implemented:
- fix drag note position in lyric edit overlay.
- should implement its own note playfield.