### PR TITLE
Add font type property

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/FontUsageUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/FontUsageUtilsTest.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Skinning.Fonts;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestToFontInfo(string family, string weight, bool italics, string fontName)
         {
             var fontUsage = new FontUsage(fontName);
-            var fontInfo = FontUsageUtils.ToFontInfo(fontUsage);
+            var fontInfo = FontUsageUtils.ToFontInfo(fontUsage, FontFormat.Internal);
             Assert.AreEqual(fontInfo.FontName, fontName);
             Assert.AreEqual(fontInfo.Family, family);
 

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
@@ -219,9 +219,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             var fontUsage = generateFontUsage();
 
             // add font to local font store for preview purpose.
-            var fontInfo = FontUsageUtils.ToFontInfo(fontUsage);
             localFontStore.ClearFont();
-            localFontStore.AddFont(fontInfo);
+            localFontStore.AddFont(fontUsage);
 
             previewText.Font = fontUsage;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Gameplay/LyricPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Gameplay/LyricPreview.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Karaoke.Skinning.Fonts;
 using osu.Game.Rulesets.Karaoke.Timing;
-using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
@@ -63,10 +62,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
             });
 
             void addFont(FontUsage fontUsage)
-            {
-                var fontInfo = FontUsageUtils.ToFontInfo(fontUsage);
-                localFontStore.AddFont(fontInfo);
-            }
+                => localFontStore.AddFont(fontUsage);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontInfo.cs
@@ -13,12 +13,12 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
 
         public string Weight { get; }
 
-        public bool UserImport { get; }
+        public FontFormat FontFormat { get; }
 
-        public FontInfo(string fontName, bool userImport = false)
+        public FontInfo(string fontName, FontFormat fontFormat)
         {
             FontName = fontName;
-            UserImport = userImport;
+            FontFormat = fontFormat;
 
             var parts = fontName.Split('-');
 
@@ -35,5 +35,14 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
                     break;
             }
         }
+    }
+
+    public enum FontFormat
+    {
+        Internal,
+
+        Fnt,
+
+        Ttf,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
@@ -90,6 +91,15 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
                     return new FontInfo(fontName, fontFormat);
                 }));
             }
+        }
+
+        public FontFormat? CheckFontFormat(FontUsage fontUsage)
+        {
+            var fontName = fontUsage.FontName;
+            if (Fonts.All(x => x.FontName != fontName))
+                return null;
+
+            return Fonts.FirstOrDefault(x => x.FontName == fontName).FontFormat;
         }
 
         public IResourceStore<TextureUpload> GetGlyphStore(FontInfo fontInfo)

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
@@ -12,7 +12,6 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Game.Rulesets.Karaoke.IO.Archives;
 using osu.Game.Rulesets.Karaoke.IO.Stores;
-using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
 {
@@ -30,58 +29,56 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
             Fonts.AddRange(new[]
             {
                 // From osu-framework
-                new FontInfo("OpenSans-Regular"),
-                new FontInfo("OpenSans-Bold"),
-                new FontInfo("OpenSans-RegularItalic"),
-                new FontInfo("OpenSans-BoldItalic"),
+                new FontInfo("OpenSans-Regular", FontFormat.Internal),
+                new FontInfo("OpenSans-Bold", FontFormat.Internal),
+                new FontInfo("OpenSans-RegularItalic", FontFormat.Internal),
+                new FontInfo("OpenSans-BoldItalic", FontFormat.Internal),
 
-                new FontInfo("Roboto-Regular"),
-                new FontInfo("Roboto-Bold"),
-                new FontInfo("RobotoCondensed-Regular"),
-                new FontInfo("RobotoCondensed-Bold"),
+                new FontInfo("Roboto-Regular", FontFormat.Internal),
+                new FontInfo("Roboto-Bold", FontFormat.Internal),
+                new FontInfo("RobotoCondensed-Regular", FontFormat.Internal),
+                new FontInfo("RobotoCondensed-Bold", FontFormat.Internal),
                 // From osu.game
-                new FontInfo("osuFont"),
+                new FontInfo("osuFont", FontFormat.Internal),
 
-                new FontInfo("Torus-Regular"),
-                new FontInfo("Torus-Light"),
-                new FontInfo("Torus-SemiBold"),
-                new FontInfo("Torus-Bold"),
+                new FontInfo("Torus-Regular", FontFormat.Internal),
+                new FontInfo("Torus-Light", FontFormat.Internal),
+                new FontInfo("Torus-SemiBold", FontFormat.Internal),
+                new FontInfo("Torus-Bold", FontFormat.Internal),
 
-                new FontInfo("Inter-Regular"),
-                new FontInfo("Inter-RegularItalic"),
-                new FontInfo("Inter-Light"),
-                new FontInfo("Inter-LightItalic"),
-                new FontInfo("Inter-SemiBold"),
-                new FontInfo("Inter-SemiBoldItalic"),
-                new FontInfo("Inter-Bold"),
-                new FontInfo("Inter-BoldItalic"),
+                new FontInfo("Inter-Regular", FontFormat.Internal),
+                new FontInfo("Inter-RegularItalic", FontFormat.Internal),
+                new FontInfo("Inter-Light", FontFormat.Internal),
+                new FontInfo("Inter-LightItalic", FontFormat.Internal),
+                new FontInfo("Inter-SemiBold", FontFormat.Internal),
+                new FontInfo("Inter-SemiBoldItalic", FontFormat.Internal),
+                new FontInfo("Inter-Bold", FontFormat.Internal),
+                new FontInfo("Inter-BoldItalic", FontFormat.Internal),
 
-                new FontInfo("Noto-Basic"),
-                new FontInfo("Noto-Hangul"),
-                new FontInfo("Noto-CJK-Basic"),
-                new FontInfo("Noto-CJK-Compatibility"),
-                new FontInfo("Noto-Thai"),
+                new FontInfo("Noto-Basic", FontFormat.Internal),
+                new FontInfo("Noto-Hangul", FontFormat.Internal),
+                new FontInfo("Noto-CJK-Basic", FontFormat.Internal),
+                new FontInfo("Noto-CJK-Compatibility", FontFormat.Internal),
+                new FontInfo("Noto-Thai", FontFormat.Internal),
 
-                new FontInfo("Venera-Light"),
-                new FontInfo("Venera-Bold"),
-                new FontInfo("Venera-Black"),
+                new FontInfo("Venera-Light", FontFormat.Internal),
+                new FontInfo("Venera-Bold", FontFormat.Internal),
+                new FontInfo("Venera-Black", FontFormat.Internal),
 
-                new FontInfo("Compatibility"),
+                new FontInfo("Compatibility", FontFormat.Internal),
             });
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            foreach (var fontType in EnumUtils.GetValues<FontType>())
-            {
-                var path = getPathByFontType(fontType);
-                var extension = getExtensionByFontType(fontType);
-                loadFontList(path, extension);
-            }
+            var supportedFormat = new[] { FontFormat.Fnt, FontFormat.Ttf };
 
-            void loadFontList(string path, string extension)
+            foreach (var fontFormat in supportedFormat)
             {
+                // check if dictionary is exist.
+                var path = getPathByFontType(fontFormat);
+                var extension = getExtensionByFontType(fontFormat);
                 var storage = host.Storage;
                 if (!storage.ExistsDirectory(path))
                     return;
@@ -90,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
                 Fonts.AddRange(fontFiles.Select(x =>
                 {
                     var fontName = Path.GetFileNameWithoutExtension(x);
-                    return new FontInfo(fontName, true);
+                    return new FontInfo(fontName, fontFormat);
                 }));
             }
         }
@@ -98,7 +95,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
         public IResourceStore<TextureUpload> GetGlyphStore(FontInfo fontInfo)
         {
             // do not import if this font is system font.
-            if (!fontInfo.UserImport)
+            var fontFormat = fontInfo.FontFormat;
+            if (fontFormat == FontFormat.Internal)
                 return null;
 
             var storage = host.Storage;
@@ -106,19 +104,18 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
                 return null;
 
             var fontName = fontInfo.FontName;
-
-            var fntGlyphStore = getFntGlyphStore(storage, fontName);
-            if (fntGlyphStore != null)
-                return fntGlyphStore;
-
-            // todo : might be able to check the font type, or where did the font from.
-            return getTtfGlyphStore(storage, fontName);
+            return fontInfo.FontFormat switch
+            {
+                FontFormat.Fnt => getFntGlyphStore(storage, fontName),
+                FontFormat.Ttf => getTtfGlyphStore(storage, fontName),
+                _ => throw new ArgumentOutOfRangeException(nameof(fontFormat))
+            };
         }
 
         private FntGlyphStore getFntGlyphStore(Storage storage, string fontName)
         {
-            var path = Path.Combine(getPathByFontType(FontType.Fnt), fontName);
-            var pathWithExtension = Path.ChangeExtension(path, getExtensionByFontType(FontType.Fnt));
+            var path = Path.Combine(getPathByFontType(FontFormat.Fnt), fontName);
+            var pathWithExtension = Path.ChangeExtension(path, getExtensionByFontType(FontFormat.Fnt));
 
             if (!storage.Exists(pathWithExtension))
                 return null;
@@ -129,37 +126,30 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
 
         private TtfGlyphStore getTtfGlyphStore(Storage storage, string fontName)
         {
-            var path = Path.Combine(getPathByFontType(FontType.Ttf), fontName);
-            var pathWithExtension = Path.ChangeExtension(path, getExtensionByFontType(FontType.Ttf));
+            var path = Path.Combine(getPathByFontType(FontFormat.Ttf), fontName);
+            var pathWithExtension = Path.ChangeExtension(path, getExtensionByFontType(FontFormat.Ttf));
 
             if (!storage.Exists(pathWithExtension))
                 return null;
 
-            var resources = new StorageBackedResourceStore(storage.GetStorageForDirectory(getPathByFontType(FontType.Ttf)));
+            var resources = new StorageBackedResourceStore(storage.GetStorageForDirectory(getPathByFontType(FontFormat.Ttf)));
             return new TtfGlyphStore(new ResourceStore<byte[]>(resources), $"{fontName}");
         }
 
-        private static string getPathByFontType(FontType type) =>
+        private static string getPathByFontType(FontFormat type) =>
             type switch
             {
-                FontType.Fnt => $"{font_base_path}/fnt",
-                FontType.Ttf => $"{font_base_path}/ttf",
+                FontFormat.Fnt => $"{font_base_path}/fnt",
+                FontFormat.Ttf => $"{font_base_path}/ttf",
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
 
-        private static string getExtensionByFontType(FontType type) =>
+        private static string getExtensionByFontType(FontFormat type) =>
             type switch
             {
-                FontType.Fnt => "zipfnt",
-                FontType.Ttf => "ttf",
+                FontFormat.Fnt => "zipfnt",
+                FontFormat.Ttf => "ttf",
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
-    }
-
-    public enum FontType
-    {
-        Fnt,
-
-        Ttf,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokePlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokePlayfieldAdjustmentContainer.cs
@@ -8,7 +8,6 @@ using osu.Framework.IO.Stores;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.IO.Stores;
 using osu.Game.Rulesets.Karaoke.Skinning.Fonts;
-using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Karaoke.UI
@@ -38,7 +37,6 @@ namespace osu.Game.Rulesets.Karaoke.UI
             };
 
             var fontInfos = targetImportFonts
-                            .Select(x => FontUsageUtils.ToFontInfo(x))
                             .Distinct()
                             .ToArray();
 

--- a/osu.Game.Rulesets.Karaoke/Utils/FontUsageUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/FontUsageUtils.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 {
     public static class FontUsageUtils
     {
-        public static FontInfo ToFontInfo(FontUsage fontUsage, bool userImport = true)
-            => new FontInfo(fontUsage.FontName, userImport);
+        public static FontInfo ToFontInfo(FontUsage fontUsage, FontFormat fontFormat)
+            => new FontInfo(fontUsage.FontName, fontFormat);
     }
 }


### PR DESCRIPTION
It's a prepare for showing font format in font selection listed in #804

What's implemented in this PR:
- `FontInfo` should have format property.
- if wants to get `glyph store` from `font manager`, will see `font format` instead of search all folder.
- `KaraokeLocalFontStore` now can accept add font by font usage, which will cost less effect on changing format after.