### PR TITLE
Implement auto generate note section

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             LyricEditorMode.Language,
             LyricEditorMode.EditRubyRomaji,
             LyricEditorMode.CreateTimeTag,
-            LyricEditorMode.EditNote,
+            LyricEditorMode.AdjustNote,
             LyricEditorMode.Layout,
             LyricEditorMode.Singer,
         };
@@ -53,7 +53,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                 case LyricEditorMode.AdjustTimeTag:
                     return "Edit time tag";
 
-                case LyricEditorMode.EditNote:
+                case LyricEditorMode.CreateNote:
+                case LyricEditorMode.CreateNotePosition:
+                case LyricEditorMode.AdjustNote:
                     return "Edit note";
 
                 case LyricEditorMode.Layout:

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             LyricEditorMode.Language,
             LyricEditorMode.EditRubyRomaji,
             LyricEditorMode.CreateTimeTag,
-            LyricEditorMode.AdjustNote,
+            LyricEditorMode.CreateNote,
             LyricEditorMode.Layout,
             LyricEditorMode.Singer,
         };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -80,7 +80,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagRowExtend(lyric);
 
-                    case LyricEditorMode.EditNote:
+                    case LyricEditorMode.CreateNote:
+                    case LyricEditorMode.CreateNotePosition:
+                    case LyricEditorMode.AdjustNote:
                         return new NoteRowExtend(lyric);
 
                     default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
@@ -1,12 +1,74 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Checker;
+using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
+    /// <summary>
+    /// In <see cref="LyricEditorMode.CreateNote"/> mode, able to let user generate notes by <see cref="TimeTag"/>
+    /// But need to make sure that lyric should not have any <see cref="TimeTagIssue"/>
+    /// If found any issue, will navigate to target lyric.
+    /// </summary>
     public class NoteAutoGenerateSection : Section
     {
         protected override string Title => "Auto generate";
+
+        private BindableDictionary<Lyric, Issue[]> bindableReports;
+
+        [BackgroundDependencyLoader]
+        private void load(LyricCheckerManager lyricCheckerManager)
+        {
+            bindableReports = lyricCheckerManager.BindableReports.GetBoundCopy();
+            bindableReports.BindCollectionChanged((a, b) =>
+            {
+                var hasTimeTagIssue = bindableReports.Values.SelectMany(x => x)
+                                                     .OfType<TimeTagIssue>().Any();
+
+                if (hasTimeTagIssue)
+                {
+                    Children = new[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = "Seems there's some time-tag issue in lyric. \nGo to time-tag edit mode then clear those issues."
+                        }
+                    };
+                }
+                else
+                {
+                    Children = new[]
+                    {
+                        new AutoGenerateButton
+                        {
+                            Text = "Generate",
+                            Action = () =>
+                            {
+                                // todo : // auto-generate time-tag.
+                            }
+                        },
+                    };
+                }
+            }, true);
+        }
+
+        public class AutoGenerateButton : OsuButton
+        {
+            public AutoGenerateButton()
+            {
+                RelativeSizeAxes = Axes.X;
+                Content.CornerRadius = 15;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
@@ -11,7 +11,9 @@ using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
@@ -26,8 +28,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private BindableDictionary<Lyric, Issue[]> bindableReports;
 
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
+
         [BackgroundDependencyLoader]
-        private void load(LyricCheckerManager lyricCheckerManager)
+        private void load(LyricCheckerManager lyricCheckerManager, NoteManager noteManager)
         {
             bindableReports = lyricCheckerManager.BindableReports.GetBoundCopy();
             bindableReports.BindCollectionChanged((a, b) =>
@@ -54,7 +59,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                             Text = "Generate",
                             Action = () =>
                             {
-                                // todo : // auto-generate time-tag.
+                                // todo : should be able to apply only selected lyric.
+                                var lyrics = beatmap.HitObjects.OfType<Lyric>().ToArray();
+                                noteManager.AutoGenerateNotes(lyrics);
                             }
                         },
                     };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
@@ -11,14 +11,14 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
-    public class TimeTagEditModeSection : Section
+    public class NoteEditModeSection : Section
     {
         protected override string Title => "Edit mode";
 
         [Cached]
-        private readonly OverlayColourProvider overlayColourProvider = OverlayColourProvider.Orange;
+        private readonly OverlayColourProvider overlayColourProvider = OverlayColourProvider.Blue;
 
         private EditModeButton[] buttons;
         private OsuMarkdownContainer description;
@@ -40,19 +40,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                     {
                         buttons = new[]
                         {
-                            new EditModeButton(LyricEditorMode.CreateTimeTag)
+                            new EditModeButton(LyricEditorMode.CreateNote)
                             {
                                 Text = "Create",
                                 Action = updateEditMode,
                                 Padding = new MarginPadding { Horizontal = 5 },
                             },
-                            new EditModeButton(LyricEditorMode.RecordTimeTag)
+                            new EditModeButton(LyricEditorMode.CreateNotePosition)
                             {
-                                Text = "Recording",
+                                Text = "Position",
                                 Action = updateEditMode,
                                 Padding = new MarginPadding { Horizontal = 5 },
                             },
-                            new EditModeButton(LyricEditorMode.AdjustTimeTag)
+                            new EditModeButton(LyricEditorMode.AdjustNote)
                             {
                                 Text = "Adjust",
                                 Action = updateEditMode,
@@ -82,15 +82,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 
                     switch (child.Mode)
                     {
-                        case LyricEditorMode.CreateTimeTag:
+                        case LyricEditorMode.CreateNote:
                             child.BackgroundColour = highLight ? colour.Blue : colour.BlueDarker;
                             break;
 
-                        case LyricEditorMode.RecordTimeTag:
+                        case LyricEditorMode.CreateNotePosition:
                             child.BackgroundColour = highLight ? colour.Red : colour.RedDarker;
                             break;
 
-                        case LyricEditorMode.AdjustTimeTag:
+                        case LyricEditorMode.AdjustNote:
                             child.BackgroundColour = highLight ? colour.Yellow : colour.YellowDarker;
                             break;
                     }
@@ -99,16 +99,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                 // update description text.
                 switch (mode)
                 {
-                    case LyricEditorMode.CreateTimeTag:
-                        description.Text = "Use keyboard to control caret position, press `N` to create new time-tag and press `D` to delete exist time-tag.";
+                    case LyricEditorMode.CreateNote:
+                        description.Text = "Using time-tag to create default notes.";
                         break;
 
-                    case LyricEditorMode.RecordTimeTag:
-                        description.Text = "Press spacing button at the right time to set current time to time-tag.";
+                    case LyricEditorMode.CreateNotePosition:
+                        description.Text = "Using singer voice data to adjust note position.";
                         break;
 
-                    case LyricEditorMode.AdjustTimeTag:
-                        description.Text = "Drag to adjust time-tag time precisely.";
+                    case LyricEditorMode.AdjustNote:
+                        description.Text = "If you are note satisfied this result, you can adjust this by hands.";
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
         {
             Children = new Drawable[]
             {
+                new NoteEditModeSection(),
                 new NoteAutoGenerateSection(),
                 new NoteIssueSection()
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -172,7 +172,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagExtend();
 
-                    case LyricEditorMode.EditNote:
+                    case LyricEditorMode.CreateNote:
+                    case LyricEditorMode.CreateNotePosition:
+                    case LyricEditorMode.AdjustNote:
                         return new NoteExtend();
 
                     case LyricEditorMode.Singer:
@@ -295,7 +297,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.AdjustTimeTag:
                     return false;
 
-                case LyricEditorMode.EditNote:
+                case LyricEditorMode.CreateNote:
+                case LyricEditorMode.CreateNotePosition:
+                case LyricEditorMode.AdjustNote:
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:
                     return false;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
@@ -57,7 +57,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.AdjustTimeTag:
                     return 33 / 360f; // orange
 
-                case LyricEditorMode.EditNote:
+                case LyricEditorMode.CreateNote:
+                case LyricEditorMode.CreateNotePosition:
+                case LyricEditorMode.AdjustNote:
                     return 203 / 360f; // blue
 
                 case LyricEditorMode.Layout:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
@@ -46,9 +46,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         AdjustTimeTag,
 
         /// <summary>
-        /// Able to create/delete/mode/split/combine note.
+        /// Enable to create/delete and reset note.
+        /// Also able to create default notes.
         /// </summary>
-        EditNote,
+        CreateNote,
+
+        /// <summary>
+        /// Auto adjust note position by singer voice data.
+        /// </summary>
+        CreateNotePosition,
+
+        /// <summary>
+        /// Adjust note position.
+        /// </summary>
+        AdjustNote,
 
         /// <summary>
         /// Can edit each lyric's layout.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor_State.cs
@@ -39,7 +39,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                         return new TimeTagCaretPositionAlgorithm(lyrics) { Mode = RecordingMovingCaretMode };
 
                     case LyricEditorMode.AdjustTimeTag:
-                    case LyricEditorMode.EditNote:
+                    case LyricEditorMode.CreateNote:
+                    case LyricEditorMode.CreateNotePosition:
+                    case LyricEditorMode.AdjustNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         return new NavigateCaretPositionAlgorithm(lyrics);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -219,7 +219,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.AdjustTimeTag:
                             return new TimeTagInfo(Lyric);
 
-                        case LyricEditorMode.EditNote:
+                        case LyricEditorMode.CreateNote:
+                        case LyricEditorMode.CreateNotePosition:
+                        case LyricEditorMode.AdjustNote:
                             return null;
 
                         case LyricEditorMode.Layout:
@@ -360,7 +362,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         break;
 
                     case LyricEditorMode.AdjustTimeTag:
-                    case LyricEditorMode.EditNote:
+                    case LyricEditorMode.CreateNote:
+                    case LyricEditorMode.CreateNotePosition:
+                    case LyricEditorMode.AdjustNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         state.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(Lyric));
@@ -514,7 +518,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                             return new DrawableTimeTagRecordCaret();
 
                         case LyricEditorMode.AdjustTimeTag:
-                        case LyricEditorMode.EditNote:
+                        case LyricEditorMode.CreateNote:
+                        case LyricEditorMode.CreateNotePosition:
+                        case LyricEditorMode.AdjustNote:
                         case LyricEditorMode.Layout:
                         case LyricEditorMode.Singer:
                             return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Notes/NoteManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Notes/NoteManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
@@ -23,6 +24,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Notes
 
         [Resolved]
         private IPlacementHandler placementHandler { get; set; }
+
+        public void AutoGenerateNotes(Lyric[] lyrics)
+        {
+            changeHandler.BeginChange();
+
+            // clear exist notes if from those
+            var matchedNotes = beatmap.HitObjects.OfType<Note>().Where(x => lyrics.Contains(x.ParentLyric)).ToArray();
+            beatmap.RemoveRange(matchedNotes);
+
+            // todo : should get the config from setting.
+            var config = new NoteGeneratorConfig();
+            var generator = new NoteGenerator(config);
+
+            foreach (var lyric in lyrics)
+            {
+                var notes = generator.CreateNotes(lyric);
+                beatmap.AddRange(notes);
+            }
+
+            changeHandler.EndChange();
+        }
 
         public void ChangeDisplay(Note note, bool display)
         {


### PR DESCRIPTION
Implement auto-generate note section.

what's add in this pr:
- split note edit mode number from 1 into 3.
- add a section to let the user able to switch.
- implement note auto-generate section.
- add the auto-generate note feature in the note manager.

todo : 
- [ ] should update the note field of creating or delete notes.
- [ ] should be able to select target notes (need to wait until #448 implemented).