### PR TITLE
Implement create font folder and hot-reload font list.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/FontSelectionDialog.cs
@@ -179,8 +179,30 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             fonts.BindCollectionChanged((a, b) =>
             {
                 // re-calculate if source changed.
-                familyProperty.Items.Clear();
-                familyProperty.Items.AddRange(fonts.Select(x => x.Family).Distinct());
+                Schedule(() =>
+                {
+                    var oldFamilies = b.OldItems?.OfType<FontInfo>().Select(x => x.Family).Distinct().ToArray();
+                    var newFamilies = b.NewItems?.OfType<FontInfo>().Select(x => x.Family).Distinct().ToArray();
+
+                    if (oldFamilies != null)
+                    {
+                        familyProperty.Items.RemoveAll(x => oldFamilies.Contains(x));
+                    }
+
+                    if (newFamilies != null)
+                    {
+                        familyProperty.Items.AddRange(newFamilies);
+                    }
+
+                    // should reset family selection if user select the font that will be removed or added.
+                    var currentFamily = familyProperty.Current.Value;
+                    var resetFamily = oldFamilies?.Contains(currentFamily) ?? false;
+
+                    if (resetFamily)
+                    {
+                        familyProperty.Current.Value = familyProperty.Items.FirstOrDefault();
+                    }
+                });
             });
 
             familyProperty.Current.BindValueChanged(x =>

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Graphics/ManageFontSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Graphics/ManageFontSettings.cs
@@ -4,9 +4,11 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Framework.Platform;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Screens.Config.Previews;
 using osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Graphics;
+using osu.Game.Rulesets.Karaoke.Skinning.Fonts;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Graphics
 {
@@ -17,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Graphics
         public override SettingsSubsectionPreview CreatePreview() => new ManageFontPreview();
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(Storage storage)
         {
             Children = new Drawable[]
             {
@@ -25,11 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Graphics
                 {
                     Text = "Open import text folder",
                     TooltipText = "After open the folder, you can drag the font file to the folder you wants to import",
-                    Action = () =>
-                    {
-                        // todo : open the folder.
-                        // todo : or should change the button to call file selector to import the file?
-                    }
+                    Action = () => storage.GetStorageForDirectory(FontManager.FONT_BASE_PATH).OpenInNativeExplorer(),
                 },
                 new SettingsButton
                 {

--- a/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Fonts/FontManager.cs
@@ -18,10 +18,14 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
 {
     public class FontManager : Component
     {
-        private const string font_base_path = @"fonts";
+        public const string FONT_BASE_PATH = @"fonts";
 
         [Resolved]
         private GameHost host { get; set; }
+
+        private Storage storage => host.Storage.GetStorageForDirectory(FONT_BASE_PATH);
+
+        private readonly FontFormat[] supportedFormat = { FontFormat.Fnt, FontFormat.Ttf };
 
         public readonly BindableList<FontInfo> Fonts = new BindableList<FontInfo>();
 
@@ -73,18 +77,14 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
         [BackgroundDependencyLoader]
         private void load()
         {
-            var supportedFormat = new[] { FontFormat.Fnt, FontFormat.Ttf };
-
             foreach (var fontFormat in supportedFormat)
             {
-                // check if dictionary is exist.
+                // will create folder if not exist.
                 var path = getPathByFontType(fontFormat);
                 var extension = getExtensionByFontType(fontFormat);
-                var storage = host.Storage;
-                if (!storage.ExistsDirectory(path))
-                    return;
 
-                var fontFiles = storage.GetFiles(path, $"*.{extension}").ToList();
+                var fontFiles = storage.GetStorageForDirectory(path)
+                                       .GetFiles("", $"*.{extension}").ToList();
                 Fonts.AddRange(fontFiles.Select(x =>
                 {
                     var fontName = Path.GetFileNameWithoutExtension(x);
@@ -107,10 +107,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
             // do not import if this font is system font.
             var fontFormat = fontInfo.FontFormat;
             if (fontFormat == FontFormat.Internal)
-                return null;
-
-            var storage = host.Storage;
-            if (!storage.ExistsDirectory(font_base_path))
                 return null;
 
             var fontName = fontInfo.FontName;
@@ -149,8 +145,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Fonts
         private static string getPathByFontType(FontFormat type) =>
             type switch
             {
-                FontFormat.Fnt => $"{font_base_path}/fnt",
-                FontFormat.Ttf => $"{font_base_path}/ttf",
+                FontFormat.Fnt => $"fnt",
+                FontFormat.Ttf => $"ttf",
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
 


### PR DESCRIPTION
Improvement of #804

What's done in this PR:
- [x] should have the ability to hot-reload the font list if the dictionary is changed in the font selector.
- [x] should be able to open the dictionary on the config page.
- [x] should create a folder at default. Need to check should do this job in `FontManager` or another place.