### PR TITLE
Refactor rearrangeable text list container

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SubInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SubInfo.cs
@@ -35,10 +35,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
                 {
                     Margin = new MarginPadding
                     {
-                        Left = 5,
-                        Right = 5,
-                        Top = 2,
-                        Bottom = 2
+                        Vertical = 2,
+                        Horizontal = 5
                     },
                     Text = "Badge"
                 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
         protected override string Title => "Select font";
 
         private readonly SpriteText previewText;
-        private readonly TextPropertyList<string> familyProperty;
-        private readonly TextPropertyList<string> weightProperty;
-        private readonly TextPropertyList<float> fontSizeProperty;
+        private readonly FontPropertyList<string> familyProperty;
+        private readonly FontPropertyList<string> weightProperty;
+        private readonly FontPropertyList<float> fontSizeProperty;
         private readonly OsuCheckbox fixedWidthCheckbox;
 
         private readonly BindableWithCurrent<FontUsage> current = new BindableWithCurrent<FontUsage>();
@@ -104,12 +104,12 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                                 {
                                     new Drawable[]
                                     {
-                                        familyProperty = new TextPropertyList<string>
+                                        familyProperty = new FontPropertyList<string>
                                         {
                                             Name = "Font family selection area",
                                             RelativeSizeAxes = Axes.Both
                                         },
-                                        weightProperty = new TextPropertyList<string>
+                                        weightProperty = new FontPropertyList<string>
                                         {
                                             Name = "Font widget selection area",
                                             RelativeSizeAxes = Axes.Both
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                                             {
                                                 new Drawable[]
                                                 {
-                                                    fontSizeProperty = new TextPropertyList<float>
+                                                    fontSizeProperty = new FontPropertyList<float>
                                                     {
                                                         Name = "Font size selection area",
                                                         RelativeSizeAxes = Axes.Both,
@@ -241,11 +241,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             fontStore?.RemoveStore(localFontStore);
         }
 
-        internal class TextPropertyList<T> : CompositeDrawable
+        internal class FontPropertyList<T> : CompositeDrawable
         {
             private readonly CornerBackground background;
             private readonly TextPropertySearchTextBox filter;
-            private readonly RearrangeableTextListContainer<T> propertyList;
+            private readonly RearrangeableTextFlowListContainer<T> propertyFlowList;
 
             private readonly BindableWithCurrent<T> current = new BindableWithCurrent<T>();
 
@@ -255,9 +255,9 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 set => current.Current = value;
             }
 
-            public BindableList<T> Items => propertyList.Items;
+            public BindableList<T> Items => propertyFlowList.Items;
 
-            public TextPropertyList()
+            public FontPropertyList()
             {
                 InternalChild = new Container
                 {
@@ -302,8 +302,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                     }
                 };
 
-                filter.Current.BindValueChanged(e => propertyList.Filter(e.NewValue));
-                Current.BindValueChanged(e => propertyList.SelectedSet.Value = e.NewValue);
+                filter.Current.BindValueChanged(e => propertyFlowList.Filter(e.NewValue));
+                Current.BindValueChanged(e => propertyFlowList.SelectedSet.Value = e.NewValue);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
@@ -288,7 +288,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                                 },
                                 new Drawable[]
                                 {
-                                    propertyList = new RearrangeableTextListContainer<T>
+                                    propertyFlowList = new RearrangeableTextFlowListContainer<T>
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         RequestSelection = item =>

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.IO.Stores;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Bindables;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
@@ -27,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
         protected override string Title => "Select font";
 
         private readonly SpriteText previewText;
-        private readonly FontPropertyList<string> familyProperty;
+        private readonly FontFamilyPropertyList familyProperty;
         private readonly FontPropertyList<string> weightProperty;
         private readonly FontPropertyList<float> fontSizeProperty;
         private readonly OsuCheckbox fixedWidthCheckbox;
@@ -104,7 +108,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                                 {
                                     new Drawable[]
                                     {
-                                        familyProperty = new FontPropertyList<string>
+                                        familyProperty = new FontFamilyPropertyList
                                         {
                                             Name = "Font family selection area",
                                             RelativeSizeAxes = Axes.Both
@@ -241,6 +245,96 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             fontStore?.RemoveStore(localFontStore);
         }
 
+        internal class FontFamilyPropertyList : FontPropertyList<string>
+        {
+            protected override RearrangeableTextFlowListContainer<string> CreateRearrangeableListContainer()
+                => new RearrangeableFontFamilyListContainer();
+
+            private class RearrangeableFontFamilyListContainer : RearrangeableTextFlowListContainer<string>
+            {
+                protected override DrawableTextListItem CreateDrawable(string item)
+                    => new DrawableFontFamilyListItem(item);
+
+                private class DrawableFontFamilyListItem : DrawableTextListItem
+                {
+                    [Resolved]
+                    private FontManager fontManager { get; set; }
+
+                    public DrawableFontFamilyListItem(string item)
+                        : base(item)
+                    {
+                    }
+
+                    protected override void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, string model)
+                    {
+                        textFlowContainer.TextAnchor = Anchor.BottomLeft;
+                        Schedule(() =>
+                        {
+                            textFlowContainer.AddText(model);
+
+                            var matchedFormat = fontManager.Fonts
+                                                           .Where(x => x.Family == Model).Select(x => x.FontFormat)
+                                                           .Distinct()
+                                                           .ToArray();
+
+                            foreach (var format in matchedFormat)
+                            {
+                                textFlowContainer.AddText(" ");
+                                textFlowContainer.AddArbitraryDrawable(new FontFormatBadge(format));
+                            }
+                        });
+                    }
+                }
+            }
+
+            private class FontFormatBadge : Container
+            {
+                private readonly FontFormat fontFormat;
+                private readonly Box box;
+                private readonly OsuSpriteText badgeText;
+
+                public FontFormatBadge(FontFormat fontFormat)
+                {
+                    this.fontFormat = fontFormat;
+
+                    AutoSizeAxes = Axes.Both;
+                    Masking = true;
+                    CornerRadius = 3;
+                    Children = new Drawable[]
+                    {
+                        box = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        badgeText = new OsuSpriteText
+                        {
+                            Font = OsuFont.Default.With(size: 10),
+                            Margin = new MarginPadding
+                            {
+                                Vertical = 1,
+                                Horizontal = 3
+                            },
+                        }
+                    };
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OsuColour colour)
+                {
+                    box.Colour = fontFormat switch
+                    {
+                        FontFormat.Internal => colour.Gray7,
+                        FontFormat.Fnt => colour.Pink,
+                        FontFormat.Ttf => colour.Blue,
+                        _ => throw new IndexOutOfRangeException(nameof(fontFormat))
+                    };
+
+                    // todo : might apply translate.
+                    badgeText.Text = fontFormat.ToString();
+                }
+            }
+        }
+
         internal class FontPropertyList<T> : CompositeDrawable
         {
             private readonly CornerBackground background;
@@ -288,14 +382,14 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                                 },
                                 new Drawable[]
                                 {
-                                    propertyFlowList = new RearrangeableTextFlowListContainer<T>
+                                    propertyFlowList = CreateRearrangeableListContainer().With(x =>
                                     {
-                                        RelativeSizeAxes = Axes.Both,
-                                        RequestSelection = item =>
+                                        x.RelativeSizeAxes = Axes.Both;
+                                        x.RequestSelection = item =>
                                         {
                                             Current.Value = item;
-                                        },
-                                    }
+                                        };
+                                    })
                                 }
                             }
                         }
@@ -305,6 +399,9 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 filter.Current.BindValueChanged(e => propertyFlowList.Filter(e.NewValue));
                 Current.BindValueChanged(e => propertyFlowList.SelectedSet.Value = e.NewValue);
             }
+
+            protected virtual RearrangeableTextFlowListContainer<T> CreateRearrangeableListContainer()
+                => new RearrangeableTextFlowListContainer<T>();
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
         protected override string Title => "Select language";
 
         private readonly LanguageSelectionSearchTextBox filter;
-        private readonly DrawableLanguageList languageList;
+        private readonly DrawableLanguageFlowList languageList;
 
         private readonly BindableWithCurrent<CultureInfo> current = new BindableWithCurrent<CultureInfo>();
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                     },
                     new Drawable[]
                     {
-                        languageList = new DrawableLanguageList
+                        languageList = new DrawableLanguageFlowList
                         {
                             RelativeSizeAxes = Axes.Both,
                             RequestSelection = item =>
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             }
         }
 
-        private class DrawableLanguageList : RearrangeableTextListContainer<CultureInfo>
+        private class DrawableLanguageFlowList : RearrangeableTextFlowListContainer<CultureInfo>
         {
             protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
                 => new DrawableLanguageListItem(item)
@@ -108,7 +108,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                     Model.NativeName
                 };
 
-                protected override string GetDisplayText(CultureInfo model) => model.DisplayName;
+                protected override void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, CultureInfo model)
+                    => textFlowContainer.AddText(model.DisplayName);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
         protected override string Title => "Select language";
 
         private readonly LanguageSelectionSearchTextBox filter;
-        private readonly DrawableLanguageFlowList languageList;
+        private readonly RearrangeableLanguageListContainer languageList;
 
         private readonly BindableWithCurrent<CultureInfo> current = new BindableWithCurrent<CultureInfo>();
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                     },
                     new Drawable[]
                     {
-                        languageList = new DrawableLanguageFlowList
+                        languageList = new RearrangeableLanguageListContainer
                         {
                             RelativeSizeAxes = Axes.Both,
                             RequestSelection = item =>
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             }
         }
 
-        private class DrawableLanguageFlowList : RearrangeableTextFlowListContainer<CultureInfo>
+        private class RearrangeableLanguageListContainer : RearrangeableTextFlowListContainer<CultureInfo>
         {
             protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
                 => new DrawableLanguageListItem(item)

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/LanguageSelectionDialog.cs
@@ -85,12 +85,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
 
         private class RearrangeableLanguageListContainer : RearrangeableTextFlowListContainer<CultureInfo>
         {
-            protected override OsuRearrangeableListItem<CultureInfo> CreateOsuDrawable(CultureInfo item)
-                => new DrawableLanguageListItem(item)
-                {
-                    SelectedSet = { BindTarget = SelectedSet },
-                    RequestSelection = set => RequestSelection?.Invoke(set)
-                };
+            protected override DrawableTextListItem CreateDrawable(CultureInfo item)
+                => new DrawableLanguageListItem(item);
 
             private class DrawableLanguageListItem : DrawableTextListItem
             {

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
@@ -18,16 +18,16 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
     /// <summary>
     /// Implement most feature for searchable text container.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class RearrangeableTextFlowListContainer<T> : OsuRearrangeableListContainer<T>
+    /// <typeparam name="TModel"></typeparam>
+    public class RearrangeableTextFlowListContainer<TModel> : OsuRearrangeableListContainer<TModel>
     {
-        public readonly Bindable<T> SelectedSet = new Bindable<T>();
+        public readonly Bindable<TModel> SelectedSet = new Bindable<TModel>();
 
-        public Action<T> RequestSelection;
+        public Action<TModel> RequestSelection;
 
-        private SearchContainer<RearrangeableListItem<T>> searchContainer;
+        private SearchContainer<RearrangeableListItem<TModel>> searchContainer;
 
-        protected override FillFlowContainer<RearrangeableListItem<T>> CreateListFillFlowContainer() => searchContainer = new SearchContainer<RearrangeableListItem<T>>
+        protected sealed override FillFlowContainer<RearrangeableListItem<TModel>> CreateListFillFlowContainer() => searchContainer = new SearchContainer<RearrangeableListItem<TModel>>
         {
             Spacing = new Vector2(0, 3),
             LayoutDuration = 200,
@@ -39,24 +39,27 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             searchContainer.SearchTerm = text;
         }
 
-        protected override OsuRearrangeableListItem<T> CreateOsuDrawable(T item)
-            => new DrawableTextListItem(item)
+        protected sealed override OsuRearrangeableListItem<TModel> CreateOsuDrawable(TModel item)
+            => CreateDrawable(item).With(d =>
             {
-                SelectedSet = { BindTarget = SelectedSet },
-                RequestSelection = set => RequestSelection?.Invoke(set)
-            };
+                d.SelectedSet.BindTarget = SelectedSet;
+                d.RequestSelection = set => RequestSelection?.Invoke(set);
+            });
 
-        public class DrawableTextListItem : OsuRearrangeableListItem<T>, IFilterable
+        protected new virtual DrawableTextListItem CreateDrawable(TModel item)
+            => new DrawableTextListItem(item);
+
+        public class DrawableTextListItem : OsuRearrangeableListItem<TModel>, IFilterable
         {
-            public readonly Bindable<T> SelectedSet = new Bindable<T>();
+            public readonly Bindable<TModel> SelectedSet = new Bindable<TModel>();
 
-            public Action<T> RequestSelection;
+            public Action<TModel> RequestSelection;
 
             private TextFlowContainer text;
 
             private Color4 selectedColour;
 
-            public DrawableTextListItem(T item)
+            public DrawableTextListItem(TModel item)
                 : base(item)
             {
                 Padding = new MarginPadding { Left = 5 };
@@ -100,7 +103,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 Model.ToString()
             };
 
-            protected virtual void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, T model)
+            protected virtual void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, TModel model)
                 => textFlowContainer.AddText(model.ToString());
 
             private bool matchingFilter = true;

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
     /// Implement most feature for searchable text container.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class RearrangeableTextListContainer<T> : OsuRearrangeableListContainer<T>
+    public class RearrangeableTextFlowListContainer<T> : OsuRearrangeableListContainer<T>
     {
         public readonly Bindable<T> SelectedSet = new Bindable<T>();
 
@@ -83,12 +83,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 }, true);
             }
 
-            protected override Drawable CreateContent() => text = new OsuTextFlowContainer
+            protected sealed override Drawable CreateContent() => text = new OsuTextFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Text = GetDisplayText(Model),
-            };
+            }.With(x => CreateDisplayContent(x, Model));
 
             protected override bool OnClick(ClickEvent e)
             {
@@ -101,7 +100,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 Model.ToString()
             };
 
-            protected virtual string GetDisplayText(T model) => model.ToString();
+            protected virtual void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, T model)
+                => textFlowContainer.AddText(model.ToString());
 
             private bool matchingFilter = true;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/129483576-e560ca70-200a-4ead-8d4c-3129e6c2fd8c.png)
What's done in this PR:
- refactor `RearrangeableTextFlowListContainer`, include rename and change API. the main goal is to let this shit be able to add drawable in content also.
- modified `RearrangeableLanguageListContainer` also.
- show badge after font-family name in font selector. for remain issue #806 and part of improvement in #804