### PR TITLE
Switch order between generate and edit mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
@@ -15,19 +15,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             {
                 switch (e.NewValue)
                 {
-                    case TextTagEditMode.Edit:
-                        Children = new Drawable[]
-                        {
-                            new TextTagEditModeSection(),
-                            new RomajiTagEditSection(),
-                        };
-                        break;
-
                     case TextTagEditMode.Generate:
                         Children = new Drawable[]
                         {
                             new TextTagEditModeSection(),
                             new RomajiTagAutoGenerateSection(),
+                        };
+                        break;
+
+                    case TextTagEditMode.Edit:
+                        Children = new Drawable[]
+                        {
+                            new TextTagEditModeSection(),
+                            new RomajiTagEditSection(),
                         };
                         break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
@@ -15,19 +15,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             {
                 switch (e.NewValue)
                 {
-                    case TextTagEditMode.Edit:
-                        Children = new Drawable[]
-                        {
-                            new TextTagEditModeSection(),
-                            new RubyTagEditSection(),
-                        };
-                        break;
-
                     case TextTagEditMode.Generate:
                         Children = new Drawable[]
                         {
                             new TextTagEditModeSection(),
                             new RubyTagAutoGenerateSection(),
+                        };
+                        break;
+
+                    case TextTagEditMode.Edit:
+                        Children = new Drawable[]
+                        {
+                            new TextTagEditModeSection(),
+                            new RubyTagEditSection(),
                         };
                         break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditMode.cs
@@ -5,9 +5,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
     public enum TextTagEditMode
     {
-        Edit,
-
         Generate,
+
+        Edit,
 
         Verify
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
@@ -27,10 +27,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             => new Dictionary<TextTagEditMode, EditModeSelectionItem>
             {
                 {
-                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric text tag in here.")
+                    TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate ruby/romaji tag.")
                 },
                 {
-                    TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate ruby/romaji tag.")
+                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric text tag in here.")
                 },
                 {
                     TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid text tag in here.")
@@ -41,10 +41,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         {
             switch (mode)
             {
-                case TextTagEditMode.Edit:
+                case TextTagEditMode.Generate:
                     return active ? colour.Blue : colour.BlueDarker;
 
-                case TextTagEditMode.Generate:
+                case TextTagEditMode.Edit:
                     return active ? colour.Red : colour.RedDarker;
 
                 case TextTagEditMode.Verify:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
@@ -13,6 +13,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         public override float ExtendWidth => 350;
 
         [Cached]
-        protected readonly Bindable<TextTagEditMode> EditMode = new Bindable<TextTagEditMode>();
+        protected readonly Bindable<TextTagEditMode> EditMode = new Bindable<TextTagEditMode>(TextTagEditMode.Edit);
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/124381220-37256900-dcfc-11eb-9280-2208024fd86d.png)

What's changed in this pr:
- Switch order between generate and edit mode, because generate color is blue and edit color is red in other edit modes.
- set default edit mode in edit ruby/romaji is edit, not generatnig.