### PR TITLE
Add time-tag check that in each lyric should have at least one end time-tag.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/Checks/CheckInvalidTimeLyricsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/Checks/CheckInvalidTimeLyricsTest.cs
@@ -50,7 +50,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Checks
         [TestCase("カラオケ", new[] { "[4,start]:4000" }, new[] { TimeTagInvalid.OutOfRange })]
         [TestCase("カラオケ", new[] { "[0,start]:5000", "[3,end]:1000" }, new[] { TimeTagInvalid.Overlapping })]
         [TestCase("カラオケ", new[] { "[0,start]:" }, new[] { TimeTagInvalid.EmptyTime })]
-        public void TestCheckInvalidTimeTags(string text, string[] timeTags, TimeTagInvalid[] invalids)
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,end]:5000" }, new TimeTagInvalid[] { }, false)]
+        [TestCase("カラオケ", new[] { "[0,start]:1000" }, new TimeTagInvalid[] { }, true)]
+        public void TestCheckInvalidTimeTags(string text, string[] timeTags, TimeTagInvalid[] invalids, bool? missingEndTimeTag = null)
         {
             var lyric = new Lyric
             {
@@ -61,6 +63,19 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit.Checks
             var issue = run(lyric).OfType<TimeTagIssue>().FirstOrDefault();
             var invalidTimeTagDictionaryKeys = issue?.InvalidTimeTags.Keys.ToArray() ?? Array.Empty<TimeTagInvalid>();
             Assert.AreEqual(invalidTimeTagDictionaryKeys, invalids);
+
+            // if test case wants to check is missing time-tag.
+            if (missingEndTimeTag != null)
+            {
+                if (missingEndTimeTag.Value)
+                {
+                    Assert.True(issue?.MissingEndTimeTag);
+                }
+                else
+                {
+                    Assert.IsNull(issue);
+                }
+            }
         }
 
         private IEnumerable<Issue> run(HitObject lyric)

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneInvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneInvalidLyricToolTip.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                     },
                 }));
 
-            setTooltip("time tag out of range", new TestTimeTagIssue(new Dictionary<TimeTagInvalid, TimeTag[]>
+            setTooltip("time tag overlapping", new TestTimeTagIssue(new Dictionary<TimeTagInvalid, TimeTag[]>
             {
                 {
                     TimeTagInvalid.Overlapping,
@@ -151,6 +151,19 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
                     }
                 }
             }));
+
+            setTooltip("time tag with no time", new TestTimeTagIssue(new Dictionary<TimeTagInvalid, TimeTag[]>
+            {
+                {
+                    TimeTagInvalid.EmptyTime,
+                    new[]
+                    {
+                        new TimeTag(new TextIndex(2))
+                    }
+                }
+            }));
+
+            setTooltip("missing end time-tag", new TestTimeTagIssue(null, true));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneInvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Edit/TestSceneInvalidLyricToolTip.cs
@@ -258,8 +258,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Edit
 
         internal class TestTimeTagIssue : TimeTagIssue
         {
-            public TestTimeTagIssue(Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags)
-                : base(new Lyric(), null, invalidTimeTags)
+            public TestTimeTagIssue(Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags, bool missingEndTimeTag = false)
+                : base(new Lyric(), null, invalidTimeTags, missingEndTimeTag)
             {
             }
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -67,8 +67,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             TimeTagAssert.ArePropertyEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
         }
 
-        [TestCase(new[] { "[0,start]:1000", "[1,start]:", "[2,start]:3000", "[3,start]:", "[3,end]:5000" }, new string[] { "[1,start]:", "[3,start]:" })]
-        [TestCase(new[] { "[0,start]:", "[3,end]:" }, new string[] { "[0,start]:", "[3,end]:" })]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:", "[2,start]:3000", "[3,start]:", "[3,end]:5000" }, new[] { "[1,start]:", "[3,start]:" })]
+        [TestCase(new[] { "[0,start]:", "[3,end]:" }, new[] { "[0,start]:", "[3,end]:" })]
         public void TestFindNoneTime(string[] timeTagTexts, string[] invalidTimeTags)
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -76,6 +76,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             TimeTagAssert.ArePropertyEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
         }
 
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,start]:2000" }, new string[] { "[3,start]:2000" })]
+        [TestCase("カラオケ", new[] { "[3,start]:2000", "[3,start]:3000", "[3,end]:4000" }, new[] { "[3,start]:2000", "[3,start]:3000" })]
+        public void TestFindStartTimeTagAtTheEndOfLyric(string text, string[] timeTagTexts, string[] invalidTimeTags)
+        {
+            var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
+            var startTimeTagsAtTheEndOfLyric = TimeTagsUtils.FindStartTimeTagAtTheEndOfLyric(timeTags, text);
+            TimeTagAssert.ArePropertyEqual(startTimeTagsAtTheEndOfLyric, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
+        }
+
         [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, GroupCheck.Asc, SelfCheck.BasedOnStart, new[] { 1 })]
         [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, GroupCheck.Asc, SelfCheck.BasedOnEnd, new[] { 0 })]
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2100", "[1,start]:2000", "[1,end]:3000" }, GroupCheck.Asc, SelfCheck.BasedOnStart, new[] { 2 })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -78,6 +78,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
         [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,end]:2000" }, true)]
         [TestCase("カラオケ", new[] { "[3,start]:2000", "[3,start]:3000", "[3,end]:4000" }, true)]
+        [TestCase("カラオケ", new[] { "[3,end]:3000", "[3,end]:4000" }, true)] // multiple end time-tag is ok.
         [TestCase("カラオケ", new[] { "[0,start]:1000" }, false)]
         [TestCase("カラオケ", new[] { "[0,start]:1000", "[5,end]:2000" }, false)] // out of range end time-tag should be count as missing.
         [TestCase("", new[] { "[0,start]:1000", "[0,end]:2000" }, false)] // empty lyric should always count as missing.

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -76,13 +76,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             TimeTagAssert.ArePropertyEqual(outOfRangeTimeTags, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
         }
 
-        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,start]:2000" }, new string[] { "[3,start]:2000" })]
-        [TestCase("カラオケ", new[] { "[3,start]:2000", "[3,start]:3000", "[3,end]:4000" }, new[] { "[3,start]:2000", "[3,start]:3000" })]
-        public void TestFindStartTimeTagAtTheEndOfLyric(string text, string[] timeTagTexts, string[] invalidTimeTags)
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[3,end]:2000" }, true)]
+        [TestCase("カラオケ", new[] { "[3,start]:2000", "[3,start]:3000", "[3,end]:4000" }, true)]
+        [TestCase("カラオケ", new[] { "[0,start]:1000" }, false)]
+        [TestCase("カラオケ", new[] { "[0,start]:1000", "[5,end]:2000" }, false)] // out of range end time-tag should be count as missing.
+        [TestCase("", new[] { "[0,start]:1000", "[0,end]:2000" }, false)] // empty lyric should always count as missing.
+        public void TestHasEndTimeTagInLyric(string text, string[] timeTagTexts, bool actual)
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
-            var startTimeTagsAtTheEndOfLyric = TimeTagsUtils.FindStartTimeTagAtTheEndOfLyric(timeTags, text);
-            TimeTagAssert.ArePropertyEqual(startTimeTagsAtTheEndOfLyric, TestCaseTagHelper.ParseTimeTags(invalidTimeTags));
+            var missing = TimeTagsUtils.HasEndTimeTagInLyric(timeTags, text);
+            Assert.AreEqual(missing, actual);
         }
 
         [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, GroupCheck.Asc, SelfCheck.BasedOnStart, new[] { 1 })]

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckInvalidTimeLyrics.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckInvalidTimeLyrics.cs
@@ -38,8 +38,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
                     yield return new IssueTemplateInvalidLyricTime(this).Create(lyric, invalidLyricTime);
 
                 var invalidTimeTags = checkInvalidTimeTags(lyric);
-                if (invalidTimeTags.Any())
-                    yield return new IssueTemplateInvalidTimeTag(this).Create(lyric, invalidTimeTags);
+                var missingEndTimeTag = checkMissingEndTimeTag(lyric);
+                if (invalidTimeTags.Any() || missingEndTimeTag)
+                    yield return new IssueTemplateInvalidTimeTag(this).Create(lyric, invalidTimeTags, missingEndTimeTag);
             }
         }
 
@@ -83,6 +84,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
             return result;
         }
 
+        private bool checkMissingEndTimeTag(Lyric lyric)
+            => !TimeTagsUtils.HasEndTimeTagInLyric(lyric.TimeTags, lyric.Text);
+
         public class IssueTemplateInvalidLyricTime : IssueTemplate
         {
             public IssueTemplateInvalidLyricTime(ICheck check)
@@ -101,8 +105,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
             {
             }
 
-            public Issue Create(Lyric lyric, Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags)
-                => new TimeTagIssue(lyric, this, invalidTimeTags);
+            public Issue Create(Lyric lyric, Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags, bool missingEndTimeTag)
+                => new TimeTagIssue(lyric, this, invalidTimeTags, missingEndTimeTag);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/Components/TimeTagIssue.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/Components/TimeTagIssue.cs
@@ -12,10 +12,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks.Components
     {
         public readonly Dictionary<TimeTagInvalid, TimeTag[]> InvalidTimeTags;
 
-        public TimeTagIssue(HitObject lyric, IssueTemplate template, Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags, params object[] args)
+        public readonly bool MissingEndTimeTag;
+
+        public TimeTagIssue(HitObject lyric, IssueTemplate template, Dictionary<TimeTagInvalid, TimeTag[]> invalidTimeTags, bool missingEndTimeTag, params object[] args)
             : base(lyric, template, args)
         {
             InvalidTimeTags = invalidTimeTags;
+            MissingEndTimeTag = missingEndTimeTag;
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
                     // Print time-tag invalid message
                     case TimeTagIssue timeTagIssue:
+                        if (timeTagIssue.MissingEndTimeTag)
+                            invalidMessage.AddAlertParagraph("Missing end time tag at the end of lyric.");
+
                         timeTagIssue.InvalidTimeTags?.ForEach(x => createTimeTagInvalidMessage(x.Key, x.Value));
                         break;
 
@@ -109,6 +112,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
                     case TimeTagInvalid.Overlapping:
                         invalidMessage.AddAlertParagraph("Time tag(s) is invalid at position ");
+                        break;
+
+                    case TimeTagInvalid.EmptyTime:
+                        invalidMessage.AddAlertParagraph("Time tag(s) is missing time at position ");
                         break;
 
                     default:

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -83,6 +83,15 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             => timeTags?.Where(x => x.Time == null).ToArray();
 
         /// <summary>
+        /// Fins start time-tag the at the end of lyric.
+        /// </summary>
+        /// <param name="timeTags"></param>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        public static TimeTag[] FindStartTimeTagAtTheEndOfLyric(TimeTag[] timeTags, string lyric)
+            => timeTags?.Where(x => x.Index.State == TextIndex.IndexState.Start && x.Index.Index == lyric.Length - 1).ToArray();
+
+        /// <summary>
         /// Find overlapping time tags.
         /// </summary>
         /// <param name="timeTags">Time tags</param>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -83,13 +83,12 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             => timeTags?.Where(x => x.Time == null).ToArray();
 
         /// <summary>
-        /// Fins start time-tag the at the end of lyric.
+        /// Check lyric has end time-tag
         /// </summary>
         /// <param name="timeTags"></param>
         /// <param name="lyric"></param>
-        /// <returns></returns>
-        public static TimeTag[] FindStartTimeTagAtTheEndOfLyric(TimeTag[] timeTags, string lyric)
-            => timeTags?.Where(x => x.Index.State == TextIndex.IndexState.Start && x.Index.Index == lyric.Length - 1).ToArray();
+        public static bool HasEndTimeTagInLyric(TimeTag[] timeTags, string lyric)
+            => timeTags.Any(x => x.Index.State == TextIndex.IndexState.End && x.Index.Index == lyric.Length - 1);
 
         /// <summary>
         /// Find overlapping time tags.


### PR DESCRIPTION
Closes issue #688 

What's changed:
- add test to check if lyric contains end time-tag.
- add missing end time-tag property in `TimeTagIssue`
- add a new role into an invalid lyric tooltip.
- add a new role into the invalid time-tag table.