### PR TITLE
Add bindable start index and bindable end index into ruby / romaji tag.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Asserts/TextTagAssert.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Asserts/TextTagAssert.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Asserts
 
             for (int i = 0; i < expect.Count; i++)
             {
-                AreEqual(expect[i], actually[i]);
-                AreEqual(expect[i], actually[i]);
+                ArePropertyEqual(expect[i], actually[i]);
+                ArePropertyEqual(expect[i], actually[i]);
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Asserts/TextTagAssert.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Asserts/TextTagAssert.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Asserts
+{
+    public class TextTagAssert : Assert
+    {
+        public static void ArePropertyEqual<T>(IReadOnlyList<T> expect, IReadOnlyList<T> actually) where T : ITextTag
+        {
+            AreEqual(expect?.Count, actually?.Count);
+            if (expect == null || actually == null)
+                return;
+
+            for (int i = 0; i < expect.Count; i++)
+            {
+                AreEqual(expect[i], actually[i]);
+                AreEqual(expect[i], actually[i]);
+            }
+        }
+
+        public static void ArePropertyEqual<T>(T expect, T actually) where T : ITextTag
+        {
+            AreEqual(expect.Text, actually.Text);
+            AreEqual(expect.StartIndex, actually.StartIndex);
+            AreEqual(expect.EndIndex, actually.EndIndex);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Asserts/TimeTagAssert.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Asserts/TimeTagAssert.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Asserts
 {
     public class TimeTagAssert : Assert
     {
-        public static void AreEqual(IReadOnlyList<TimeTag> expect, IReadOnlyList<TimeTag> actually)
+        public static void ArePropertyEqual(IReadOnlyList<TimeTag> expect, IReadOnlyList<TimeTag> actually)
         {
             AreEqual(expect?.Count, actually?.Count);
             if (expect == null || actually == null)
@@ -17,9 +17,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Asserts
 
             for (int i = 0; i < expect.Count; i++)
             {
-                AreEqual(expect[i].Index, actually[i].Index);
-                AreEqual(expect[i].Time, actually[i].Time);
+                ArePropertyEqual(expect[i], actually[i]);
             }
+        }
+
+        public static void ArePropertyEqual(TimeTag expect, TimeTag actually)
+        {
+            AreEqual(expect.Index, actually.Index);
+            AreEqual(expect.Time, actually.Time);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -36,17 +36,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
 
                 var working = new TestWorkingBeatmap(decoder.Decode(stream));
 
-                Assert.AreEqual(1, working.BeatmapInfo.BeatmapVersion);
-                Assert.AreEqual(1, working.Beatmap.BeatmapInfo.BeatmapVersion);
-                Assert.AreEqual(1, working.GetPlayableBeatmap(new KaraokeRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapInfo.BeatmapVersion);
+                Assert.AreEqual(working.BeatmapInfo.BeatmapVersion, 1);
+                Assert.AreEqual(working.Beatmap.BeatmapInfo.BeatmapVersion, 1);
+                Assert.AreEqual(working.GetPlayableBeatmap(new KaraokeRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapInfo.BeatmapVersion, 1);
 
                 // Test lyric part decode result
                 var lyrics = working.Beatmap.HitObjects.OfType<Lyric>();
-                Assert.AreEqual(54, lyrics.Count());
+                Assert.AreEqual(lyrics.Count(), 54);
 
                 // Test note decode part
                 var notes = working.Beatmap.HitObjects.OfType<Note>().Where(x => x.Display).ToList();
-                Assert.AreEqual(36, notes.Count);
+                Assert.AreEqual(notes.Count, 36);
 
                 testNote("た", 0, note: notes[0]);
                 testNote("だ", 0, note: notes[1]);
@@ -142,8 +142,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
 
         private static void testNote(string text, int tone, bool half = false, Note note = null)
         {
-            Assert.AreEqual(text, note?.Text);
-            Assert.AreEqual(tone, note?.Tone.Scale);
+            Assert.AreEqual(note?.Text, text);
+            Assert.AreEqual(note?.Tone.Scale, tone);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -5,6 +5,7 @@ using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags.Ja;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RomajiTags.Ja
@@ -38,7 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RomajiTags.Ja
             var romajiTags = generator.CreateRomajiTags(lyric);
             var actualRomajiTags = TestCaseTagHelper.ParseRomajiTags(actualRomaji);
 
-            Assert.AreEqual(romajiTags, actualRomajiTags);
+            TextTagAssert.ArePropertyEqual(romajiTags, actualRomajiTags);
         }
 
         private JaRomajiTagGeneratorConfig generatorConfig(params string[] properties)

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RomajiTags/RomajiTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RomajiTags/RomajiTagGeneratorSelectorTest.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RomajiTags
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RomajiTags
             };
             var selector = new RomajiTagGeneratorSelector();
             var generatedRomaji = selector.GenerateRomajiTags(lyric);
-            Assert.AreEqual(generatedRomaji, TestCaseTagHelper.ParseRomajiTags(actualRomaji));
+            TextTagAssert.ArePropertyEqual(generatedRomaji, TestCaseTagHelper.ParseRomajiTags(actualRomaji));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -5,6 +5,7 @@ using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags.Ja
@@ -46,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags.Ja
             var rubyTags = generator.CreateRubyTags(lyric);
             var actualRubyTags = TestCaseTagHelper.ParseRubyTags(actualRuby);
 
-            Assert.AreEqual(rubyTags, actualRubyTags);
+            TextTagAssert.ArePropertyEqual(rubyTags, actualRubyTags);
         }
 
         private JaRubyTagGeneratorConfig generatorConfig(params string[] properties)

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/RubyTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/RubyTags/RubyTagGeneratorSelectorTest.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.RubyTags
             };
             var selector = new RubyTagGeneratorSelector();
             var generatedRuby = selector.GenerateRubyTags(lyric);
-            Assert.AreEqual(generatedRuby, TestCaseTagHelper.ParseRubyTags(actualRuby));
+            TextTagAssert.ArePropertyEqual(generatedRuby, TestCaseTagHelper.ParseRubyTags(actualRuby));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags
             var actualIndexed = TestCaseTagHelper.ParseTimeTags(actualTimeTags);
 
             // check should be equal
-            TimeTagAssert.AreEqual(timeTags, actualIndexed);
+            TimeTagAssert.ArePropertyEqual(timeTags, actualIndexed);
         }
 
         protected TConfig GeneratorConfig(params string[] properties)

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/TimeTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Generator/TimeTags/TimeTagGeneratorSelectorTest.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Generator.TimeTags
             };
             var selector = new TimeTagGeneratorSelector();
             var generatedTimeTags = selector.GenerateTimeTags(lyric);
-            TimeTagAssert.AreEqual(generatedTimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTag));
+            TimeTagAssert.ArePropertyEqual(generatedTimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTag));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RomajiTagConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RomajiTagConverterTest.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
 {
@@ -50,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
                 EndIndex = endIndex,
                 Text = text
             };
-            Assert.AreEqual(result, actual);
+            TextTagAssert.ArePropertyEqual(result, actual);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagConverterTest.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
 {
@@ -49,7 +50,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
                 EndIndex = endIndex,
                 Text = text
             };
-            Assert.AreEqual(result, actual);
+            TextTagAssert.ArePropertyEqual(result, actual);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
             LyricUtils.RemoveText(lyric, position, count);
-            TimeTagAssert.AreEqual(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
+            TimeTagAssert.ArePropertyEqual(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
         }
 
         [TestCase("kake", 2, "rao", "karaoke")]
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
             LyricUtils.AddText(lyric, position, addedText);
-            TimeTagAssert.AreEqual(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
+            TimeTagAssert.ArePropertyEqual(lyric.TimeTags, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 RubyTags = TestCaseTagHelper.ParseRubyTags(rubies),
             };
             LyricUtils.RemoveText(lyric, position, count);
-            Assert.AreEqual(lyric.RubyTags, TestCaseTagHelper.ParseRubyTags(targetRubies));
+            TextTagAssert.ArePropertyEqual(lyric.RubyTags, TestCaseTagHelper.ParseRubyTags(targetRubies));
         }
 
         [TestCase(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }, 0, 2, new[] { "[0,1]:o", "[1,2]:ke" })]
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 RomajiTags = TestCaseTagHelper.ParseRomajiTags(romajies),
             };
             LyricUtils.RemoveText(lyric, position, count);
-            Assert.AreEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
+            TextTagAssert.ArePropertyEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
         }
 
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, 2, new[] { "[0,start]:3000", "[1,start]:4000" })]
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 RubyTags = TestCaseTagHelper.ParseRubyTags(rubies),
             };
             LyricUtils.AddText(lyric, position, addedText);
-            Assert.AreEqual(lyric.RubyTags, TestCaseTagHelper.ParseRubyTags(targetRubies));
+            TextTagAssert.ArePropertyEqual(lyric.RubyTags, TestCaseTagHelper.ParseRubyTags(targetRubies));
         }
 
         [TestCase(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }, 0, "karaoke", new[] { "[7,8]:か", "[8,9]:ら", "[9,10]:お", "[10,11]:け" })]
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 RomajiTags = TestCaseTagHelper.ParseRomajiTags(romajies),
             };
             LyricUtils.AddText(lyric, position, addedText);
-            Assert.AreEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
+            TextTagAssert.ArePropertyEqual(lyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(targetRomajies));
         }
 
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, "karaoke", new[] { "[7,start]:1000", "[8,start]:2000", "[9,start]:3000", "[10,start]:4000" })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
@@ -54,8 +54,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var (firstLyric, secondLyric) = LyricsUtils.SplitLyric(lyric, splitIndex);
 
-            TimeTagAssert.AreEqual(firstLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(firstTimeTags));
-            TimeTagAssert.AreEqual(secondLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(secondTimeTags));
+            TimeTagAssert.ArePropertyEqual(firstLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(firstTimeTags));
+            TimeTagAssert.ArePropertyEqual(secondLyric.TimeTags, TestCaseTagHelper.ParseTimeTags(secondTimeTags));
         }
 
         [TestCase("カラオケ", new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }, 2,

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
@@ -76,8 +76,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var (firstLyric, secondLyric) = LyricsUtils.SplitLyric(lyric, splitIndex);
 
-            Assert.AreEqual(firstLyric.RubyTags, TestCaseTagHelper.ParseRubyTags(firstRubyTags));
-            Assert.AreEqual(secondLyric.RubyTags, TestCaseTagHelper.ParseRubyTags(secondRubyTags));
+            TextTagAssert.ArePropertyEqual(firstLyric.RubyTags, TestCaseTagHelper.ParseRubyTags(firstRubyTags));
+            TextTagAssert.ArePropertyEqual(secondLyric.RubyTags, TestCaseTagHelper.ParseRubyTags(secondRubyTags));
         }
 
         [TestCase("カラオケ", new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }, 2,
@@ -98,8 +98,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var (firstLyric, secondLyric) = LyricsUtils.SplitLyric(lyric, splitIndex);
 
-            Assert.AreEqual(firstLyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(firstRomajiTags));
-            Assert.AreEqual(secondLyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(secondRomajiTags));
+            TextTagAssert.ArePropertyEqual(firstLyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(firstRomajiTags));
+            TextTagAssert.ArePropertyEqual(secondLyric.RomajiTags, TestCaseTagHelper.ParseRomajiTags(secondRomajiTags));
         }
 
         [Ignore("Not really sure second lyric is based on lyric time or time-tag time.")]
@@ -248,7 +248,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var combineLyric = LyricsUtils.CombineLyric(lyric1, lyric2);
             var rubyTags = combineLyric.RubyTags;
-            Assert.AreEqual(rubyTags, TestCaseTagHelper.ParseRubyTags(actualRubyTags));
+            TextTagAssert.ArePropertyEqual(rubyTags, TestCaseTagHelper.ParseRubyTags(actualRubyTags));
         }
 
         [TestCase(new[] { "[0,0]:romaji" }, new[] { "[0,0]:ローマ字" }, new[] { "[0,0]:romaji", "[7,7]:ローマ字" })]
@@ -271,7 +271,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var combineLyric = LyricsUtils.CombineLyric(lyric1, lyric2);
             var romajiTags = combineLyric.RomajiTags;
-            Assert.AreEqual(romajiTags, TestCaseTagHelper.ParseRomajiTags(actualRomajiTags));
+            TextTagAssert.ArePropertyEqual(romajiTags, TestCaseTagHelper.ParseRomajiTags(actualRomajiTags));
         }
 
         [TestCase(new double[] { 1000, 0 }, new double[] { 1000, 0 }, new double[] { 1000, 0 })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
@@ -21,12 +22,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             // test ruby tag.
             var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
-            Assert.AreEqual(TextTagUtils.FixTimeTagPosition(rubyTag), actualRubyTag);
+            TextTagAssert.ArePropertyEqual(TextTagUtils.FixTimeTagPosition(rubyTag), actualRubyTag);
 
             // test romaji tag.
             var romajiTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRomaji = TestCaseTagHelper.ParseRubyTag(actualTag);
-            Assert.AreEqual(TextTagUtils.FixTimeTagPosition(romajiTag), actualRomaji);
+            TextTagAssert.ArePropertyEqual(TextTagUtils.FixTimeTagPosition(romajiTag), actualRomaji);
         }
 
         [TestCase("[0,1]:ka", 1, "[1,2]:ka")]
@@ -38,12 +39,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             // test ruby tag.
             var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
-            Assert.AreEqual(TextTagUtils.Shifting(rubyTag, shifting), actualRubyTag);
+            TextTagAssert.ArePropertyEqual(TextTagUtils.Shifting(rubyTag, shifting), actualRubyTag);
 
             // test romaji tag.
             var romajiTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRomaji = TestCaseTagHelper.ParseRubyTag(actualTag);
-            Assert.AreEqual(TextTagUtils.Shifting(romajiTag, shifting), actualRomaji);
+            TextTagAssert.ArePropertyEqual(TextTagUtils.Shifting(romajiTag, shifting), actualRomaji);
         }
 
         [TestCase("[0,1]:ka", "karaoke", false)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagsUtilsTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestSort(string[] textTags, TextTagsUtils.Sorting sorting, string[] actualTextTags)
         {
             var sortedTextTags = TextTagsUtils.Sort(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
-            Assert.AreEqual(sortedTextTags, TestCaseTagHelper.ParseRubyTags(actualTextTags));
+            TextTagAssert.ArePropertyEqual(sortedTextTags, TestCaseTagHelper.ParseRubyTags(actualTextTags));
         }
 
         [TestCase(new[] { "[0,7]:ka" }, "karaoke", new string[] { })]
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestFindOutOfRange(string[] textTags, string lyric, string[] actualTextTags)
         {
             var invalidTextTag = TextTagsUtils.FindOutOfRange(TestCaseTagHelper.ParseRubyTags(textTags), lyric);
-            Assert.AreEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
+            TextTagAssert.ArePropertyEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
         }
 
         [TestCase(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o" }, TextTagsUtils.Sorting.Asc, new string[] { })]
@@ -42,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestFindOverlapping(string[] textTags, TextTagsUtils.Sorting sorting, string[] actualTextTags)
         {
             var invalidTextTag = TextTagsUtils.FindOverlapping(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
-            Assert.AreEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
+            TextTagAssert.ArePropertyEqual(invalidTextTag, TestCaseTagHelper.ParseRubyTags(actualTextTags));
         }
 
         [TestCase(new[] { "[0,1]:ka" }, "[0,1]:ka")]
@@ -51,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         {
             var rubyTags = TestCaseTagHelper.ParseRubyTags(textTags);
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTextTag);
-            Assert.AreEqual(TextTagsUtils.Combine(rubyTags), actualRubyTag);
+            TextTagAssert.ArePropertyEqual(TextTagsUtils.Combine(rubyTags), actualRubyTag);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
             var sortedTimeTag = TimeTagsUtils.Sort(timeTags);
-            TimeTagAssert.AreEqual(sortedTimeTag, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
+            TimeTagAssert.ArePropertyEqual(sortedTimeTag, TestCaseTagHelper.ParseTimeTags(actualTimeTags));
         }
 
         [TestCase("カラオケ", new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new string[] { })]
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
             var outOfRangeTimeTags = TimeTagsUtils.FindOutOfRange(timeTags, text);
-            TimeTagAssert.AreEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
+            TimeTagAssert.ArePropertyEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
         }
 
         [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, GroupCheck.Asc, SelfCheck.BasedOnStart, new[] { 1 })]
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             // check which part is fixed, using list of time to check result.
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
             var fixedTimeTag = TimeTagsUtils.FixInvalid(timeTags, other, self);
-            TimeTagAssert.AreEqual(fixedTimeTag, TestCaseTagHelper.ParseTimeTags(actualTimeTagTexts));
+            TimeTagAssert.ArePropertyEqual(fixedTimeTag, TestCaseTagHelper.ParseTimeTags(actualTimeTagTexts));
         }
 
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, new double[] { 1100, 2000, 2100, 3000 })]

--- a/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
@@ -1,25 +1,48 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public struct RomajiTag : ITextTag
+    public class RomajiTag : ITextTag
     {
+        [JsonIgnore]
+        public readonly Bindable<string> TextBindable = new Bindable<string>();
+
         /// <summary>
         /// If kanji Matched, then apply romaji
         /// </summary>
-        public string Text { get; set; }
+        public string Text
+        {
+            get => TextBindable.Value;
+            set => TextBindable.Value = value;
+        }
+
+        [JsonIgnore]
+        public readonly BindableInt StartIndexBindable = new BindableInt();
 
         /// <summary>
         /// Start index
         /// </summary>
-        public int StartIndex { get; set; }
+        public int StartIndex
+        {
+            get => StartIndexBindable.Value;
+            set => StartIndexBindable.Value = value;
+        }
+
+        [JsonIgnore]
+        public readonly BindableInt EndIndexBindable = new BindableInt();
 
         /// <summary>
         /// End index
         /// </summary>
-        public int EndIndex { get; set; }
+        public int EndIndex
+        {
+            get => EndIndexBindable.Value;
+            set => EndIndexBindable.Value = value;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
@@ -1,25 +1,48 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using Newtonsoft.Json;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public struct RubyTag : ITextTag
+    public class RubyTag : ITextTag
     {
+        [JsonIgnore]
+        public readonly Bindable<string> TextBindable = new Bindable<string>();
+
         /// <summary>
         /// If kanji Matched, then apply ruby
         /// </summary>
-        public string Text { get; set; }
+        public string Text
+        {
+            get => TextBindable.Value;
+            set => TextBindable.Value = value;
+        }
+
+        [JsonIgnore]
+        public readonly BindableInt StartIndexBindable = new BindableInt();
 
         /// <summary>
         /// Start index
         /// </summary>
-        public int StartIndex { get; set; }
+        public int StartIndex
+        {
+            get => StartIndexBindable.Value;
+            set => StartIndexBindable.Value = value;
+        }
+
+        [JsonIgnore]
+        public readonly BindableInt EndIndexBindable = new BindableInt();
 
         /// <summary>
         /// End index
         /// </summary>
-        public int EndIndex { get; set; }
+        public int EndIndex
+        {
+            get => EndIndexBindable.Value;
+            set => EndIndexBindable.Value = value;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 int endIndex = key.Index;
 
                 var text = lyric.Text[startIndex..endIndex];
-                var ruby = lyric.RubyTags?.Where(x => x.StartIndex == startIndex && x.EndIndex == endIndex).FirstOrDefault().Text;
+                var ruby = lyric.RubyTags?.Where(x => x.StartIndex == startIndex && x.EndIndex == endIndex).FirstOrDefault()?.Text;
 
                 if (!string.IsNullOrEmpty(text))
                 {


### PR DESCRIPTION
Fist implementation of #608 

What's changed in this pr:
- Add bindable start index and bindable end index into ruby/romaji tag.
- Change object from struct into class.