### PR TITLE
Refactor edit mode logic

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/DrawableKaraokeEditorRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/DrawableKaraokeEditorRuleset.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class DrawableKaraokeEditorRuleset : DrawableKaraokeRuleset
     {
-        private readonly Bindable<EditMode> bindableEditMode = new Bindable<EditMode>();
         private readonly Bindable<bool> bindableDisplayRubyToggle = new Bindable<bool>();
         private readonly Bindable<bool> bindableDisplayRomajiToggle = new Bindable<bool>();
         private readonly Bindable<bool> bindableDisplayTranslateToggle = new Bindable<bool>();
@@ -29,13 +28,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         public DrawableKaraokeEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
-            bindableEditMode.BindValueChanged(e =>
-            {
-                if (e.NewValue == EditMode.LyricEditor)
-                    Playfield.Hide();
-                else
-                    Playfield.Show();
-            }, true);
             bindableDisplayRubyToggle.BindValueChanged(x => { Session.SetValue(KaraokeRulesetSession.DisplayRuby, x.NewValue); });
             bindableDisplayRomajiToggle.BindValueChanged(x => { Session.SetValue(KaraokeRulesetSession.DisplayRomaji, x.NewValue); });
             bindableDisplayTranslateToggle.BindValueChanged(x => { Session.SetValue(KaraokeRulesetSession.UseTranslate, x.NewValue); });
@@ -52,7 +44,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [BackgroundDependencyLoader]
         private void load(KaraokeRulesetEditConfigManager editConfigManager)
         {
-            editConfigManager.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.DisplayRuby, bindableDisplayRubyToggle);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.DisplayRomaji, bindableDisplayRomajiToggle);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.DisplayTranslate, bindableDisplayTranslateToggle);

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBlueprintContainer.cs
@@ -2,46 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Screens.Edit.Compose.Components;
-using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class KaraokeBlueprintContainer : ComposeBlueprintContainer
     {
-        private readonly Bindable<EditMode> bindableEditMode = new Bindable<EditMode>();
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
-        {
-            if (bindableEditMode.Value == EditMode.LyricEditor)
-                return false;
-
-            return base.ReceivePositionalInputAt(screenSpacePos);
-        }
-
         public KaraokeBlueprintContainer(HitObjectComposer composer)
             : base(composer)
         {
-            bindableEditMode.BindValueChanged(e =>
-            {
-                if (e.NewValue == EditMode.LyricEditor)
-                {
-                    Hide();
-                }
-                else
-                {
-                    Show();
-                }
-            }, true);
         }
 
         public override OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject)
@@ -60,11 +35,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         }
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new KaraokeSelectionHandler();
-
-        [BackgroundDependencyLoader]
-        private void load(KaraokeRulesetEditConfigManager editConfigManager)
-        {
-            editConfigManager.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
-        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
@@ -65,7 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly SingerManager singerManager;
 
         [Cached]
-        private readonly LanguageSelectionDialog languageSelectionDialog;
+        private LanguageSelectionDialog languageSelectionDialog;
 
         [Resolved]
         private Editor editor { get; set; }
@@ -84,11 +85,35 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(lyricManager = new LyricManager());
             AddInternal(lyricCheckerManager = new LyricCheckerManager());
             AddInternal(singerManager = new SingerManager());
-            LayerBelowRuleset.Add(new KaraokeLyricEditor(ruleset)
+            LayerBelowRuleset.Add(languageSelectionDialog = new LanguageSelectionDialog());
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            CreateMenuBar();
+            AddInternal(new KaraokeLyricEditor(Ruleset)
             {
                 RelativeSizeAxes = Axes.Both
             });
-            LayerBelowRuleset.Add(languageSelectionDialog = new LanguageSelectionDialog());
+
+            var bindableEditMode = new Bindable<EditMode>();
+            bindableEditMode.BindValueChanged(e =>
+            {
+                if (e.NewValue == EditMode.LyricEditor)
+                {
+                    InternalChildren[0].Hide(); // hide content
+                    InternalChildren[1].Hide(); // hide left-side toggle.
+                    InternalChildren[2].Show(); // show lyric editor.
+                }
+                else
+                {
+                    InternalChildren[0].Show();
+                    InternalChildren[1].Show();
+                    InternalChildren[2].Hide();
+                }
+            });
+            editConfigManager.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
         }
 
         public new KaraokePlayfield Playfield => drawableRuleset.Playfield;
@@ -190,11 +215,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => Array.Empty<HitObjectCompositionTool>();
 
         protected override IEnumerable<TernaryButton> CreateTernaryButtons() => Array.Empty<TernaryButton>();
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            CreateMenuBar();
-        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class KaraokeHitObjectComposer : HitObjectComposer<KaraokeHitObject>
     {
+        private readonly Bindable<EditMode> bindableEditMode = new Bindable<EditMode>();
+
         private DrawableKaraokeEditorRuleset drawableRuleset;
 
         [Cached(Type = typeof(IPositionCalculator))]
@@ -97,7 +99,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
                 RelativeSizeAxes = Axes.Both
             });
 
-            var bindableEditMode = new Bindable<EditMode>();
             bindableEditMode.BindValueChanged(e =>
             {
                 if (e.NewValue == EditMode.LyricEditor)
@@ -112,7 +113,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
                     InternalChildren[1].Show();
                     InternalChildren[2].Hide();
                 }
-            });
+            }, true);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeLyricEditor.cs
@@ -12,8 +12,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class KaraokeLyricEditor : CompositeDrawable
     {
-        private readonly Bindable<EditMode> bindableEditMode = new Bindable<EditMode>();
-
         private readonly Bindable<float> bindableLyricEditorFontSize = new Bindable<float>();
         private readonly Bindable<Mode> bindableLyricEditorMode = new Bindable<Mode>();
         private readonly Bindable<RecordingMovingCaretMode> bindableRecordingMovingCaretMode = new Bindable<RecordingMovingCaretMode>();
@@ -31,14 +29,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
                 {
                     RelativeSizeAxes = Axes.Both,
                 }
-            });
-
-            bindableEditMode.BindValueChanged(e =>
-            {
-                if (e.NewValue == EditMode.LyricEditor)
-                    Show();
-                else
-                    Hide();
             });
             bindableLyricEditorMode.BindValueChanged(e =>
             {
@@ -65,8 +55,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [BackgroundDependencyLoader]
         private void load(KaraokeRulesetEditConfigManager editConfigManager)
         {
-            editConfigManager.BindWith(KaraokeRulesetEditSetting.EditMode, bindableEditMode);
-
             editConfigManager.BindWith(KaraokeRulesetEditSetting.LyricEditorFontSize, bindableLyricEditorFontSize);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.LyricEditorMode, bindableLyricEditorMode);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.RecordingMovingCaretMode, bindableRecordingMovingCaretMode);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/119230808-5ef7ad80-bb50-11eb-89db-b0938aaa42ba.png)

What's changed in this pr:
- collect show/hide some component logic if switch edit mod.
- now lyric editor is able to use full-size.
- for preparing to add spacing for editing ruby/romaji tag in #601 and idea is from #621