### PR TITLE
Implement click to navigation to target time.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseTagHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseTagHelper.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.IO;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -155,6 +158,34 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Helper
                     new TimeTag(new TextIndex((int)text?.Length - 1, TextIndex.IndexState.End), endTime)
                 }
             };
+        }
+
+        /// <summary>
+        /// Process test case lyric string format into <see cref="Lyric"/>
+        /// </summary>
+        /// <example>
+        /// "[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]"
+        /// </example>
+        /// <param name="str">Lyric string format</param>
+        /// <returns><see cref="Lyric"/>Lyric object</returns>
+        public static Lyric ParseLyricWithTimeTag(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return new Lyric();
+
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            using (var reader = new LineBufferedReader(stream))
+            {
+                // Create stream
+                writer.Write(str);
+                writer.Flush();
+                stream.Position = 0;
+
+                // Create karaoke note decoder
+                var decoder = new LrcDecoder();
+                return decoder.Decode(reader).HitObjects.OfType<Lyric>().FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -167,6 +167,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("からおけ", "[0,end]", "-か")]
         [TestCase("からおけ", "[3,start]", "け-")]
         [TestCase("からおけ", "[3,end]", "-からおけ")]
+        [TestCase("からおけ", "[4,start]", "-")] // not showing text if index out of range.
+        [TestCase("からおけ", "[4,end]", "-")]
+        [TestCase("からおけ", "[-1,start]", "-")]
+        [TestCase("からおけ", "[-1,end]", "-")]
         public void TestGetTimeTagIndexDisplayText(string text, string textIndexStr, string actual)
         {
             var lyric = TestCaseTagHelper.ParseLyricWithTimeTag(text);

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -155,6 +155,25 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(LyricUtils.HasTimedTimeTags(lyric), hasTimedTimeTag);
         }
 
+        [TestCase("[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]", "[0,start]", "か-")]
+        [TestCase("[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]", "[0,end]", "-か")]
+        [TestCase("[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]", "[3,start]", "け-")]
+        [TestCase("[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]", "[3,end]", "-け")]
+        [TestCase("[00:01.00]からおけ[00:05.00]", "[0,start]", "からおけ-")]
+        [TestCase("[00:01.00]からおけ[00:05.00]", "[0,end]", "-か")]
+        [TestCase("[00:01.00]からおけ[00:05.00]", "[3,start]", "け-")]
+        [TestCase("[00:01.00]からおけ[00:05.00]", "[3,end]", "-からおけ")]
+        [TestCase("からおけ", "[0,start]", "からおけ-")]
+        [TestCase("からおけ", "[0,end]", "-か")]
+        [TestCase("からおけ", "[3,start]", "け-")]
+        [TestCase("からおけ", "[3,end]", "-からおけ")]
+        public void TestGetTimeTagIndexDisplayText(string text, string textIndexStr, string actual)
+        {
+            var lyric = TestCaseTagHelper.ParseLyricWithTimeTag(text);
+            var textIndex = TestCaseTagHelper.ParseTextIndex(textIndexStr);
+            Assert.AreEqual(LyricUtils.GetTimeTagIndexDisplayText(lyric, textIndex), actual);
+        }
+
         #endregion
 
         #region Time display

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorBlueprintContainer.cs
@@ -16,6 +16,7 @@ using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osu.Game.Screens.Edit.Compose.Components;
 
@@ -25,6 +26,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
     {
         [Resolved(CanBeNull = true)]
         private TimeTagEditor timeline { get; set; }
+
+        [Resolved]
+        private EditorClock editorClock { get; set; }
 
         [Resolved]
         private LyricManager lyricManager { get; set; }
@@ -119,6 +123,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
             => new TimeTagEditorHitObjectBlueprint(item);
 
         protected override DragBox CreateDragBox(Action<RectangleF> performSelect) => new TimelineDragBox(performSelect);
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            base.OnClick(e);
+
+            // skip if already have selected blueprint.
+            if (ClickedBlueprint != null)
+                return true;
+
+            // navigation to target time.
+            var navigationTime = timeline.SnapScreenSpacePositionToValidTime(e.ScreenSpaceMousePosition);
+            if (navigationTime.Time == null)
+                return false;
+
+            editorClock.SeekSmoothlyTo(navigationTime.Time.Value);
+            return true;
+        }
 
         protected class TimeTagEditorSelectionHandler : SelectionHandler<TimeTag>
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Overlays/Components/TimeTagEditor/TimeTagEditorHitObjectBlueprint.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEditor
@@ -78,6 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Overlays.Components.TimeTagEdito
         [BackgroundDependencyLoader]
         private void load(TimeTagEditor timeline, OsuColour colours)
         {
+            timeTagText.Text = LyricUtils.GetTimeTagIndexDisplayText(timeline.HitObject, Item.Index);
             timeTagPiece.Colour = colours.BlueLight;
             timeTagWithNoTimePiece.Colour = colours.Red;
             startTime.BindValueChanged(e =>

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -168,6 +168,10 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             if (string.IsNullOrEmpty(text))
                 throw new ArgumentNullException(nameof(text));
 
+            // not showing text if index out of range.
+            if (index.Index < 0 || index.Index >= text.Length)
+                return "-";
+
             var timeTags = lyric.TimeTags;
 
             if (index.State == TextIndex.IndexState.Start)

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -156,6 +157,36 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         public static bool HasTimedTimeTags(Lyric lyric)
         {
             return lyric?.TimeTags?.Any(x => x.Time.HasValue) ?? false;
+        }
+
+        public static string GetTimeTagIndexDisplayText(Lyric lyric, TextIndex index)
+        {
+            if (lyric == null)
+                throw new ArgumentNullException(nameof(lyric));
+
+            var text = lyric.Text;
+            if (string.IsNullOrEmpty(text))
+                throw new ArgumentNullException(nameof(text));
+
+            var timeTags = lyric.TimeTags;
+
+            if (index.State == TextIndex.IndexState.Start)
+            {
+                var previousTimeTag = timeTags.FirstOrDefault(x => x.Index > index);
+                var startIndex = index.Index;
+                var endIndex = previousTimeTag?.Index.Index ?? text.Length;
+                return $"{text.Substring(startIndex, endIndex - startIndex)}-";
+            }
+
+            if (index.State == TextIndex.IndexState.End)
+            {
+                var previousTimeTag = timeTags.Reverse().FirstOrDefault(x => x.Index < index);
+                var startIndex = previousTimeTag?.Index.Index ?? 0;
+                var endIndex = index.Index + 1;
+                return $"-{text.Substring(startIndex, endIndex - startIndex)}";
+            }
+
+            throw new IndexOutOfRangeException(nameof(index.State));
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         #endregion
 
-        #region Text tags
+        #region Time tags
 
         public static bool HasTimedTimeTags(List<Lyric> lyrics)
             => lyrics?.Any(LyricUtils.HasTimedTimeTags) ?? false;


### PR DESCRIPTION
Implement part of #594 

What's changed in this pr:
- Implement click to navigation time.
- Implement time-tag display text change.
- Add `ParseLyricWithTimeTag` in lyric test utils.