### PR TITLE
Adjust edit mode order

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
@@ -21,12 +21,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             LyricEditorMode.View,
             LyricEditorMode.Manage,
             LyricEditorMode.Typing,
+            LyricEditorMode.Language,
             LyricEditorMode.EditRubyRomaji,
             LyricEditorMode.CreateTimeTag,
             LyricEditorMode.EditNote,
             LyricEditorMode.Layout,
             LyricEditorMode.Singer,
-            LyricEditorMode.Language
         };
 
         protected override string GetName(LyricEditorMode selection)
@@ -41,6 +41,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 
                 case LyricEditorMode.Typing:
                     return "Typing";
+
+                case LyricEditorMode.Language:
+                    return "Select language";
 
                 case LyricEditorMode.EditRubyRomaji:
                     return "Edit ruby / romaji";
@@ -58,9 +61,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
 
                 case LyricEditorMode.Singer:
                     return "Select singer";
-
-                case LyricEditorMode.Language:
-                    return "Select language";
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(selection));

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
@@ -22,8 +22,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             LyricEditorMode.Manage,
             LyricEditorMode.Typing,
             LyricEditorMode.EditRubyRomaji,
-            LyricEditorMode.EditNote,
             LyricEditorMode.CreateTimeTag,
+            LyricEditorMode.EditNote,
             LyricEditorMode.Layout,
             LyricEditorMode.Singer,
             LyricEditorMode.Language
@@ -45,13 +45,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                 case LyricEditorMode.EditRubyRomaji:
                     return "Edit ruby / romaji";
 
-                case LyricEditorMode.EditNote:
-                    return "Edit note";
-
                 case LyricEditorMode.CreateTimeTag:
                 case LyricEditorMode.RecordTimeTag:
                 case LyricEditorMode.AdjustTimeTag:
                     return "Edit time tag";
+
+                case LyricEditorMode.EditNote:
+                    return "Edit note";
 
                 case LyricEditorMode.Layout:
                     return "Select layout";

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -77,11 +77,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             {
                 switch (mode)
                 {
-                    case LyricEditorMode.EditNote:
-                        return new NoteRowExtend(lyric);
-
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagRowExtend(lyric);
+
+                    case LyricEditorMode.EditNote:
+                        return new NoteRowExtend(lyric);
 
                     default:
                         return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -282,6 +282,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.View:
                 case LyricEditorMode.Manage:
                 case LyricEditorMode.Typing: // will handle in OnKeyDown
+                case LyricEditorMode.Language:
                 case LyricEditorMode.EditRubyRomaji:
                     return false;
 
@@ -297,7 +298,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.EditNote:
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:
-                case LyricEditorMode.Language:
                     return false;
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -167,13 +167,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case LyricEditorMode.EditRubyRomaji:
                         return new TextTagExtend();
 
-                    case LyricEditorMode.EditNote:
-                        return new NoteExtend();
-
                     case LyricEditorMode.CreateTimeTag:
                     case LyricEditorMode.RecordTimeTag:
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagExtend();
+
+                    case LyricEditorMode.EditNote:
+                        return new NoteExtend();
 
                     case LyricEditorMode.Singer:
                         return new SingerExtend();
@@ -283,7 +283,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.Manage:
                 case LyricEditorMode.Typing: // will handle in OnKeyDown
                 case LyricEditorMode.EditRubyRomaji:
-                case LyricEditorMode.EditNote:
                     return false;
 
                 case LyricEditorMode.CreateTimeTag:
@@ -295,6 +294,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.AdjustTimeTag:
                     return false;
 
+                case LyricEditorMode.EditNote:
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:
                 case LyricEditorMode.Language:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return 50 / 360f; // yellow
 
                 case LyricEditorMode.Typing:
+                case LyricEditorMode.Language:
                 case LyricEditorMode.EditRubyRomaji:
                     return 333 / 360f; // pink
 
@@ -61,7 +62,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:
-                case LyricEditorMode.Language:
                     return 271 / 360f; // purple
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
@@ -51,13 +51,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.EditRubyRomaji:
                     return 333 / 360f; // pink
 
-                case LyricEditorMode.EditNote:
-                    return 203 / 360f; // blue
-
                 case LyricEditorMode.CreateTimeTag:
                 case LyricEditorMode.RecordTimeTag:
                 case LyricEditorMode.AdjustTimeTag:
                     return 33 / 360f; // orange
+
+                case LyricEditorMode.EditNote:
+                    return 203 / 360f; // blue
 
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
@@ -26,11 +26,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         EditRubyRomaji,
 
         /// <summary>
-        /// Able to create/delete/mode/split/combine note.
-        /// </summary>
-        EditNote,
-
-        /// <summary>
         /// Enable to create/delete and reset time tag.
         /// </summary>
         CreateTimeTag,
@@ -44,6 +39,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// Precisely adjust time-tag time.
         /// </summary>
         AdjustTimeTag,
+
+        /// <summary>
+        /// Able to create/delete/mode/split/combine note.
+        /// </summary>
+        EditNote,
 
         /// <summary>
         /// Can edit each lyric's layout.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         Typing,
 
         /// <summary>
+        /// Can edit each lyric's language.
+        /// </summary>
+        Language,
+
+        /// <summary>
         /// Able to create/delete ruby/romaji.
         /// </summary>
         EditRubyRomaji,
@@ -54,10 +59,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// Can edit each lyric's singer.
         /// </summary>
         Singer,
-
-        /// <summary>
-        /// Can edit each lyric's language.
-        /// </summary>
-        Language,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                         return new TypingCaretPositionAlgorithm(lyrics);
 
                     case LyricEditorMode.EditRubyRomaji:
-                    case LyricEditorMode.EditNote:
                         return new NavigateCaretPositionAlgorithm(lyrics);
 
                     case LyricEditorMode.CreateTimeTag:
@@ -40,6 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                         return new TimeTagCaretPositionAlgorithm(lyrics) { Mode = RecordingMovingCaretMode };
 
                     case LyricEditorMode.AdjustTimeTag:
+                    case LyricEditorMode.EditNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         return new NavigateCaretPositionAlgorithm(lyrics);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -206,6 +206,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.View:
                         case LyricEditorMode.Manage:
                         case LyricEditorMode.Typing:
+                            return null;
+
+                        case LyricEditorMode.Language:
+                            return new LanguageInfo(Lyric);
+
                         case LyricEditorMode.EditRubyRomaji:
                             return null;
 
@@ -222,9 +227,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
 
                         case LyricEditorMode.Singer:
                             return new SingerInfo(Lyric);
-
-                        case LyricEditorMode.Language:
-                            return new LanguageInfo(Lyric);
 
                         default:
                             throw new IndexOutOfRangeException(nameof(mode));
@@ -501,6 +503,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.Typing:
                             return new DrawableLyricInputCaret();
 
+                        case LyricEditorMode.Language:
                         case LyricEditorMode.EditRubyRomaji:
                             return null;
 
@@ -514,7 +517,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.EditNote:
                         case LyricEditorMode.Layout:
                         case LyricEditorMode.Singer:
-                        case LyricEditorMode.Language:
                             return null;
 
                         default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -207,13 +207,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.Manage:
                         case LyricEditorMode.Typing:
                         case LyricEditorMode.EditRubyRomaji:
-                        case LyricEditorMode.EditNote:
                             return null;
 
                         case LyricEditorMode.CreateTimeTag:
                         case LyricEditorMode.RecordTimeTag:
                         case LyricEditorMode.AdjustTimeTag:
                             return new TimeTagInfo(Lyric);
+
+                        case LyricEditorMode.EditNote:
+                            return null;
 
                         case LyricEditorMode.Layout:
                             return new LayoutInfo(Lyric);
@@ -342,7 +344,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         break;
 
                     case LyricEditorMode.EditRubyRomaji:
-                    case LyricEditorMode.EditNote:
                         state.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(Lyric));
                         break;
 
@@ -357,6 +358,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         break;
 
                     case LyricEditorMode.AdjustTimeTag:
+                    case LyricEditorMode.EditNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         state.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(Lyric));
@@ -502,9 +504,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.EditRubyRomaji:
                             return null;
 
-                        case LyricEditorMode.EditNote:
-                            return null;
-
                         case LyricEditorMode.CreateTimeTag:
                             return new DrawableTimeTagEditCaret();
 
@@ -512,6 +511,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                             return new DrawableTimeTagRecordCaret();
 
                         case LyricEditorMode.AdjustTimeTag:
+                        case LyricEditorMode.EditNote:
                         case LyricEditorMode.Layout:
                         case LyricEditorMode.Singer:
                         case LyricEditorMode.Language:


### PR DESCRIPTION
- move edit note mode next to edit time-tag mode.
- move edit language mode next to typing mode.

Note:
change the step because we what user create karaoke beatmap following the order in `LyricEditorMode`