### PR TITLE
Implement default lyric piece

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/EditorLyricPiece.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Rulesets.Karaoke.Skinning.Default;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
 {
@@ -13,9 +16,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
     {
         public Action<LyricFont> ApplyFontAction;
 
+        protected Lyric HitObject;
+
         public EditorLyricPiece(Lyric lyric)
             : base(lyric)
         {
+            HitObject = lyric;
+
             DisplayRuby = true;
             DisplayRomaji = true;
         }
@@ -56,6 +63,33 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             }
 
             return new TextIndex(text.Length - 1, TextIndex.IndexState.End);
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(ISkinSource skin)
+        {
+            // this is a temp way to apply font.
+            skin.GetConfig<KaraokeSkinLookup, LyricFont>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricStyle, HitObject.Singers))?.BindValueChanged(karaokeFont =>
+            {
+                var newFont = karaokeFont.NewValue;
+                if (newFont == null)
+                    return;
+
+                ApplyFont(karaokeFont.NewValue);
+
+                // Apply text font info
+                var lyricFont = newFont.LyricTextFontInfo.LyricTextFontInfo;
+                Font = getFont(lyricFont.CharSize);
+
+                var rubyFont = newFont.RubyTextFontInfo.LyricTextFontInfo;
+                RubyFont = getFont(rubyFont.CharSize);
+
+                var romajiFont = newFont.RomajiTextFontInfo.LyricTextFontInfo;
+                RomajiFont = getFont(romajiFont.CharSize);
+
+                static FontUsage getFont(float? charSize = null)
+                    => FontUsage.Default.With(size: charSize * 2);
+            }, true);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/EditorLyricPiece.cs
@@ -2,53 +2,28 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Objects.Drawables;
+using osu.Game.Rulesets.Karaoke.Skinning.Default;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
-using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
 {
-    public class DrawableEditLyric : DrawableLyric
+    public class EditorLyricPiece : DefaultLyricPiece
     {
         public Action<LyricFont> ApplyFontAction;
 
-        public DrawableEditLyric(Lyric lyric)
+        public EditorLyricPiece(Lyric lyric)
             : base(lyric)
         {
             DisplayRuby = true;
             DisplayRomaji = true;
         }
 
-        protected override void ApplyFont(LyricFont font)
+        public override void ApplyFont(LyricFont font)
         {
             ApplyFontAction?.Invoke(font);
             base.ApplyFont(font);
-        }
-
-        protected override void ApplyLayout(LyricLayout layout)
-        {
-            base.ApplyLayout(layout);
-            Padding = new MarginPadding(0);
-        }
-
-        protected override void UpdateStartTimeStateTransforms()
-        {
-            // Do not fade-in / fade-out while changing armed state.
-        }
-
-        public override double LifetimeStart
-        {
-            get => double.MinValue;
-            set => base.LifetimeStart = double.MinValue;
-        }
-
-        public override double LifetimeEnd
-        {
-            get => double.MaxValue;
-            set => base.LifetimeEnd = double.MaxValue;
         }
 
         public float GetPercentageWidth(int startIndex, int endIndex, float percentage = 0)
@@ -58,19 +33,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             // todo : it's a temp way to get position.
             TextIndex getTextIndexByIndex(int index)
             {
-                if (HitObject.Text?.Length <= index)
+                if (Text?.Length <= index)
                     return new TextIndex(index - 1, TextIndex.IndexState.End);
 
                 return new TextIndex(index);
             }
         }
 
-        public float GetPercentageWidth(TextIndex startIndex, TextIndex endIndex, float percentage = 0)
-            => KaraokeText.GetPercentageWidth(startIndex, endIndex, percentage);
-
         public TextIndex GetHoverIndex(float position)
         {
-            var text = KaraokeText.Text;
+            var text = Text;
             if (string.IsNullOrEmpty(text))
                 return new TextIndex();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
@@ -48,7 +48,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
                     {
                         // need to delay until karaoke text has been calculated.
                         ScheduleAfterChildren(UpdateTimeTags);
-                        caretContainer.Height = font.LyricTextFontInfo.LyricTextFontInfo.CharSize * 1.7f;
+                        // it's a magic number and should find a way to fix that.
+                        caretContainer.Height = font.LyricTextFontInfo.LyricTextFontInfo.CharSize * 2f + 13; 
                     }
                 },
                 timeTagContainer = new Container
@@ -309,14 +310,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             var isEnd = Lyric.Text?.Length <= textIndex;
             var percentage = isEnd ? 1 : 0;
             var offset = isEnd ? 10 : -10; // todo : might have better way to get position.
-            return lyricPiece.GetPercentageWidth(textIndex, textIndex + 1, percentage) * 2 + offset;
+            return lyricPiece.GetPercentageWidth(textIndex, textIndex + 1, percentage) + offset;
         }
 
         private float textIndexPosition(TextIndex textIndex)
         {
             var isStart = textIndex.State == TextIndex.IndexState.Start;
             var percentage = isStart ? 0 : 1;
-            return lyricPiece.GetPercentageWidth(textIndex, textIndex, percentage) * 2;
+            return lyricPiece.GetPercentageWidth(textIndex, textIndex, percentage);
         }
 
         private float extraSpacing(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricRows/Lyrics/LyricControl.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
     {
         private const int time_tag_spacing = 8;
 
-        private readonly DrawableEditLyric drawableLyric;
+        private readonly EditorLyricPiece lyricPiece;
         private readonly Container timeTagContainer;
         private readonly Container caretContainer;
 
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             Padding = new MarginPadding { Bottom = 10 };
             Children = new Drawable[]
             {
-                drawableLyric = new DrawableEditLyric(lyric)
+                lyricPiece = new EditorLyricPiece(lyric)
                 {
                     ApplyFontAction = font =>
                     {
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
                 }
             };
 
-            drawableLyric.RomajiTagsBindable.BindValueChanged(e =>
+            lyricPiece.RomajiTagsBindable.BindValueChanged(e =>
             {
                 var displayRomaji = e?.NewValue?.Any() ?? false;
                 var marginWidth = displayRomaji ? 30 : 15;
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
                 caretContainer.Margin = new MarginPadding { Bottom = marginWidth };
             }, true);
 
-            drawableLyric.TimeTagsBindable.BindValueChanged(e =>
+            lyricPiece.TimeTagsBindable.BindValueChanged(e =>
             {
                 ScheduleAfterChildren(UpdateTimeTags);
             });
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
                 return false;
 
             var position = ToLocalSpace(e.ScreenSpaceMousePosition).X / 2;
-            var index = drawableLyric.GetHoverIndex(position);
+            var index = lyricPiece.GetHoverIndex(position);
 
             switch (state.Mode)
             {
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
         [BackgroundDependencyLoader]
         private void load(EditorClock clock)
         {
-            drawableLyric.Clock = clock;
+            lyricPiece.Clock = clock;
             state.BindableMode.BindValueChanged(e =>
             {
                 // initial default caret here
@@ -288,7 +288,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
         protected void UpdateTimeTags()
         {
             timeTagContainer.Clear();
-            var timeTags = drawableLyric.TimeTagsBindable.Value;
+            var timeTags = lyricPiece.TimeTagsBindable.Value;
             if (timeTags == null)
                 return;
 
@@ -309,20 +309,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricRows.Lyrics
             var isEnd = Lyric.Text?.Length <= textIndex;
             var percentage = isEnd ? 1 : 0;
             var offset = isEnd ? 10 : -10; // todo : might have better way to get position.
-            return drawableLyric.GetPercentageWidth(textIndex, textIndex + 1, percentage) * 2 + offset;
+            return lyricPiece.GetPercentageWidth(textIndex, textIndex + 1, percentage) * 2 + offset;
         }
 
         private float textIndexPosition(TextIndex textIndex)
         {
             var isStart = textIndex.State == TextIndex.IndexState.Start;
             var percentage = isStart ? 0 : 1;
-            return drawableLyric.GetPercentageWidth(textIndex, textIndex, percentage) * 2;
+            return lyricPiece.GetPercentageWidth(textIndex, textIndex, percentage) * 2;
         }
 
         private float extraSpacing(TimeTag timeTag)
         {
             var isStart = timeTag.Index.State == TextIndex.IndexState.Start;
-            var timeTags = isStart ? drawableLyric.TimeTagsBindable.Value.Reverse() : drawableLyric.TimeTagsBindable.Value;
+            var timeTags = isStart ? lyricPiece.TimeTagsBindable.Value.Reverse() : lyricPiece.TimeTagsBindable.Value;
             var duplicatedTagAmount = timeTags.SkipWhile(t => t != timeTag).Count(x => x.Index == timeTag.Index) - 1;
             var spacing = duplicatedTagAmount * time_tag_spacing * (isStart ? 1 : -1);
             return spacing;

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Skinning;
+using System;
+using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Skinning.Default
+{
+    /// <summary>
+    /// This component is focusing on display ruby and romaji.
+    /// </summary>
+    public class DefaultLyricPiece : KaraokeSpriteText
+    {
+        private const int whole_chunk_index = -1;
+
+        public readonly IBindable<string> TextBindable = new Bindable<string>();
+        public readonly IBindable<TimeTag[]> TimeTagsBindable = new Bindable<TimeTag[]>();
+        public readonly IBindable<RubyTag[]> RubyTagsBindable = new Bindable<RubyTag[]>();
+        public readonly IBindable<RomajiTag[]> RomajiTagsBindable = new Bindable<RomajiTag[]>();
+
+        private readonly Lyric hitObject;
+        private readonly int chunkIndex;
+
+        public DefaultLyricPiece(Lyric hitObject, int chunkIndex = whole_chunk_index)
+        {
+            this.hitObject = hitObject;
+            this.chunkIndex = chunkIndex;
+
+            TextBindable.BindTo(hitObject.TextBindable);
+            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
+            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
+            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(ISkinSource skin)
+        {
+            TextBindable.BindValueChanged(text => applyText(text.NewValue));
+            TimeTagsBindable.BindValueChanged(timeTags => applyTimeTag(timeTags.NewValue));
+            RubyTagsBindable.BindValueChanged(rubyTags => applyRuby(rubyTags.NewValue));
+            RomajiTagsBindable.BindValueChanged(romajiTags => applyRomaji(romajiTags.NewValue));
+        }
+
+        private void applyText(string text)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Text = text;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyTimeTag(TimeTag[] timeTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                TimeTags = TimeTagsUtils.ToDictionary(timeTags);
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyRuby(RubyTag[] rubyTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Rubies = DisplayRuby ? rubyTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyRomaji(RomajiTag[] romajiTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Romajies = DisplayRomaji ? romajiTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        protected virtual void ApplyFont(LyricFont font)
+        {
+            // From text sample
+            FrontTextTexture = new SolidTexture { SolidColor = Color4.Blue }; // font.FrontTextBrushInfo.TextBrush.ConvertToTextureSample();
+            FrontBorderTexture = font.FrontTextBrushInfo.BorderBrush.ConvertToTextureSample();
+            FrontTextShadowTexture = font.FrontTextBrushInfo.ShadowBrush.ConvertToTextureSample();
+
+            // Back text sample
+            BackTextTexture = font.BackTextBrushInfo.TextBrush.ConvertToTextureSample();
+            BackBorderTexture = font.BackTextBrushInfo.BorderBrush.ConvertToTextureSample();
+            BackTextShadowTexture = font.BackTextBrushInfo.ShadowBrush.ConvertToTextureSample();
+
+            // Apply text info
+            var lyricFont = font.LyricTextFontInfo.LyricTextFontInfo;
+            Border = lyricFont.EdgeSize > 0;
+            BorderRadius = lyricFont.EdgeSize;
+
+            // Apply shadow
+            Shadow = font.UseShadow;
+            ShadowOffset = font.ShadowOffset;
+        }
+
+        private bool displayRuby;
+
+        public bool DisplayRuby
+        {
+            get => displayRuby;
+            set
+            {
+                if (displayRuby == value)
+                    return;
+
+                displayRuby = value;
+                Schedule(() => applyRuby(hitObject.RubyTags));
+            }
+        }
+
+        private bool displayRomaji;
+
+        public bool DisplayRomaji
+        {
+            get => displayRomaji;
+            set
+            {
+                if (displayRomaji == value)
+                    return;
+
+                displayRomaji = value;
+                Schedule(() => applyRomaji(hitObject.RomajiTags));
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            TextBindable.UnbindFrom(hitObject.TextBindable);
+            TimeTagsBindable.UnbindFrom(hitObject.TimeTagsBindable);
+            RubyTagsBindable.UnbindFrom(hitObject.RubyTagsBindable);
+            RomajiTagsBindable.UnbindFrom(hitObject.RomajiTagsBindable);
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
@@ -34,19 +34,15 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Default
             this.hitObject = hitObject;
             this.chunkIndex = chunkIndex;
 
-            TextBindable.BindTo(hitObject.TextBindable);
-            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
-            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
-            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
-        }
-
-        [BackgroundDependencyLoader(true)]
-        private void load(ISkinSource skin)
-        {
             TextBindable.BindValueChanged(text => applyText(text.NewValue));
             TimeTagsBindable.BindValueChanged(timeTags => applyTimeTag(timeTags.NewValue));
             RubyTagsBindable.BindValueChanged(rubyTags => applyRuby(rubyTags.NewValue));
             RomajiTagsBindable.BindValueChanged(romajiTags => applyRomaji(romajiTags.NewValue));
+
+            TextBindable.BindTo(hitObject.TextBindable);
+            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
+            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
+            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
         }
 
         private void applyText(string text)
@@ -97,7 +93,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Default
             }
         }
 
-        protected virtual void ApplyFont(LyricFont font)
+        public virtual void ApplyFont(LyricFont font)
         {
             // From text sample
             FrontTextTexture = new SolidTexture { SolidColor = Color4.Blue }; // font.FrontTextBrushInfo.TextBrush.ConvertToTextureSample();

--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
@@ -2,12 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
-using osu.Game.Skinning;
 using System;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Fonts;
 using osuTK.Graphics;


### PR DESCRIPTION
Separate karaoke lyric in drawable lyric into a new piece, called `DefaultLyricPiece`
.
Why this change needed:
- `DefaultLyricPiece` is focused on text and style display, remain part like layout will be handled in the parent.
- some case not wants to use the whole feature of drawable lyrics, so `DefaultLyricPiece` might be a better choice for use.
- fix style broken in the lyric editor.
- better for future works(V2).