### PR TITLE
Fix some behavior in recording time-tag mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -148,16 +148,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Lyrics.CaretPosition.Algorithms
             TestMoveToLast(lyrics, caretPosition, algorithms => algorithms.Mode = mode);
         }
 
-        [TestCase(nameof(singleLyric), 0, 0)]
-        [TestCase(nameof(singleLyricWithNoText), 0, NOT_EXIST_TAG)]
-        public void TestMoveToTarget(string sourceName, int lyricIndex, int index)
+        [TestCase(nameof(singleLyric), RecordingMovingCaretMode.None, 0, 0)]
+        [TestCase(nameof(singleLyric), RecordingMovingCaretMode.OnlyStartTag, 0, 0)]
+        [TestCase(nameof(singleLyric), RecordingMovingCaretMode.OnlyEndTag, 0, 4)]
+        [TestCase(nameof(singleLyricWithNoText), RecordingMovingCaretMode.None, 0, NOT_EXIST_TAG)]
+        public void TestMoveToTarget(string sourceName, RecordingMovingCaretMode mode, int lyricIndex, int index)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[lyricIndex];
             var caretPosition = CreateTimeTagCaretPosition(lyrics, lyricIndex, index);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, caretPosition);
+            TestMoveToTarget(lyrics, lyric, caretPosition, algorithms => algorithms.Mode = mode);
         }
 
         protected override void AssertEqual(TimeTagCaretPosition compare, TimeTagCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -81,11 +81,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public override TimeTagCaretPosition MoveToTarget(Lyric lyric)
         {
-            var timeTags = lyric.TimeTags ?? new TimeTag[] { };
-            if (timeTags.Any())
-                return new TimeTagCaretPosition(lyric, timeTags.FirstOrDefault());
-
-            return new TimeTagCaretPosition(lyric, null);
+            var targetTimeTag = lyric.TimeTags?.FirstOrDefault(timeTagMovable);
+            return new TimeTagCaretPosition(lyric, targetTimeTag);
         }
 
         private TimeTagCaretPosition timeTagToPosition(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -100,6 +100,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             BindableMode.BindValueChanged(e =>
             {
+                initialCaretPositionAlgorithm();
+
                 // display add new lyric only with edit mode.
                 container.DisplayBottomDrawable = e.NewValue == LyricEditorMode.Manage;
 
@@ -112,7 +114,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             BindableRecordingMovingCaretMode.BindValueChanged(e =>
             {
-                Schedule(createAlgorithmList);
+                initialCaretPositionAlgorithm();
             });
         }
 
@@ -216,7 +218,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                         BindableLyrics.Insert(0, lyric);
                     }
 
-                    createAlgorithmList();
+                    initialCaretPositionAlgorithm();
                 }
             };
             beatmap.HitObjectRemoved += e =>
@@ -224,12 +226,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 if (e is Lyric lyric)
                 {
                     BindableLyrics.Remove(lyric);
-                    createAlgorithmList();
+                    initialCaretPositionAlgorithm();
                 }
             };
 
-            // create algorithm set
-            createAlgorithmList();
+            initialCaretPositionAlgorithm();
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -109,6 +109,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 // should control grid container spacing and place some component.
                 initializeExtendArea();
             }, true);
+
+            BindableRecordingMovingCaretMode.BindValueChanged(e =>
+            {
+                Schedule(createAlgorithmList);
+            });
         }
 
         private void initializeExtendArea()
@@ -392,16 +397,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public RecordingMovingCaretMode RecordingMovingCaretMode
         {
             get => BindableRecordingMovingCaretMode.Value;
-            set
-            {
-                if (BindableRecordingMovingCaretMode.Value == value)
-                    return;
-
-                BindableRecordingMovingCaretMode.Value = value;
-
-                // should wait until beatmap has been loaded.
-                Schedule(createAlgorithmList);
-            }
+            set => BindableRecordingMovingCaretMode.Value = value;
         }
 
         public bool AutoFocusEditLyric

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -115,6 +115,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             BindableRecordingMovingCaretMode.BindValueChanged(e =>
             {
                 initialCaretPositionAlgorithm();
+
+                ResetPosition(Mode);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
@@ -42,12 +42,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Parts
 
             bindableMode.BindValueChanged(x =>
             {
-                updateStyle();
+                // should wait until caret position algorithm loaded.
+                Schedule(updateStyle);
             });
 
             bindableRecordingMovingCaretMode.BindValueChanged(x =>
             {
-                updateStyle();
+                // should wait until caret position algorithm loaded.
+                Schedule(updateStyle);
             });
 
             var index = timeTagCaretPosition.TimeTag.Index;


### PR DESCRIPTION
What's fixed:
- should make sure to initialize caret algorithm if update recording config.
- use single algorithm instead of dictionary.
- should wait until algorithm loaded.
- fix caret position algorithm.
- should reset position if recording mode changed.