### PR TITLE
Fix change log style

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
-using Markdig;
-using Markdig.Extensions.AutoIdentifiers;
 using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -183,12 +181,6 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
                 }
             }
         }
-
-        protected override MarkdownPipeline CreateBuilder()
-            => new MarkdownPipelineBuilder().UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
-                                            .UseYamlFrontMatter()
-                                            .UseEmojiAndSmiley()
-                                            .UseAdvancedExtensions().Build();
 
         protected class UserLinkText : MarkdownLinkText
         {

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
         }
 
         /// <summary>
-        /// Override <see cref="MarkdownTextFlowContainer"/> to limit image display size
+        /// Override <see cref="OsuMarkdownTextFlowContainer"/> to limit image display size
         /// </summary>
         /// <returns></returns>
         public override MarkdownTextFlowContainer CreateTextFlow() => new ChangeLogMarkdownTextFlowContainer();
@@ -52,19 +52,19 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
         /// </summary>
         public class ChangeLogMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
         {
-            protected override void AddImage(LinkInline linkInline) => AddDrawable(new ChangeLogMarkdownImage(linkInline.Url));
+            protected override void AddImage(LinkInline linkInline) => AddDrawable(new ChangeLogMarkdownImage(linkInline));
 
             public ChangeLogMarkdownTextFlowContainer()
             {
                 TextAnchor = Anchor.BottomLeft;
             }
 
-            public class ChangeLogMarkdownImage : MarkdownImage
+            public class ChangeLogMarkdownImage : OsuMarkdownImage
             {
                 private readonly LayoutValue widthSizeCache = new LayoutValue(Invalidation.DrawSize);
 
-                public ChangeLogMarkdownImage(string url)
-                    : base(url)
+                public ChangeLogMarkdownImage(LinkInline linkInline)
+                    : base(linkInline)
                 {
                     AutoSizeAxes = Axes.None;
                     RelativeSizeAxes = Axes.X;
@@ -140,7 +140,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
                             if (string.IsNullOrEmpty(issue))
                                 continue;
 
-                            AddDrawable(new MarkdownLinkText($"{text}{issue}", new LinkInline
+                            AddDrawable(new OsuMarkdownLinkText($"{text}#{issue}", new LinkInline
                             {
                                 Url = new Uri(baseUri, $"pull/{issue}").AbsoluteUri
                             }));
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
             }
         }
 
-        protected class UserLinkText : MarkdownLinkText
+        protected class UserLinkText : OsuMarkdownLinkText
         {
             public UserLinkText(string text, LinkInline linkInline)
                 : base(text, linkInline)

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
@@ -6,11 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
-using Markdig.Extensions.Yaml;
-using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Layout;
 using osu.Game.Graphics.Containers.Markdown;
@@ -30,15 +27,6 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
             {
                 Text = httpClient.GetStringAsync(build.ReadmeDownloadUrl).Result;
             }
-        }
-
-        protected override void AddMarkdownComponent(IMarkdownObject markdownObject, FillFlowContainer container, int level)
-        {
-            // hide hidden message in markdown document
-            if (markdownObject is YamlFrontMatterBlock)
-                return;
-
-            base.AddMarkdownComponent(markdownObject, container, level);
         }
 
         public override MarkdownTextFlowContainer CreateTextFlow() => new ChangeLogMarkdownTextFlowContainer();

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
@@ -50,11 +50,6 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
         {
             protected override void AddImage(LinkInline linkInline) => AddDrawable(new ChangeLogMarkdownImage(linkInline));
 
-            public ChangeLogMarkdownTextFlowContainer()
-            {
-                TextAnchor = Anchor.BottomLeft;
-            }
-
             /// <summary>
             /// Override <see cref="OsuMarkdownImage"/> to limit image display size
             /// </summary>
@@ -168,7 +163,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
                     AddText(" by:", t =>
                     {
                         t.Scale = textScale;
-                        t.Padding = new MarginPadding { Bottom = 2 };
+                        t.Padding = new MarginPadding { Top = 6 };
                     });
                     AddDrawable(new UserLinkText(user, new LinkInline
                     {
@@ -176,17 +171,18 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
                     })
                     {
                         Scale = textScale,
+                        Anchor = Anchor.BottomLeft,
                     });
                 }
             }
-        }
 
-        private class UserLinkText : OsuMarkdownLinkText
-        {
-            public UserLinkText(string text, LinkInline linkInline)
-                : base(text, linkInline)
+            private class UserLinkText : OsuMarkdownLinkText
             {
-                Padding = new MarginPadding { Bottom = 2 };
+                public UserLinkText(string text, LinkInline linkInline)
+                    : base(text, linkInline)
+                {
+                    Padding = new MarginPadding { Top = 6 };
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/UI/Components/SaitenStatus.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Components/SaitenStatus.cs
@@ -10,6 +10,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.Containers.Markdown;
+using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
@@ -23,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Components
         private readonly SpriteIcon icon;
         private readonly MarkdownTextFlowContainer messageText;
 
-        public SpriteText CreateSpriteText() => new SpriteText();
+        public SpriteText CreateSpriteText() => new OsuSpriteText();
 
         public SaitenStatus(SaitenStatusMode statusMode)
         {
@@ -38,7 +40,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.Components
                 {
                     Size = new Vector2(size),
                 },
-                messageText = new MarkdownTextFlowContainer
+                messageText = new OsuMarkdownTextFlowContainer
                 {
                     RelativeSizeAxes = Axes.None,
                     AutoSizeAxes = Axes.Both


### PR DESCRIPTION
After:
![image](https://user-images.githubusercontent.com/9100368/129440305-ed7f71ff-a7ac-4663-bb8b-bfe78dedc94f.png)

What's fixed in this PR:
- Fix the second line will at the top of the first line.
- Remove some duplicated config.
- Most components should inherit osu's one.