### PR TITLE
Add config button next to the auto-generate button.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
@@ -11,10 +11,12 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 {
@@ -31,9 +33,39 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
                 Children = new Drawable[]
                 {
-                    new AutoGenerateButton
+                    new GridContainer
                     {
-                        StartSelecting = () => disableSelectingLyrics
+                        AutoSizeAxes = Axes.Y,
+                        RelativeSizeAxes = Axes.X,
+                        ColumnDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 5),
+                            new Dimension(GridSizeMode.Absolute, 36)
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize)
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new AutoGenerateButton
+                                {
+                                    StartSelecting = () => disableSelectingLyrics
+                                },
+                                null,
+                                new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Size = new Vector2(36),
+                                    Icon = FontAwesome.Solid.Cog,
+                                    Action = OpenConfigSetting,
+                                },
+                            }
+                        },
                     },
                     CreateInvalidLyricAlertTextContainer().With(t =>
                     {
@@ -61,6 +93,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         protected abstract void Apply(Lyric[] lyrics);
 
         protected abstract InvalidLyricAlertTextContainer CreateInvalidLyricAlertTextContainer();
+
+        protected virtual void OpenConfigSetting()
+        {
+            // todo : change to abstract class and force to implement.
+        }
 
         private class AutoGenerateButton : SelectLyricButton
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/126054467-024bed73-4af7-447d-97a2-1c1e8af20bb5.png)
Implement part of #759 
This is how it looks like.
And because the switch screen in the editor hasn't been implemented, so there's no way to show the config page.