### PR TITLE
Make otf glyph store can work in gameplay.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Stores/BaseGlyphStoreTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Stores/BaseGlyphStoreTest.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Game.Rulesets.Karaoke.Tests.Resources;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Stores
+{
+    /// <summary>
+    /// Use <see cref="GlyphStore"/> as test case actual result for comparing.
+    /// </summary>
+    /// <typeparam name="TGlyphStore"></typeparam>
+    public abstract class BaseGlyphStoreTest<TGlyphStore> where TGlyphStore : IGlyphStore
+    {
+        protected TGlyphStore CustomizeGlyphStore { get; private set; }
+
+        protected GlyphStore GlyphStore { get; private set; }
+
+        [OneTimeSetUp]
+        protected void OneTimeSetUp()
+        {
+            // create and load glyph store.
+            var fontResourceStore = new NamespacedResourceStore<byte[]>(TestResources.GetStore(), $"Resources.Testing.Fonts.Fnt.OpenSans");
+            GlyphStore = new GlyphStore(fontResourceStore, FontName);
+            GlyphStore.LoadFontAsync().Wait();
+
+            // create load load customize glyph store.
+            var customizeFontResourceStore = new NamespacedResourceStore<byte[]>(TestResources.GetStore(), $"Resources.Testing.Fonts.{FontType}");
+            CustomizeGlyphStore = CreateFontStore(customizeFontResourceStore, FontName);
+            CustomizeGlyphStore.LoadFontAsync().Wait();
+        }
+
+        protected abstract string FontType { get; }
+
+        protected abstract string FontName { get; }
+
+        protected abstract TGlyphStore CreateFontStore(ResourceStore<byte[]> store, string assetName);
+
+        [Test]
+        public void CompareFontNameWithOrigin()
+        {
+            var fontName = CustomizeGlyphStore.FontName;
+            var actual = GlyphStore.FontName;
+
+            Assert.AreEqual(fontName, actual);
+        }
+
+        [TestCase('a')]
+        [TestCase(' ')]
+        [TestCase('ㄅ')] // should not have those texts in store.
+        [TestCase('あ')] // should not have those texts in store.
+        public void CompareHasGlyphWithOrigin(char c)
+        {
+            var hasGlyph = CustomizeGlyphStore.HasGlyph(c);
+            var actual = GlyphStore.HasGlyph(c);
+
+            Assert.AreEqual(hasGlyph, actual);
+        }
+
+        [Test]
+        public void CompareGetBaseHeightWithOrigin()
+        {
+            var baseHeight = CustomizeGlyphStore.GetBaseHeight();
+            var actual = GlyphStore.GetBaseHeight();
+
+            Assert.AreEqual(baseHeight, actual);
+        }
+
+        [TestCase('a')]
+        [TestCase('A')]
+        [TestCase('1')]
+        [TestCase(' ')]
+        [TestCase('@')]
+        [TestCase('#')]
+        public void CompareGetCharacterGlyphWithOrigin(char c)
+        {
+            var characterGlyph = CustomizeGlyphStore.Get(c);
+            var actual = GlyphStore.Get(c);
+
+            // because get character glyph should make sure that this glyph store contains char, so will not be null.
+            Assert.IsNotNull(characterGlyph);
+            Assert.IsNotNull(actual);
+
+            // test all property should be matched.
+            Assert.AreEqual(characterGlyph.Character, actual.Character);
+            Assert.AreEqual(characterGlyph.XOffset, actual.XOffset);
+            Assert.AreEqual(characterGlyph.YOffset, actual.YOffset);
+            Assert.AreEqual(characterGlyph.XAdvance, actual.XAdvance);
+        }
+
+        [TestCase('a', 'a')]
+        [TestCase('a', 'b')]
+        [TestCase('i', 'v')] // todo: should got a result that is not zero.
+        [TestCase('t', 'i')]
+        [TestCase('a', 'あ')]
+        public void CompareGetKerningWithOrigin(char left, char right)
+        {
+            var kerning = CustomizeGlyphStore.GetKerning(left, right);
+            var actual = GlyphStore.GetKerning(left, right);
+
+            Assert.AreEqual(kerning, actual);
+        }
+
+        [TestCase('a')]
+        [TestCase('A')]
+        [TestCase('1')]
+        [TestCase(' ')]
+        [TestCase('@')]
+        [TestCase('#')]
+        public void CompareGetTextureUploadWithOrigin(char c)
+        {
+            var characterGlyph = (CustomizeGlyphStore as IResourceStore<TextureUpload>)?.Get(new string(new[] { c }));
+            var actual = GlyphStore.Get(new string(new[] { c }));
+
+            // todo : should test with pixel perfect, but it's ok to pass if size is almost the same.
+            Assert.AreEqual(characterGlyph.Width, actual.Width);
+            Assert.AreEqual(characterGlyph.Height, actual.Height);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Stores/TtfGlyphStoreTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Stores/TtfGlyphStoreTest.cs
@@ -4,69 +4,17 @@
 using NUnit.Framework;
 using osu.Framework.IO.Stores;
 using osu.Game.Rulesets.Karaoke.IO.Stores;
-using osu.Game.Rulesets.Karaoke.Tests.Resources;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.IO.Stores
 {
-    public class TtfGlyphStoreTest
+    [Ignore("This shit is not implemented.")]
+    public class TtfGlyphStoreTest : BaseGlyphStoreTest<TtfGlyphStore>
     {
-        private TtfGlyphStore glyphStore;
+        protected override string FontType => "Ttf";
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            var fontResourceStore = new NamespacedResourceStore<byte[]>(TestResources.GetStore(), "Resources.Testing.Fonts.Ttf");
-            glyphStore = new TtfGlyphStore(fontResourceStore, "OpenSans-Regular");
-            glyphStore.LoadFontAsync().Wait();
-        }
+        protected override string FontName => "OpenSans-Regular";
 
-        [TestCase('a', true)]
-        [TestCase(' ', true)]
-        [TestCase('ㄅ', false)]
-        [TestCase('あ', false)]
-        public void TestHasGlyph(char c, bool include)
-        {
-            Assert.AreEqual(glyphStore.HasGlyph(c), include);
-        }
-
-        [Test]
-        public void TestGetBaseHeight()
-        {
-            // todo : not really sure why is 2780 in here.
-            Assert.AreEqual(glyphStore.GetBaseHeight(), 2789);
-        }
-
-        [TestCase('a', true)]
-        [TestCase('ㄅ', false)]
-        [TestCase('あ', false)]
-        public void TestGetCharacterGlyph(char c, bool include)
-        {
-            var characterGlyph = glyphStore.Get(c);
-
-            if (characterGlyph == null)
-            {
-                Assert.IsFalse(include);
-                return;
-            }
-
-            Assert.AreEqual(characterGlyph.Character, c);
-        }
-
-        [TestCase('a', 'a', 0)]
-        [TestCase('a', 'b', 0)]
-        [TestCase('a', 'あ', 0)]
-        public void TestGetKerning(char left, char right, int kerning)
-        {
-            Assert.AreEqual(glyphStore.GetKerning(left, right), kerning);
-        }
-
-        [TestCase('a', true)]
-        [TestCase('ㄅ', false)]
-        [TestCase('あ', false)]
-        public void TestGetTextureUpload(char c, bool include)
-        {
-            var textureUpload = glyphStore.Get(new string(new[] { c }));
-            Assert.AreEqual(textureUpload != null, include);
-        }
+        protected override TtfGlyphStore CreateFontStore(ResourceStore<byte[]> store, string assetName)
+            => new TtfGlyphStore(store, assetName);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/IO/Stores/KaraokeLocalFontStore.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Stores/KaraokeLocalFontStore.cs
@@ -38,9 +38,8 @@ namespace osu.Game.Rulesets.Karaoke.IO.Stores
             if (glyphStore == null)
                 return;
 
-            // it's the temp way, will be removed eventually.
-            AddStore(glyphStore as FntGlyphStore);
-            fontInfos.Add(fontInfo, glyphStore);
+            AddStore(glyphStore);
+            fontInfos.Add(fontInfo, glyphStore as IGlyphStore);
         }
 
         public void RemoveFont(FontInfo fontInfo)

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
-using osu.Game.IO.Archives;
 using osu.Game.Rulesets.Karaoke.IO.Archives;
 using osu.Game.Rulesets.Karaoke.IO.Stores;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -112,7 +111,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
             if (fntGlyphStore != null)
                 return fntGlyphStore;
 
-            // todo : might be able to check the font type.
+            // todo : might be able to check the font type, or where did the font from.
             return getTtfGlyphStore(storage, fontName);
         }
 
@@ -136,7 +135,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
             if (!storage.Exists(pathWithExtension))
                 return null;
 
-            var resources = new LegacyFileArchiveReader(pathWithExtension);
+            var resources = new StorageBackedResourceStore(storage.GetStorageForDirectory(getPathByFontType(FontType.Ttf)));
             return new TtfGlyphStore(new ResourceStore<byte[]>(resources), $"{fontName}");
         }
 

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Game.IO.Archives;
@@ -95,7 +96,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
             }
         }
 
-        public IGlyphStore GetGlyphStore(FontInfo fontInfo)
+        public IResourceStore<TextureUpload> GetGlyphStore(FontInfo fontInfo)
         {
             // do not import if this font is system font.
             if (!fontInfo.UserImport)

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2021.807.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.2.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2021.809.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.814.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />
     <PackageReference Include="NicoKaraParser" Version="1.1.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="osu.Framework.KaraokeFont" Version="2021.807.0" />
+    <PackageReference Include="osu.Framework.KaraokeFont" Version="2021.814.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="1.2.0" />
     <PackageReference Include="ppy.osu.Game" Version="2021.814.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />


### PR DESCRIPTION
What's changed in this pr:
- update package to let `FontStore` support customized glyph store.
- update `TtfGlyphStore`'s code.
- Fix `font manager` cannot load font correctly.
- add base test case for testing customize font to make sure that value should be same as origin glyph store.

Mark that will have improvement tracking in #804, and prepare for #802
