### PR TITLE
Use `Storage.PresentFileExternally` when opening lyric files after export

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Export/ExportLyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Export/ExportLyricManager.cs
@@ -23,8 +23,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
         public void ExportToLrc()
         {
             var exportStorage = storage.GetStorageForDirectory("lrc");
+            var filename = $"{beatmap.Name}.lrc";
 
-            using (var outputStream = exportStorage.GetStream($"{beatmap.Name}.lrc", FileAccess.Write, FileMode.Create))
+            using (var outputStream = exportStorage.GetStream(filename, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(outputStream))
             {
                 var encoder = new LrcEncoder();
@@ -34,14 +35,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
                 }));
             }
 
-            exportStorage.PresentExternally();
+            exportStorage.PresentFileExternally(filename);
         }
 
         public void ExportToText()
         {
             var exportStorage = storage.GetStorageForDirectory("text");
+            var filename = $"{beatmap.Name}.txt";
 
-            using (var outputStream = exportStorage.GetStream($"{beatmap.Name}.txt", FileAccess.Write, FileMode.Create))
+            using (var outputStream = exportStorage.GetStream(filename, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(outputStream))
             {
                 var encoder = new LyricTextEncoder();
@@ -51,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
                 }));
             }
 
-            exportStorage.PresentExternally();
+            exportStorage.PresentFileExternally(filename);
         }
 
         public void ExportToJson()
@@ -59,8 +61,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
             // note : this is for develop testing purpose.
             // will be removed eventually
             var exportStorage = storage.GetStorageForDirectory("json");
+            var filename = $"{beatmap.Name}.json";
 
-            using (var outputStream = exportStorage.GetStream($"{beatmap.Name}.json", FileAccess.Write, FileMode.Create))
+            using (var outputStream = exportStorage.GetStream(filename, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(outputStream))
             {
                 var encoder = new KaraokeJsonBeatmapEncoder();
@@ -70,7 +73,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
                 }));
             }
 
-            exportStorage.PresentExternally();
+            exportStorage.PresentFileExternally(filename);
         }
     }
 }


### PR DESCRIPTION
Uses the newly-added `PresentFileExternally` to show files in windows explorer.
This has the added benefit of selecting/highlighting the file, making it easier to know which file was just exported.
(The selecting/highlighting part currently only works on Windows.)

I made the upstream change in https://github.com/ppy/osu-framework/pull/4831, so I wanted to get consumers updated to the new feature.
That's why I'm making this PR.