### PR TITLE
Fix cause crash in time-tag edit mode if all time-tag with no-time in lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
         public readonly Lyric HitObject;
 
-        private double startPosition;
+        public double StartTime { get; private set; }
 
-        private double endPosition;
+        public double EndTime { get; private set; }
 
         public TimeTagEditor(Lyric lyric)
         {
@@ -37,8 +37,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             lyric.TimeTagsBindable.GetBoundCopy().BindValueChanged(e =>
             {
                 // todo : change time mignt not call time-tag changed.
-                startPosition = e.NewValue?.Where(x => x.Time != null).FirstOrDefault()?.Time ?? 0 - 500;
-                endPosition = e.NewValue?.Where(x => x.Time != null).LastOrDefault()?.Time ?? 1000000;
+                StartTime = e.NewValue?.Where(x => x.Time != null).FirstOrDefault()?.Time ?? 0 - 500;
+                EndTime = e.NewValue?.Where(x => x.Time != null).LastOrDefault()?.Time ?? 1000000;
             }, true);
 
             RelativeSizeAxes = Axes.X;
@@ -117,11 +117,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             var position = getTimeFromPosition(new Vector2(value));
 
             // should prevent dragging or moving is out of time-tag range.
-            if (position < startPosition - preempt_time)
-                value = getPositionFromTime(startPosition - preempt_time);
+            if (position < StartTime - preempt_time)
+                value = getPositionFromTime(StartTime - preempt_time);
 
-            if (position > endPosition - zoomMillionSecond + preempt_time)
-                value = getPositionFromTime(endPosition - zoomMillionSecond + preempt_time);
+            if (position > EndTime - zoomMillionSecond + preempt_time)
+                value = getPositionFromTime(EndTime - zoomMillionSecond + preempt_time);
 
             base.OnUserScroll(value, animated, distanceDecay);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
@@ -22,6 +24,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
     {
         private const float timeline_height = 38;
 
+        public readonly IBindable<TimeTag[]> TimeTagsBindable = new Bindable<TimeTag[]>();
+
         [Resolved]
         private EditorClock editorClock { get; set; }
 
@@ -34,12 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
         public TimeTagEditor(Lyric lyric)
         {
             HitObject = lyric;
-            lyric.TimeTagsBindable.GetBoundCopy().BindValueChanged(e =>
-            {
-                // todo : change time mignt not call time-tag changed.
-                StartTime = e.NewValue?.Where(x => x.Time != null).FirstOrDefault()?.Time ?? 0 - 500;
-                EndTime = e.NewValue?.Where(x => x.Time != null).LastOrDefault()?.Time ?? 1000000;
-            }, true);
 
             RelativeSizeAxes = Axes.X;
             Padding = new MarginPadding { Top = 10 };
@@ -48,6 +46,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             ZoomDuration = 200;
             ZoomEasing = Easing.OutQuint;
             ScrollbarVisible = false;
+
+            TimeTagsBindable.BindArrayChanged(addItems =>
+            {
+                foreach (var obj in addItems)
+                {
+                    obj.TimeBindable.BindValueChanged(e =>
+                    {
+                        updateTimeRange();
+                    });
+                }
+            }, removedItems =>
+            {
+                foreach (var obj in removedItems)
+                {
+                    obj.TimeBindable.UnbindEvents();
+                }
+            });
+
+            TimeTagsBindable.BindTo(lyric.TimeTagsBindable);
+
+            updateTimeRange();
+        }
+
+        private void updateTimeRange()
+        {
+            var fistTimeTag = TimeTagsBindable.Value.FirstOrDefault();
+            var lastTimeTag = TimeTagsBindable.Value.LastOrDefault();
+
+            StartTime = GetPreviewTime(fistTimeTag) - 500;
+            EndTime = GetPreviewTime(lastTimeTag) + 500;
         }
 
         private Box background;
@@ -124,6 +152,34 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 value = getPositionFromTime(EndTime - zoomMillionSecond + preempt_time);
 
             base.OnUserScroll(value, animated, distanceDecay);
+        }
+
+        public double GetPreviewTime(TimeTag timeTag)
+        {
+            var time = timeTag.Time;
+
+            if (time != null)
+                return time.Value;
+
+            var timeTags = HitObject.TimeTags;
+
+            const float preempt_time = 200;
+            var previousTimeTagWithTime = timeTags.GetPreviousMatch(timeTag, x => x.Time.HasValue);
+            var nextTimeTagWithTime = timeTags.GetNextMatch(timeTag, x => x.Time.HasValue);
+
+            if (previousTimeTagWithTime?.Time != null)
+            {
+                return previousTimeTagWithTime.Time.Value + preempt_time;
+            }
+
+            if (nextTimeTagWithTime?.Time != null)
+            {
+                return nextTimeTagWithTime.Time.Value - preempt_time;
+            }
+
+            // will goes in here if all time-tag are no time.
+            var index = timeTags.IndexOf(timeTag);
+            return index * preempt_time;
         }
 
         public SnapResult SnapScreenSpacePositionToValidPosition(Vector2 screenSpacePosition) =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -162,6 +162,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 return time.Value;
 
             var timeTags = HitObject.TimeTags;
+            var index = timeTags.IndexOf(timeTag);
 
             const float preempt_time = 200;
             var previousTimeTagWithTime = timeTags.GetPreviousMatch(timeTag, x => x.Time.HasValue);
@@ -169,16 +170,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
             if (previousTimeTagWithTime?.Time != null)
             {
-                return previousTimeTagWithTime.Time.Value + preempt_time;
+                var diffIndex = timeTags.IndexOf(previousTimeTagWithTime) - index;
+                return previousTimeTagWithTime.Time.Value - preempt_time * diffIndex;
             }
 
             if (nextTimeTagWithTime?.Time != null)
             {
-                return nextTimeTagWithTime.Time.Value - preempt_time;
+                var diffIndex = timeTags.IndexOf(nextTimeTagWithTime) - index;
+                return nextTimeTagWithTime.Time.Value - preempt_time * diffIndex;
             }
 
             // will goes in here if all time-tag are no time.
-            var index = timeTags.IndexOf(timeTag);
             return index * preempt_time;
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
@@ -65,26 +65,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             if (!base.ApplySnapResult(blueprints, result))
                 return false;
 
-            var firstDragTimeTagTime = blueprints.First().Item.Time;
-            if (firstDragTimeTagTime == null)
+            if (result.Time == null)
                 return false;
 
-            // main goal is applying delta time while dragging.
-            if (result.Time.HasValue)
+            var timeTagBlueprints = blueprints.OfType<TimeTagEditorHitObjectBlueprint>();
+            var firstDragBlueprint = timeTagBlueprints.FirstOrDefault();
+            if (firstDragBlueprint == null)
+                return false;
+
+            var offset = result.Time.Value - firstDragBlueprint.PreviewTime;
+            if (offset == 0)
+                return false;
+
+            // todo : should not save separately.
+            foreach (var blueprint in blueprints.OfType<TimeTagEditorHitObjectBlueprint>())
             {
-                // Apply the start time at the newly snapped-to position
-                double offset = result.Time.Value - firstDragTimeTagTime.Value;
-
-                if (offset == 0)
-                    return false;
-
-                // todo : should not save separately.
-                foreach (var blueprint in blueprints)
-                {
-                    // todo : fix logic error.
-                    var timeTag = blueprint.Item;
-                    timeTag.Time += offset;
-                }
+                var timeTag = blueprint.Item;
+                timeTag.Time = blueprint.PreviewTime + offset;
             }
 
             return true;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
@@ -7,10 +7,12 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
@@ -78,7 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 return false;
 
             // todo : should not save separately.
-            foreach (var blueprint in blueprints.OfType<TimeTagEditorHitObjectBlueprint>())
+            foreach (var blueprint in timeTagBlueprints)
             {
                 var timeTag = blueprint.Item;
                 timeTag.Time = blueprint.PreviewTime + offset;
@@ -159,6 +161,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 {
                     lyricManager.RemoveTimeTag(item);
                 }
+            }
+
+            protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<TimeTag>> selection)
+            {
+                var timeTags = selection.Select(x => x.Item);
+
+                if (timeTags.Any(x => x.Time != null))
+                {
+                    return new[]
+                    {
+                        new OsuMenuItem("Clear time", MenuItemType.Standard, () =>
+                        {
+                            timeTags.ForEach(x => x.Time = null);
+                        })
+                    };
+                }
+
+                return base.GetContextMenuItemsForSelection(selection);
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
         }
 
         protected override IEnumerable<SelectionBlueprint<TimeTag>> SortForMovement(IReadOnlyList<SelectionBlueprint<TimeTag>> blueprints)
-            => blueprints.OrderBy(b => b.Item.Time);
+            => blueprints.OrderBy(b => b.Item.Index);
 
         protected override bool ApplySnapResult(SelectionBlueprint<TimeTag>[] blueprints, SnapResult result)
         {
@@ -174,6 +174,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                         new OsuMenuItem("Clear time", MenuItemType.Standard, () =>
                         {
                             timeTags.ForEach(x => x.Time = null);
+
+                            // todo : should re-calculate all preview position because some time-tag without position might be affected.
                         })
                     };
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorBlueprintContainer.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             if (firstDragBlueprint == null)
                 return false;
 
-            var offset = result.Time.Value - firstDragBlueprint.PreviewTime;
+            var offset = result.Time.Value - timeline.GetPreviewTime(firstDragBlueprint.Item);
             if (offset == 0)
                 return false;
 
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             foreach (var blueprint in timeTagBlueprints)
             {
                 var timeTag = blueprint.Item;
-                timeTag.Time = blueprint.PreviewTime + offset;
+                timeTag.Time = timeline.GetPreviewTime(timeTag) + offset;
             }
 
             return true;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -14,7 +14,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
-using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -85,15 +84,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
             timeTagWithNoTimePiece.Colour = colours.Red;
             startTime.BindValueChanged(e =>
             {
-                adjustStyle();
-                adjustPosition();
-            }, true);
-
-            // adjust style if time changed.
-            void adjustStyle()
-            {
                 var hasValue = hasTime();
 
+                // update show time-tag style.
                 switch (hasValue)
                 {
                     case true:
@@ -106,58 +99,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                         timeTagWithNoTimePiece.Show();
                         break;
                 }
-            }
 
-            // assign blueprint position in here.
-            void adjustPosition()
-            {
-                var time = startTime.Value;
-
-                if (time != null)
+                Schedule(() =>
                 {
-                    PreviewTime = (float)time.Value;
-                }
-                else
-                {
-                    var timeTags = timeline.HitObject.TimeTags;
-
-                    const float preempt_time = 200;
-                    var previousTimeTagWithTime = timeTags.GetPreviousMatch(Item, x => x.Time.HasValue);
-                    var nextTimeTagWithTime = timeTags.GetNextMatch(Item, x => x.Time.HasValue);
-
-                    if (previousTimeTagWithTime?.Time != null)
-                    {
-                        PreviewTime = (float)previousTimeTagWithTime.Time.Value + preempt_time;
-                    }
-                    else if (nextTimeTagWithTime?.Time != null)
-                    {
-                        PreviewTime = (float)nextTimeTagWithTime.Time.Value - preempt_time;
-                    }
-                    else
-                    {
-                        // will goes in here if all time-tag are no time.
-                        var index = timeTags.IndexOf(Item);
-                        PreviewTime = (float)timeline.StartTime + index * preempt_time;
-                    }
-                }
-            }
-        }
-
-        private double previewTime;
-
-        public double PreviewTime
-        {
-            get => previewTime;
-            set
-            {
-                if(previewTime == value)
-                    return;
-
-                previewTime = value;
-
-                // update position also.
-                X = (float)previewTime;
-            }
+                    // should wait until all time-tag time has been modified.
+                    X = (float)timeline.GetPreviewTime(Item);
+                });
+            }, true);
         }
 
         protected override void OnSelected()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -154,6 +154,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                     return;
 
                 previewTime = value;
+
+                // update position also.
                 X = (float)previewTime;
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
                 if (time != null)
                 {
-                    X = (float)time.Value;
+                    PreviewTime = (float)time.Value;
                 }
                 else
                 {
@@ -127,19 +127,34 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
                     if (previousTimeTagWithTime?.Time != null)
                     {
-                        X = (float)previousTimeTagWithTime.Time.Value + preempt_time;
+                        PreviewTime = (float)previousTimeTagWithTime.Time.Value + preempt_time;
                     }
                     else if (nextTimeTagWithTime?.Time != null)
                     {
-                        X = (float)nextTimeTagWithTime.Time.Value - preempt_time;
+                        PreviewTime = (float)nextTimeTagWithTime.Time.Value - preempt_time;
                     }
                     else
                     {
                         // will goes in here if all time-tag are no time.
                         var index = timeTags.IndexOf(Item);
-                        X = (float)timeline.StartTime + index * preempt_time;
+                        PreviewTime = (float)timeline.StartTime + index * preempt_time;
                     }
                 }
+            }
+        }
+
+        private double previewTime;
+
+        public double PreviewTime
+        {
+            get => previewTime;
+            set
+            {
+                if(previewTime == value)
+                    return;
+
+                previewTime = value;
+                X = (float)previewTime;
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -136,7 +135,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                     }
                     else
                     {
-                        throw new ArgumentNullException(nameof(previousTimeTagWithTime));
+                        // will goes in here if all time-tag are no time.
+                        var index = timeTags.IndexOf(Item);
+                        X = (float)timeline.StartTime + index * preempt_time;
                     }
                 }
             }


### PR DESCRIPTION
Fix will cause a crash if all time-tag are no time in lyric if the user in time-tag edit mode.

Fix issue #674 