### PR TITLE
Implement layout section in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Containers/Section.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Containers/Section.cs
@@ -12,6 +12,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Containers
 {
     public abstract class Section : Container
     {
+        protected const float SECTION_PADDING = 10;
+
+        protected const float SECTION_SPACING = 10;
+
         private readonly FillFlowContainer flow;
 
         [Resolved]
@@ -26,7 +30,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Containers
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Padding = new MarginPadding(10);
+            Padding = new MarginPadding(SECTION_PADDING);
 
             InternalChildren = new Drawable[]
             {
@@ -39,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Containers
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Spacing = new Vector2(10),
+                    Spacing = new Vector2(SECTION_SPACING),
                     Direction = FillDirection.Vertical,
                     Margin = new MarginPadding { Top = 30 }
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
@@ -2,10 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning;
@@ -19,34 +16,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
     {
         private const float scale = 0.4f;
 
-        private readonly Box background;
-        private readonly Box previewLyric;
-        private readonly OsuSpriteText notSupportText;
+        private readonly DrawableLayoutPreview preview;
 
         [Resolved(canBeNull: true)]
         private ISkinSource skinSource { get; set; }
 
         public LayoutToolTip()
         {
-            Children = new Drawable[]
+            Child = preview = new DrawableLayoutPreview
             {
-                background = new Box
-                {
-                    Size = new Vector2(512 * scale, 384 * scale),
-                },
-                previewLyric = new Box
-                {
-                    Height = 15
-                },
-                notSupportText = new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                }
+                Size = new Vector2(512 * scale, 384 * scale),
             };
-
-            previewLyric.Hide();
-            notSupportText.Hide();
         }
 
         public override bool SetContent(object content)
@@ -58,52 +38,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             var layoutIndex = lyric.LayoutIndex;
             var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricLayout, layoutIndex)).Value;
 
-            // Display in content
-            if (layout == null)
-            {
-                // mark layout as not supported, or skin is not loaded
-                notSupportText.Show();
-
-                if (skinSource == null)
-                    notSupportText.Text = "Sorry, skin is not exist.";
-                else
-                    notSupportText.Text = "Sorry, layout is not exist.";
-            }
-            else
-            {
-                // Display box preview position
-                previewLyric.Show();
-
-                // Set preview width
-                const float text_size = 20;
-                previewLyric.Width = (lyric.Text?.Length ?? 10) * text_size * scale;
-                previewLyric.Height = text_size * 1.5f * scale;
-
-                // Set relative position
-                previewLyric.Anchor = layout.Alignment;
-                previewLyric.Origin = layout.Alignment;
-
-                // Set margin
-                const float padding = 30 * scale;
-                var horizontalMargin = layout.HorizontalMargin * scale + padding;
-                var verticalMargin = layout.VerticalMargin * scale + padding;
-                previewLyric.Margin = new MarginPadding
-                {
-                    Left = layout.Alignment.HasFlag(Anchor.x0) ? horizontalMargin : 0,
-                    Right = layout.Alignment.HasFlag(Anchor.x2) ? horizontalMargin : 0,
-                    Top = layout.Alignment.HasFlag(Anchor.y0) ? verticalMargin : 0,
-                    Bottom = layout.Alignment.HasFlag(Anchor.y2) ? verticalMargin : 0
-                };
-            }
+            // Display in content\
+            preview.Layout = layout;
+            preview.Lyric = lyric;
 
             return true;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            background.Colour = colours.Gray2;
-            previewLyric.Colour = colours.Yellow;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableLayoutPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableLayoutPreview.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Sprites
+{
+    public class DrawableLayoutPreview : CompositeDrawable
+    {
+        private const float scale = 0.4f;
+
+        private readonly Box background;
+        private readonly Box previewLyric;
+        private readonly OsuSpriteText notSupportText;
+
+        [Resolved(canBeNull: true)]
+        private ISkinSource skinSource { get; set; }
+
+        public DrawableLayoutPreview()
+        {
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                previewLyric = new Box
+                {
+                    Height = 15
+                },
+                notSupportText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+
+            previewLyric.Hide();
+            notSupportText.Hide();
+        }
+
+        private LyricLayout layout;
+
+        public LyricLayout Layout
+        {
+            get => layout;
+            set
+            {
+                if (layout == value)
+                    return;
+
+                layout = value;
+                updateLayout();
+            }
+        }
+
+        private Lyric lyric;
+
+        public Lyric Lyric
+        {
+            get => lyric;
+            set
+            {
+                if (lyric == value)
+                    return;
+
+                lyric = value;
+                updateLayout();
+            }
+        }
+
+        private void updateLayout()
+        {
+            // Display in content
+            if (Layout == null)
+            {
+                // mark layout as not supported, or skin is not loaded
+                notSupportText.Show();
+
+                if (skinSource == null)
+                    notSupportText.Text = "Sorry, skin is not exist.";
+                else
+                    notSupportText.Text = "Sorry, layout is not exist.";
+            }
+            else
+            {
+                // Display box preview position
+                previewLyric.Show();
+
+                // Set preview width
+                const float text_size = 20;
+                previewLyric.Width = (Lyric?.Text?.Length ?? 10) * text_size * scale;
+                previewLyric.Height = text_size * 1.5f * scale;
+
+                // Set relative position
+                previewLyric.Anchor = layout.Alignment;
+                previewLyric.Origin = layout.Alignment;
+
+                // Set margin
+                const float padding = 30 * scale;
+                var horizontalMargin = layout.HorizontalMargin * scale + padding;
+                var verticalMargin = layout.VerticalMargin * scale + padding;
+                previewLyric.Margin = new MarginPadding
+                {
+                    Left = layout.Alignment.HasFlag(Anchor.x0) ? horizontalMargin : 0,
+                    Right = layout.Alignment.HasFlag(Anchor.x2) ? horizontalMargin : 0,
+                    Top = layout.Alignment.HasFlag(Anchor.y0) ? verticalMargin : 0,
+                    Bottom = layout.Alignment.HasFlag(Anchor.y2) ? verticalMargin : 0
+                };
+            }
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            background.Colour = colours.Gray2;
+            previewLyric.Colour = colours.Yellow;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
@@ -1,35 +1,46 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 {
-    public abstract class EditExtend : CompositeDrawable
+    public abstract class EditExtend : Container
     {
         public abstract ExtendDirection Direction { get; }
 
         public abstract float ExtendWidth { get; }
 
+        protected override Container<Drawable> Content => content;
+
+        private readonly FillFlowContainer content;
+
         protected EditExtend()
         {
             RelativeSizeAxes = Axes.Both;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AddInternal(new CornerBackground
+            InternalChildren = new Drawable[]
             {
-                Depth = float.MaxValue,
-                RelativeSizeAxes = Axes.Both,
-                Alpha = 0.5f,
-                Colour = Color4.Black
-            });
+                new CornerBackground
+                {
+                    Depth = float.MaxValue,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.5f,
+                    Colour = Color4.Black
+                },
+                new OsuScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = content = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                    }
+                }
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutExtend.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
+{
+    public class LayoutExtend : EditExtend
+    {
+        public override ExtendDirection Direction => ExtendDirection.Left;
+
+        public override float ExtendWidth => 240;
+
+        public LayoutExtend()
+        {
+            Children = new[]
+            {
+                new LayoutSelection(),
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutSelection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutSelection.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Skinning;
+using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
+{
+    public class LayoutSelection : FillFlowContainer
+    {
+        private const float padding = 20;
+        private const float spacing = 10;
+
+        private const float selection_size = (240 - padding * 2 - spacing) / 2;
+
+        public LayoutSelection()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Spacing = new Vector2(spacing);
+            Direction = FillDirection.Full;
+            Padding = new MarginPadding(padding);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skinSource, ILyricEditorState state)
+        {
+            var layoutDictionary = skinSource.GetConfig<KaraokeIndexLookup, IDictionary<int, string>>(KaraokeIndexLookup.Layout)?.Value;
+            if (layoutDictionary == null)
+                return;
+
+            foreach (var layoutIndex in layoutDictionary)
+            {
+                var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricLayout, layoutIndex.Key)).Value;
+                AddInternal(new LayoutSelectionItem(layout)
+                {
+                    Size = new Vector2(selection_size)
+                });
+            }
+
+            state.BindableCaretPosition.BindValueChanged(e =>
+            {
+                var lyric = e.NewValue?.Lyric;
+                var layoutSelectionItems = InternalChildren.OfType<LayoutSelectionItem>();
+
+                foreach (var item in layoutSelectionItems)
+                {
+                    item.Lyric = lyric;
+                }
+            });
+        }
+
+        public class LayoutSelectionItem : CompositeDrawable
+        {
+            private readonly Bindable<int> selectedLayoutIndex = new Bindable<int>();
+
+            private readonly DrawableLayoutPreview drawableLayoutPreview;
+
+            private readonly LyricLayout layout;
+
+            public LayoutSelectionItem(LyricLayout layout)
+            {
+                this.layout = layout;
+
+                Masking = true;
+                CornerRadius = 5f;
+
+                InternalChildren = new Drawable[]
+                {
+                    drawableLayoutPreview = new DrawableLayoutPreview
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Layout = layout,
+                    }
+                };
+
+                selectedLayoutIndex.BindValueChanged(e =>
+                {
+                    var selected = layout.ID == e.NewValue;
+                    BorderThickness = selected ? 3 : 0;
+                }, true);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colour)
+            {
+                BorderColour = colour.Yellow;
+            }
+
+            public Lyric Lyric
+            {
+                get => drawableLayoutPreview.Lyric;
+                set
+                {
+                    if (drawableLayoutPreview.Lyric == value)
+                        return;
+
+                    // unbind previous event
+                    Lyric?.LayoutIndexBindable.UnbindFrom(selectedLayoutIndex);
+
+                    // update lyric
+                    drawableLayoutPreview.Lyric = value;
+
+                    // bind layout index.
+                    Lyric?.LayoutIndexBindable.BindTo(selectedLayoutIndex);
+                }
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                selectedLayoutIndex.Value = layout.ID;
+                return base.OnClick(e);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutSelection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Layouts/LayoutSelection.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -22,7 +23,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
     public class LayoutSelection : Section
     {
         private const float layout_settion_horizontal_padding = 20;
-        private const float selection_size = (240 - layout_settion_horizontal_padding * 2 - SECTION_SPACING) / 2;
+
+        private const float layout_setting_vertical_spacing = 15;
 
         protected override string Title => "Layout";
 
@@ -39,6 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
 
             // use lazy way to initialize fill flow container in section.
             fillFlowContainer.Direction = FillDirection.Full;
+            fillFlowContainer.Spacing = new Vector2(SECTION_SPACING, layout_setting_vertical_spacing);
         }
 
         [BackgroundDependencyLoader]
@@ -51,10 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
             foreach (var layoutIndex in layoutDictionary)
             {
                 var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricLayout, layoutIndex.Key)).Value;
-                Content.Add(new LayoutSelectionItem(layout)
-                {
-                    Size = new Vector2(selection_size)
-                });
+                Content.Add(new LayoutSelectionItem(layout));
             }
 
             state.BindableCaretPosition.BindValueChanged(e =>
@@ -69,11 +69,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
             }, true);
         }
 
-        public class LayoutSelectionItem : CompositeDrawable
+        public class LayoutSelectionItem : FillFlowContainer
         {
+            private const float selection_size = (240 - layout_settion_horizontal_padding * 2 - SECTION_SPACING) / 2;
+
             private readonly Bindable<int> selectedLayoutIndex = new Bindable<int>();
 
             private readonly DrawableLayoutPreview drawableLayoutPreview;
+
+            private readonly Container cornerContainer;
 
             private readonly LyricLayout layout;
 
@@ -81,29 +85,40 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts
             {
                 this.layout = layout;
 
-                Masking = true;
-                CornerRadius = 5f;
+                AutoSizeAxes = Axes.Both;
+                Spacing = new Vector2(5);
+                Direction = FillDirection.Vertical;
 
                 InternalChildren = new Drawable[]
                 {
-                    drawableLayoutPreview = new DrawableLayoutPreview
+                    cornerContainer = new Container
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Layout = layout,
+                        AutoSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = 5f,
+                        Child = drawableLayoutPreview = new DrawableLayoutPreview
+                        {
+                            Size = new Vector2(selection_size),
+                            Layout = layout,
+                        }
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = layout.Name
                     }
                 };
 
                 selectedLayoutIndex.BindValueChanged(e =>
                 {
                     var selected = layout.ID == e.NewValue;
-                    BorderThickness = selected ? 3 : 0;
+                    cornerContainer.BorderThickness = selected ? 3 : 0;
                 }, true);
             }
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colour)
             {
-                BorderColour = colour.Yellow;
+                cornerContainer.BorderColour = colour.Yellow;
             }
 
             public Lyric Lyric

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyRomajiTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyRomajiTagExtend.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
@@ -15,19 +13,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         public TextTagExtend()
         {
-            InternalChild = new OsuScrollContainer
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Child = new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Children = new Drawable[]
-                    {
-                        new RubyTagEditSection(),
-                        new RomajiTagEditSection(),
-                    }
-                }
+                new RubyTagEditSection(),
+                new RomajiTagEditSection(),
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics.Containers;
-
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 {
     public class SingerExtend : EditExtend
@@ -15,18 +11,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 
         public SingerExtend()
         {
-            InternalChild = new OsuScrollContainer
+            Children = new[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Child = new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Children = new Drawable[]
-                    {
-                        new SingerEditSection(),
-                    }
-                }
+                new SingerEditSection(),
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Layouts;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -148,6 +149,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
                     case Mode.Singer:
                         return new SingerExtend();
+
+                    case Mode.Layout:
+                        return new LayoutExtend();
 
                     default:
                         return null;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/119349202-d6584900-bcd8-11eb-959e-da768d5883fb.png)
This is how it looks in this PR;
.
The idea is from #621
In comparison to pop-up dialog every time when the user tries to select a layout for the lyric.
It might be better just show selection on the left side.