### PR TITLE
Use lazy way to fix CD not working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: Setup dotnet version
+      uses: actions/setup-dotnet@v1 # Build with netCore 3.1 because ILRepack not support .net5
+      with:
+        dotnet-version: '3.1.x' # SDK Version to use.
     - name: Fetch all tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Get current tag


### PR DESCRIPTION
because ILRepack not working in .net5
so should roll-back environment from .net5 to .netCore 3.1

Caused in #413 