### PR TITLE
Able to adjust ruby romaji margin in config page.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -61,7 +61,9 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetSetting.LyricScale, 2, 1, 4, 0.01);
             SetDefault(KaraokeRulesetSetting.MainFont, new FontUsage("Torus", 48, "Bold"), 48f, 48f);
             SetDefault(KaraokeRulesetSetting.RubyFont, new FontUsage("Torus", 20, "Bold"), 8f, 48f);
+            SetDefault(KaraokeRulesetSetting.RubyMargin, 5, 0, 20);
             SetDefault(KaraokeRulesetSetting.RomajiFont, new FontUsage("Torus", 20, "Bold"), 8f, 48f);
+            SetDefault(KaraokeRulesetSetting.RomajiMargin, 0, 0, 20);
             SetDefault(KaraokeRulesetSetting.ForceUseDefaultFont, false);
             SetDefault(KaraokeRulesetSetting.TranslateFont, new FontUsage("Torus", 18, "Bold"), 10f, 48f);
             SetDefault(KaraokeRulesetSetting.ForceUseDefaultTranslateFont, false);
@@ -154,7 +156,9 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         LyricScale,
         MainFont,
         RubyFont,
+        RubyMargin,
         RomajiFont,
+        RomajiMargin,
         ForceUseDefaultFont,
         TranslateFont,
         ForceUseDefaultTranslateFont,

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -40,7 +40,9 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
         private readonly Bindable<FontUsage> mainFontUsageBindable = new();
         private readonly Bindable<FontUsage> rubyFontUsageBindable = new();
+        private readonly Bindable<int> rubyMarginBindable = new();
         private readonly Bindable<FontUsage> romajiFontUsageBindable = new();
+        private readonly Bindable<int> romajiMarginBindable = new();
         private readonly Bindable<FontUsage> translateFontUsageBindable = new();
 
         private readonly IBindable<int[]> singersBindable = new Bindable<int[]>();
@@ -110,13 +112,17 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             {
                 config.BindWith(KaraokeRulesetSetting.MainFont, mainFontUsageBindable);
                 config.BindWith(KaraokeRulesetSetting.RubyFont, rubyFontUsageBindable);
+                config.BindWith(KaraokeRulesetSetting.RubyMargin, rubyMarginBindable);
                 config.BindWith(KaraokeRulesetSetting.RomajiFont, romajiFontUsageBindable);
+                config.BindWith(KaraokeRulesetSetting.RomajiMargin, romajiMarginBindable);
                 config.BindWith(KaraokeRulesetSetting.TranslateFont, translateFontUsageBindable);
             }
 
             mainFontUsageBindable.BindValueChanged(_ => updateFontUsage());
             rubyFontUsageBindable.BindValueChanged(_ => updateFontUsage());
+            rubyMarginBindable.BindValueChanged(_ => updateFontUsage());
             romajiFontUsageBindable.BindValueChanged(_ => updateFontUsage());
+            romajiMarginBindable.BindValueChanged(_ => updateFontUsage());
             translateFontUsageBindable.BindValueChanged(_ => updateFontUsage());
         }
 
@@ -187,9 +193,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
                 var rubyFont = lyricFont?.RubyTextFontInfo?.LyricTextFontInfo;
                 lyricPiece.RubyFont = getFont(KaraokeRulesetSetting.RubyFont, rubyFont);
+                lyricPiece.RubyMargin = rubyMarginBindable.Value;
 
                 var romajiFont = lyricFont?.RomajiTextFontInfo?.LyricTextFontInfo;
                 lyricPiece.RomajiFont = getFont(KaraokeRulesetSetting.RomajiFont, romajiFont);
+                lyricPiece.RomajiMargin = romajiMarginBindable.Value;
             }
 
             // Apply translate font.

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -82,11 +82,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 Origin = Anchor.TopLeft,
             });
 
-            useTranslateBindable.BindValueChanged(_ => applyTranslate());
-            preferLanguageBindable.BindValueChanged(_ => applyTranslate());
-            displayRubyBindable.BindValueChanged(e => lyricPieces.ForEach(x => x.DisplayRuby = e.NewValue));
-            displayRomajiBindable.BindValueChanged(e => lyricPieces.ForEach(x => x.DisplayRomaji = e.NewValue));
-
             if (session != null)
             {
                 // gameplay.
@@ -104,9 +99,10 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 config.BindWith(KaraokeRulesetSetting.DisplayRomaji, displayRomajiBindable);
             }
 
-            singersBindable.BindValueChanged(_ => { updateFontStyle(); });
-            layoutIndexBindable.BindValueChanged(_ => { updateLayout(); });
-            translateTextBindable.BindCollectionChanged((_, _) => { applyTranslate(); });
+            useTranslateBindable.BindValueChanged(_ => applyTranslate(), true);
+            preferLanguageBindable.BindValueChanged(_ => applyTranslate(), true);
+            displayRubyBindable.BindValueChanged(e => lyricPieces.ForEach(x => x.DisplayRuby = e.NewValue));
+            displayRomajiBindable.BindValueChanged(e => lyricPieces.ForEach(x => x.DisplayRomaji = e.NewValue));
 
             if (config != null)
             {
@@ -124,6 +120,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             romajiFontUsageBindable.BindValueChanged(_ => updateFontUsage());
             romajiMarginBindable.BindValueChanged(_ => updateFontUsage());
             translateFontUsageBindable.BindValueChanged(_ => updateFontUsage());
+
+            // property in hitobject.
+            singersBindable.BindValueChanged(_ => { updateFontStyle(); });
+            layoutIndexBindable.BindValueChanged(_ => { updateLayout(); });
+            translateTextBindable.BindCollectionChanged((_, _) => { applyTranslate(); });
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -193,10 +193,12 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 lyricPiece.Font = getFont(KaraokeRulesetSetting.MainFont, mainFont);
 
                 var rubyFont = lyricFont?.RubyTextFontInfo?.LyricTextFontInfo;
+                lyricPiece.DisplayRuby = displayRubyBindable.Value;
                 lyricPiece.RubyFont = getFont(KaraokeRulesetSetting.RubyFont, rubyFont);
                 lyricPiece.RubyMargin = rubyMarginBindable.Value;
 
                 var romajiFont = lyricFont?.RomajiTextFontInfo?.LyricTextFontInfo;
+                lyricPiece.DisplayRomaji = displayRomajiBindable.Value;
                 lyricPiece.RomajiFont = getFont(KaraokeRulesetSetting.RomajiFont, romajiFont);
                 lyricPiece.RomajiMargin = romajiMarginBindable.Value;
             }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Gameplay/LyricPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Previews/Gameplay/LyricPreview.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -24,6 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
         private readonly Bindable<FontUsage> rubyFont = new();
         private readonly Bindable<FontUsage> romajiFont = new();
         private readonly Bindable<FontUsage> translateFont = new();
+        private readonly Bindable<CultureInfo> preferLanguage = new();
 
         [Resolved]
         private FontStore fontStore { get; set; }
@@ -60,6 +62,10 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
             {
                 addFont(e.NewValue);
             });
+            preferLanguage.BindValueChanged(e =>
+            {
+                drawableLyric.HitObject.Translates = createPreviewTranslate(e.NewValue);
+            });
 
             void addFont(FontUsage fontUsage)
                 => localFontStore.AddFont(fontUsage);
@@ -77,6 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
             config.BindWith(KaraokeRulesetSetting.RubyFont, rubyFont);
             config.BindWith(KaraokeRulesetSetting.RomajiFont, romajiFont);
             config.BindWith(KaraokeRulesetSetting.TranslateFont, translateFont);
+            config.BindWith(KaraokeRulesetSetting.PreferLanguage, preferLanguage);
         }
 
         protected override void Dispose(bool isDisposing)
@@ -114,11 +121,22 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Previews.Gameplay
                         Text = "karaoke"
                     },
                 },
-                Translates =
-                {
-                    { new CultureInfo("Ja-JP"), "からおけ" },
-                },
                 HitWindows = new KaraokeHitWindows(),
             };
+
+        private IDictionary<CultureInfo, string> createPreviewTranslate(CultureInfo cultureInfo)
+        {
+            var translate = cultureInfo.Name switch
+            {
+                "ja" or "Ja-jp" => "カラオケ",
+                "zh-Hant" or "zh-TW" => "卡拉OK",
+                _ => "karaoke"
+            };
+
+            return new Dictionary<CultureInfo, string>
+            {
+                { cultureInfo, translate },
+            };
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Graphics/LyricFontSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Graphics/LyricFontSettings.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Graphics
             {
                 new SettingsSlider<double>
                 {
-                    LabelText = "Font scale",
+                    LabelText = "Overall scale",
                     Current = Config.GetBindable<double>(KaraokeRulesetSetting.LyricScale),
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
@@ -40,10 +40,22 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Graphics
                     LabelText = "Default ruby font",
                     Current = Config.GetBindable<FontUsage>(KaraokeRulesetSetting.RubyFont)
                 },
+                new SettingsSlider<int>
+                {
+                    LabelText = "Ruby margin",
+                    Current = Config.GetBindable<int>(KaraokeRulesetSetting.RubyMargin),
+                    KeyboardStep = 1,
+                },
                 new SettingsFont
                 {
                     LabelText = "Default romaji font",
                     Current = Config.GetBindable<FontUsage>(KaraokeRulesetSetting.RomajiFont)
+                },
+                new SettingsSlider<int>
+                {
+                    LabelText = "Romaji margin",
+                    Current = Config.GetBindable<int>(KaraokeRulesetSetting.RomajiMargin),
+                    KeyboardStep = 1,
                 },
                 new SettingsCheckbox
                 {


### PR DESCRIPTION
What's added in this pr:
- Able to adjust ruby romaji margin in the config page.
- Fix translate is disappear in the lyric if the translated language is not Japanese.
- Fix not hide ruby/romaji if user select to hide them.