### PR TITLE
Improve singer editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
@@ -1,10 +1,32 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
 {
     internal class AvatarSection : EditSingerSection
     {
         protected override string Title => "Avatar";
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                new LabelledImageSelector
+                {
+                    Label = "Avatar",
+                    Description = "Select image to set avater."
+                },
+                new LabelledColourSelector
+                {
+                    Label = "Colour",
+                    Description = "Select singer colour."
+                }
+            };
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
@@ -109,11 +109,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
 
             if (e.AltPressed)
             {
+                // todo : this event not working while zooming, because zooming will also call scrollto.
+                // bindableCurrent.Value = getCurrentPosition();
+
                 // Update zoom to target, ignore easing value.
                 bindableZoom.Value = Zoom;
             }
 
             return true;
+
+            float getCurrentPosition()
+            {
+                // params
+                var zoomedContent = Content;
+                var focusPoint = zoomedContent.ToLocalSpace(e.ScreenSpaceMousePosition).X;
+                var contentSize = zoomedContent.DrawWidth;
+                var scrollOffset = Current;
+
+                // calculation
+                float focusOffset = focusPoint - scrollOffset;
+                float expectedWidth = DrawWidth * Zoom;
+                float targetOffset = expectedWidth * (focusPoint / contentSize) - focusOffset;
+
+                return targetOffset;
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -21,14 +22,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
     {
         private const float timeline_height = 38;
 
-        [Resolved(CanBeNull = true)]
-        private SingerManager singerManager { get; set; }
-
         [Resolved]
         private EditorClock editorClock { get; set; }
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
+
+        public Bindable<float> bindableZoom;
+        public Bindable<float> bindableCurrent;
 
         public readonly Singer Singer;
 
@@ -48,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
         private Container mainContent;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load(SingerManager singerManager, OsuColour colour)
         {
             AddInternal(background = new Box
             {
@@ -81,23 +82,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
             MinZoom = getZoomLevelForVisibleMilliseconds(20000);
             Zoom = getZoomLevelForVisibleMilliseconds(5000);
 
-            // todo : might need better way to sync the zoom and scroll position.
-            singerManager?.BindableZoom.BindValueChanged(e =>
+            bindableZoom = singerManager.BindableZoom.GetBoundCopy();
+            bindableCurrent = singerManager.BindableCurrent.GetBoundCopy();
+
+            bindableZoom.BindValueChanged(e =>
             {
                 if (e.NewValue == Zoom)
                     return;
 
                 Zoom = e.NewValue;
-            });
+            }, true);
 
-            singerManager?.BindableCurrent.BindValueChanged(e =>
+            bindableCurrent.BindValueChanged(e =>
             {
-                // not make self-assign.
-                if (Current != Target)
-                    return;
-
-                ScrollTo(e.NewValue, false);
-            });
+                ScrollTo(e.NewValue);
+            }, true);
         }
 
         private float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(editorClock.TrackLength / milliseconds));
@@ -108,9 +107,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
             if (!zoneChanged)
                 return false;
 
-            // Update bindable to trigger zone changed.
-            if (singerManager != null)
-                singerManager.BindableZoom.Value = Zoom;
+            if (e.AltPressed)
+            {
+                // Update zoom to target, ignore easing value.
+                bindableZoom.Value = Zoom;
+            }
 
             return true;
         }
@@ -129,11 +130,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
             ScrollTo(position, false);
         }
 
-        protected override void UpdateAfterChildren()
+        protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = null)
         {
-            base.UpdateAfterChildren();
+            base.OnUserScroll(value, animated, distanceDecay);
 
-            singerManager.BindableCurrent.Value = Current;
+            // update current value if user scroll to.
+            bindableCurrent.Value = value;
         }
 
         private float getPositionFromTime(double time)

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/CreateNewLyricPlacementRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/CreateNewLyricPlacementRow.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
                     TooltipText = "Click to add new singer",
                     Action = () =>
                     {
-                        var singerId = singerManager.Singers.Count;
+                        var singerId = singerManager.Singers.Count + 1;
                         singerManager.CreateSinger(new Singer(singerId)
                         {
                             Name = "New singer"

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerManager.cs
@@ -32,6 +32,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
             if (beatmap?.PlayableBeatmap is KaraokeBeatmap karaokeBeatmap)
             {
                 Singers.AddRange(karaokeBeatmap.Singers);
+
+                // should write-back if singer changed.
+                Singers.BindCollectionChanged((a, b) =>
+                {
+                    karaokeBeatmap.Singers = Singers.ToArray();
+                });
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/ColorPicker.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/ColorPicker.cs
@@ -3,11 +3,12 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
 {
-    public class ColorPicker : Box
+    public class ColorPicker : Box, IHasCurrentValue<Color4>
     {
         public Bindable<Color4> CurrentColor { get; set; } = new Bindable<Color4>();
 
@@ -16,5 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             Height = 200;
             Colour = Color4.Blue;
         }
+
+        public Bindable<Color4> Current { get; set; } = new Bindable<Color4>();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledColourSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledColourSelector.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
+{
+    public class LabelledColourSelector : LabelledComponent<ColorPicker, Color4>
+    {
+        public LabelledColourSelector()
+            : base(true)
+        {
+        }
+
+        protected override ColorPicker CreateComponent()
+            => new ColorPicker
+            {
+                RelativeSizeAxes = Axes.X,
+            };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledImageSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledImageSelector.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
+{
+    /// <summary>
+    /// A labelled textbox which reveals an inline file chooser when clicked.
+    /// Will be replaced after has official one.
+    /// </summary>
+    public class LabelledImageSelector : LabelledTextBox
+    {
+    }
+}


### PR DESCRIPTION
Implement part of #691

what's fixed:
- implement fake colour and avatar picker.
- apply to singer detail edit dialog.
- position is hard to sync if zoom out to min value.
- scale and position are different if create a new singer.
- should update right-side selection if singer deleted