### PR TITLE
Should show invalid text hint next of generate area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
@@ -25,22 +25,26 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap beatmap, LyricSelectionState lyricSelectionState, OsuColour colours)
         {
-            var disableSelectingLyrics = GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>().ToArray());
-
-            Children = new Drawable[]
+            Schedule(() =>
             {
-                new AutoGenerateButton
+                var disableSelectingLyrics = GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>().ToArray());
+
+                Children = new Drawable[]
                 {
-                    StartSelecting = () => disableSelectingLyrics
-                },
-                CreateInvalidLyricAlertTextContainer().With(t =>
-                {
-                    t.RelativeSizeAxes = Axes.X;
-                    t.AutoSizeAxes = Axes.Y;
-                    t.Colour = colours.GrayF;
-                    t.Alpha = disableSelectingLyrics.Any() ? 1 : 0;
-                })
-            };
+                    new AutoGenerateButton
+                    {
+                        StartSelecting = () => disableSelectingLyrics
+                    },
+                    CreateInvalidLyricAlertTextContainer().With(t =>
+                    {
+                        t.RelativeSizeAxes = Axes.X;
+                        t.AutoSizeAxes = Axes.Y;
+                        t.Colour = colours.GrayF;
+                        t.Alpha = disableSelectingLyrics.Any() ? 1 : 0;
+                        t.Padding = new MarginPadding { Horizontal = 20 };
+                    })
+                };
+            });
 
             lyricSelectionState.Action = e =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         protected sealed override string Title => "Auto generate";
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap, LyricSelectionState lyricSelectionState)
+        private void load(EditorBeatmap beatmap, LyricSelectionState lyricSelectionState, OsuColour colours)
         {
             var disableSelectingLyrics = GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>().ToArray());
 
@@ -33,9 +33,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
                 {
                     StartSelecting = () => disableSelectingLyrics
                 },
-                CreateInvalidLyricAlertTextContainer().With(e =>
+                CreateInvalidLyricAlertTextContainer().With(t =>
                 {
-                    e.Alpha = disableSelectingLyrics.Any() ? 1 : 0;
+                    t.RelativeSizeAxes = Axes.X;
+                    t.AutoSizeAxes = Axes.Y;
+                    t.Colour = colours.GrayF;
+                    t.Alpha = disableSelectingLyrics.Any() ? 1 : 0;
                 })
             };
 
@@ -62,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             protected override string SelectingText => "Cancel generate";
         }
 
-        protected class InvalidLyricAlertTextContainer : CustomizableTextContainer
+        protected abstract class InvalidLyricAlertTextContainer : CustomizableTextContainer
         {
             [Resolved]
             private ILyricEditorState state { get; set; }
@@ -71,11 +74,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             {
                 AddIconFactory(name, () => new ClickableSpriteText
                 {
-                    Font = new FontUsage(size: 20),
                     Text = text,
                     Action = () => state.Mode = switchToEditMode,
                 });
             }
+
+            protected override SpriteText CreateSpriteText()
+                => base.CreateSpriteText().With(x => x.Font = x.Font.With(size: 16));
 
             internal class ClickableSpriteText : OsuSpriteText
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
@@ -1,9 +1,16 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -18,13 +25,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap beatmap, LyricSelectionState lyricSelectionState)
         {
-            Children = new[]
+            var disableSelectingLyrics = GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>().ToArray());
+
+            Children = new Drawable[]
             {
                 new AutoGenerateButton
                 {
-                    StartSelecting = () =>
-                        GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>().ToArray())
+                    StartSelecting = () => disableSelectingLyrics
                 },
+                CreateInvalidLyricAlertTextContainer().With(e =>
+                {
+                    e.Alpha = disableSelectingLyrics.Any() ? 1 : 0;
+                })
             };
 
             lyricSelectionState.Action = e =>
@@ -41,11 +53,46 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         protected abstract void Apply(Lyric[] lyrics);
 
+        protected abstract InvalidLyricAlertTextContainer CreateInvalidLyricAlertTextContainer();
+
         private class AutoGenerateButton : SelectLyricButton
         {
             protected override string StandardText => "Generate";
 
             protected override string SelectingText => "Cancel generate";
+        }
+
+        protected class InvalidLyricAlertTextContainer : CustomizableTextContainer
+        {
+            [Resolved]
+            private ILyricEditorState state { get; set; }
+
+            protected void SwitchToModel(string name, string text, LyricEditorMode switchToEditMode)
+            {
+                AddIconFactory(name, () => new ClickableSpriteText
+                {
+                    Font = new FontUsage(size: 20),
+                    Text = text,
+                    Action = () => state.Mode = switchToEditMode,
+                });
+            }
+
+            internal class ClickableSpriteText : OsuSpriteText
+            {
+                public Action Action { get; set; }
+
+                protected override bool OnClick(ClickEvent e)
+                {
+                    Action?.Invoke();
+                    return base.OnClick(e);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OsuColour colours)
+                {
+                    Colour = colours.Yellow;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageAutoGenerateSection.cs
@@ -20,5 +20,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
 
         protected override void Apply(Lyric[] lyrics)
             => lyricManager.AutoDetectLyricLanguage(lyrics);
+
+        protected override InvalidLyricAlertTextContainer CreateInvalidLyricAlertTextContainer()
+            => new InvalidLyricTextAlertTextContainer();
+
+        protected class InvalidLyricTextAlertTextContainer : InvalidLyricAlertTextContainer
+        {
+            private const string edit_mode = "TYPING_MODE";
+
+            public InvalidLyricTextAlertTextContainer()
+            {
+                SwitchToModel(edit_mode, "typing mode", LyricEditorMode.Typing);
+                Text = $"Seems some lyric has no texts, go to [{edit_mode}] to fill the text.";
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
@@ -31,5 +31,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         protected override void Apply(Lyric[] lyrics)
             => noteManager.AutoGenerateNotes(lyrics);
+
+        protected override InvalidLyricAlertTextContainer CreateInvalidLyricAlertTextContainer()
+            => new InvalidLyricTimeTagAlertTextContainer();
+
+        protected class InvalidLyricTimeTagAlertTextContainer : InvalidLyricAlertTextContainer
+        {
+            private const string adjust_time_tag_mode = "ADJUST_TIME_TAG_MODE";
+
+            public InvalidLyricTimeTagAlertTextContainer()
+            {
+                SwitchToModel(adjust_time_tag_mode, "adjust time-tag mode", LyricEditorMode.AdjustTimeTag);
+                Text = $"Seems some lyric contains invalid time-tag, go to [{adjust_time_tag_mode}] to fix those issue.";
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagAutoGenerateSection.cs
@@ -4,13 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class RomajiTagAutoGenerateSection : AutoGenerateSection
+    public class RomajiTagAutoGenerateSection : TextTagAutoGenerateSection
     {
         [Resolved]
         private RubyRomajiManager rubyRomaji { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagAutoGenerateSection.cs
@@ -4,13 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class RubyTagAutoGenerateSection : AutoGenerateSection
+    public class RubyTagAutoGenerateSection : TextTagAutoGenerateSection
     {
         [Resolved]
         private RubyRomajiManager rubyRomaji { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagAutoGenerateSection.cs
@@ -1,26 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
-using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class TimeTagAutoGenerateSection : AutoGenerateSection
+    public abstract class TextTagAutoGenerateSection : AutoGenerateSection
     {
-        [Resolved]
-        private LyricManager lyricManager { get; set; }
-
-        protected override Dictionary<Lyric, string> GetDisableSelectingLyrics(Lyric[] lyrics)
-            => lyrics.Where(x => x.Language == null)
-                     .ToDictionary(k => k, i => "Before generate time-tag, need to assign language first.");
-
-        protected override void Apply(Lyric[] lyrics)
-            => lyricManager.AutoGenerateTimeTags(lyrics);
-
         protected override InvalidLyricAlertTextContainer CreateInvalidLyricAlertTextContainer()
             => new InvalidLyricLanguageAlertTextContainer();
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/124375753-c6bc1f00-dcde-11eb-8df4-8dbe637b2a75.png)

Closes issue #734 
show a text and navigation if has any invalid lyrics.