### PR TITLE
Implement time-tag with and without time tag style

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditor.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -48,24 +47,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
-            AddInternal(new Container
+            AddInternal(background = new Box
             {
+                Name = "Background",
                 Depth = 1,
                 RelativeSizeAxes = Axes.X,
                 Height = timeline_height,
-                Masking = true,
-                EdgeEffect = new EdgeEffectParameters
-                {
-                    Type = EdgeEffectType.Shadow,
-                },
-                Children = new[]
-                {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colour.Gray3,
-                    }
-                }
+                Colour = colour.Gray3,
             });
             AddRange(new Drawable[]
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditor.cs
@@ -3,9 +3,11 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
@@ -15,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
     [Cached]
     public class TimeTagEditor : ZoomableScrollContainer
     {
-        private const float timeline_height = 48;
+        private const float timeline_height = 38;
 
         [Resolved]
         private EditorClock editorClock { get; set; }
@@ -27,12 +29,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             HitObject = lyric;
 
             RelativeSizeAxes = Axes.X;
+            Padding = new MarginPadding { Top = 10 };
             Height = timeline_height;
 
             ZoomDuration = 200;
             ZoomEasing = Easing.OutQuint;
             ScrollbarVisible = false;
         }
+
+        private Box background;
 
         private Container mainContent;
 
@@ -41,8 +46,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
         private TimelineTickDisplay ticks;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuColour colour)
         {
+            AddInternal(new Container
+            {
+                Depth = 1,
+                RelativeSizeAxes = Axes.X,
+                Height = timeline_height,
+                Masking = true,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Shadow,
+                },
+                Children = new[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colour.Gray3,
+                    }
+                }
+            });
             AddRange(new Drawable[]
             {
                 mainContent = new Container
@@ -62,14 +86,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             // initialize scroll zone.
             MaxZoom = getZoomLevelForVisibleMilliseconds(500);
             MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-            Zoom = getZoomLevelForVisibleMilliseconds(2000);
+            Zoom = getZoomLevelForVisibleMilliseconds(3000);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            var position = getPositionFromTime(HitObject.LyricStartTime);
+            const float preempt_time = 200;
+            var position = getPositionFromTime(HitObject.LyricStartTime - preempt_time);
             ScrollTo(position, false);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
@@ -81,13 +81,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             {
                 case TextIndex.IndexState.Start:
                     timeTagPiece.Origin = Anchor.CentreLeft;
-                    timeTagWithNoTimePiece.Origin = Anchor.TopLeft;
+                    timeTagWithNoTimePiece.Origin = Anchor.BottomLeft;
                     timeTagText.Origin = Anchor.TopLeft;
                     break;
 
                 case TextIndex.IndexState.End:
                     timeTagPiece.Origin = Anchor.CentreRight;
-                    timeTagWithNoTimePiece.Origin = Anchor.TopRight;
+                    timeTagWithNoTimePiece.Origin = Anchor.BottomLeft;
                     timeTagText.Origin = Anchor.TopRight;
                     break;
             }
@@ -100,8 +100,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             timeTagWithNoTimePiece.Colour = colours.Red;
             startTime.BindValueChanged(e =>
             {
-                // assign blueprint position in here.
-                var hasValue = e.NewValue.HasValue;
+                // adjust style if time changed.
+                var hasValue = hasTime();
 
                 switch (hasValue)
                 {
@@ -118,6 +118,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             }, true);
         }
 
+        private bool hasTime() => this.startTime.Value.HasValue;
+
         protected override void OnSelected()
         {
             // base logic hides selected blueprints when not selected, but timeline doesn't do that.
@@ -129,9 +131,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            timeTagPiece.ReceivePositionalInputAt(screenSpacePos);
+            hasTime() ? timeTagPiece.ReceivePositionalInputAt(screenSpacePos) : timeTagWithNoTimePiece.ReceivePositionalInputAt(screenSpacePos);
 
-        public override Quad SelectionQuad => timeTagPiece.ScreenSpaceDrawQuad;
+        public override Quad SelectionQuad =>
+            hasTime() ? timeTagPiece.ScreenSpaceDrawQuad : timeTagWithNoTimePiece.ScreenSpaceDrawQuad;
 
         public override Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.TopLeft;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
@@ -22,14 +22,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
 {
     public class TimeTagEditorHitObjectBlueprint : SelectionBlueprint<TimeTag>
     {
-        private const float circle_size = 38;
-
         public Action<DragEvent> OnDragHandled;
 
         [UsedImplicitly]
         private readonly Bindable<double?> startTime;
 
         private readonly TimeTagPiece timeTagPiece;
+        private readonly TimeTagWithNoTimePiece timeTagWithNoTimePiece;
         private readonly OsuSpriteText timeTagText;
 
         public TimeTagEditorHitObjectBlueprint(TimeTag item)
@@ -51,13 +50,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
                 else
                 {
                     // todo : should get relative position.
+                    X = 18000f;
                 }
             }, true);
 
             RelativePositionAxes = Axes.X;
 
-            RelativeSizeAxes = Axes.X;
-            Height = circle_size;
+            RelativeSizeAxes = Axes.Y;
+            AutoSizeAxes = Axes.X;
 
             AddRangeInternal(new Drawable[]
             {
@@ -65,10 +65,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
                 {
                     Anchor = Anchor.CentreLeft,
                 },
+                timeTagWithNoTimePiece = new TimeTagWithNoTimePiece(item)
+                {
+                    Anchor = Anchor.BottomLeft,
+                },
                 timeTagText = new OsuSpriteText
                 {
                     Text = "Demo",
                     Anchor = Anchor.BottomLeft,
+                    Y = 10,
                 }
             });
 
@@ -76,11 +81,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             {
                 case TextIndex.IndexState.Start:
                     timeTagPiece.Origin = Anchor.CentreLeft;
+                    timeTagWithNoTimePiece.Origin = Anchor.TopLeft;
                     timeTagText.Origin = Anchor.TopLeft;
                     break;
 
                 case TextIndex.IndexState.End:
                     timeTagPiece.Origin = Anchor.CentreRight;
+                    timeTagWithNoTimePiece.Origin = Anchor.TopRight;
                     timeTagText.Origin = Anchor.TopRight;
                     break;
             }
@@ -89,6 +96,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
+            timeTagPiece.Colour = colours.BlueLight;
+            timeTagWithNoTimePiece.Colour = colours.Red;
             startTime.BindValueChanged(e =>
             {
                 // assign blueprint position in here.
@@ -97,11 +106,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
                 switch (hasValue)
                 {
                     case true:
-                        timeTagPiece.Colour = colours.BlueLight;
+                        timeTagPiece.Show();
+                        timeTagWithNoTimePiece.Hide();
                         break;
 
                     case false:
-                        timeTagPiece.Colour = colours.Red;
+                        timeTagPiece.Hide();
+                        timeTagWithNoTimePiece.Show();
                         break;
                 }
             }, true);
@@ -161,6 +172,37 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
                         triangle.Scale = new Vector2(-1, 1);
                         box.Anchor = Anchor.CentreRight;
                         box.Origin = Anchor.CentreRight;
+                        break;
+                }
+            }
+        }
+
+        public class TimeTagWithNoTimePiece : CompositeDrawable
+        {
+            protected readonly RightTriangle triangle;
+
+            public TimeTagWithNoTimePiece(TimeTag timeTag)
+            {
+                AutoSizeAxes = Axes.Y;
+                Width = 10;
+                InternalChildren = new Drawable[]
+                {
+                    triangle = new RightTriangle
+                    {
+                        Size = new Vector2(10),
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre
+                    }
+                };
+
+                switch (timeTag.Index.State)
+                {
+                    case TextIndex.IndexState.Start:
+                        triangle.Scale = new Vector2(1);
+                        break;
+
+                    case TextIndex.IndexState.End:
+                        triangle.Scale = new Vector2(-1, 1);
                         break;
                 }
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/117533835-d514f400-b029-11eb-9b56-c0f685e55a59.png)
It's part of the style implementation of #594 
.
What's add to this PR:
- implement time-tag style in `TimeTagEditorHitObjectBlueprint`
- add background and adjust style in `TimeTagEditor`
- adjust zoom and preview start time in  `TimeTagEditor`