### PR TITLE
Implement singer section in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/SubSinger.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/SubSinger.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
 {
@@ -10,6 +11,8 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
         public int Order { get; set; }
 
         public int ID { get; private set; }
+
+        public Color4? Color { get; set; }
 
         public int Parent { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Types/ISinger.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Types/ISinger.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types
 {
     public interface ISinger : IHasOrder
     {
         int ID { get; }
+
+        Color4? Color { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state)
         {
-            state.BindableCaretPosition.BindValueChanged(x =>
+            state.BindableCaretPosition.BindValueChanged(e =>
             {
-                Lyric = x.NewValue.Lyric;
+                Lyric = e.NewValue.Lyric;
                 var romajiTags = Lyric?.RomajiTags;
                 TextTags.Clear();
                 if (romajiTags != null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyRomajiTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyRomajiTagExtend.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         public TextTagExtend()
         {
-            InternalChild = new OsuScrollContainer()
+            InternalChild = new OsuScrollContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = new FillFlowContainer

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state)
         {
-            state.BindableCaretPosition.BindValueChanged(x =>
+            state.BindableCaretPosition.BindValueChanged(e =>
             {
-                Lyric = x.NewValue.Lyric;
+                Lyric = e.NewValue.Lyric;
                 var rubyTags = Lyric?.RubyTags;
                 TextTags.Clear();
                 if (rubyTags != null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
+{
+    public class SingerEditSection : Section
+    {
+        private readonly Bindable<int[]> singerIndexes = new Bindable<int[]>();
+        protected override string Title => "Singer";
+
+        public SingerEditSection()
+        {
+            singerIndexes.BindValueChanged(e =>
+            {
+                foreach (var singerLabel in Content.OfType<LabelledSingerSwitchButton>())
+                {
+                    // should mark singer as selected/unselected.
+                    var singerId = singerLabel.Singer.ID;
+                    var selected = singerIndexes.Value?.Contains(singerId) ?? false;
+
+                    // update singer label selection.
+                    singerLabel.Current.Value = selected;
+                }
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(EditorBeatmap beatmap, ILyricEditorState state)
+        {
+            // update singer
+            if (beatmap?.PlayableBeatmap is KaraokeBeatmap karaokeBeatmap)
+            {
+                var singers = karaokeBeatmap.Singers;
+                Content.AddRange(singers.Select(x =>
+                {
+                    var singerName = x.Name;
+                    var description = x.Description;
+                    return new LabelledSingerSwitchButton(x)
+                    {
+                        Label = singerName,
+                        Description = description,
+                    };
+                }));
+            }
+
+            // update lyric.
+            state.BindableCaretPosition.BindValueChanged(e =>
+            {
+                e.OldValue?.Lyric?.SingersBindable.UnbindFrom(singerIndexes);
+                e.NewValue?.Lyric?.SingersBindable.BindTo(singerIndexes);
+            });
+        }
+
+        public class LabelledSingerSwitchButton : LabelledSwitchButton
+        {
+            public ISinger Singer { get; }
+
+            public LabelledSingerSwitchButton(ISinger singer)
+            {
+                Singer = singer;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
@@ -4,11 +4,15 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Screens.Edit;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 {
@@ -62,11 +66,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 
         public class LabelledSingerSwitchButton : LabelledSwitchButton
         {
+            protected const float AVATAR_CORNER_RADIUS = 40f;
+
             public ISinger Singer { get; }
 
             public LabelledSingerSwitchButton(ISinger singer)
             {
                 Singer = singer;
+
+                if (InternalChildren[1] is FillFlowContainer fillflowContainer)
+                {
+                    fillflowContainer.Padding
+                        = new MarginPadding
+                        {
+                            Horizontal = CONTENT_PADDING_HORIZONTAL,
+                            Vertical = CONTENT_PADDING_VERTICAL,
+                            Left = CONTENT_PADDING_HORIZONTAL + 40 + CONTENT_PADDING_HORIZONTAL,
+                        };
+                }
+
+                AddInternal(new DrawableCircleSingerAvatar
+                {
+                    Singer = singer,
+                    Size = new Vector2(AVATAR_CORNER_RADIUS),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding
+                    {
+                        Left = CONTENT_PADDING_HORIZONTAL,
+                    }
+                });
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
+{
+    public class SingerExtend : EditExtend
+    {
+        public override ExtendDirection Direction => ExtendDirection.Left;
+
+        public override float ExtendWidth => 300;
+
+        public SingerExtend()
+        {
+            InternalChild = new OsuScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        new SingerEditSection(),
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -13,6 +13,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -144,6 +145,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 {
                     case Mode.RubyRomajiMode:
                         return new TextTagExtend();
+
+                    case Mode.Singer:
+                        return new SingerExtend();
 
                     default:
                         return null;

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableCircleSingerAvatar.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableCircleSingerAvatar.cs
@@ -4,7 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             BorderThickness = 5;
         }
 
-        public override Singer Singer
+        public override ISinger Singer
         {
             get => base.Singer;
             set

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableSingerAvatar.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableSingerAvatar.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
 {
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             });
         }
 
-        private Singer singer;
+        private ISinger singer;
 
-        public virtual Singer Singer
+        public virtual ISinger Singer
         {
             get => singer;
             set


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/119263381-cc234580-bc19-11eb-91e1-38f66ef2ad91.png)
This is how it looks in this PR;
And this feature will able to use until customize ruleset able to access the editor.
.
The idea is from #621 
In comparison to pop-up dialog every time when the user trys to select a singer for the lyric.
It might be better just show selection on the left-side.