### PR TITLE
Fix importor test case broken.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/KaraokeTestBrowser.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/KaraokeTestBrowser.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.IO.Stores;
+using osu.Game.Tests;
+
+namespace osu.Game.Rulesets.Karaoke.Tests
+{
+    public class KaraokeTestBrowser : OsuTestBrowser
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // add shader resource from font package.
+            Resources.AddStore(new NamespacedResourceStore<byte[]>(new FontResourceStore(), "Resources"));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/VisualTestRunner.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/VisualTestRunner.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework;
 using osu.Framework.Platform;
-using osu.Game.Tests;
 
 namespace osu.Game.Rulesets.Karaoke.Tests
 {
@@ -15,7 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests
         {
             using (DesktopGameHost host = Host.GetSuitableHost(@"karaoke-visual-test-runner", true))
             {
-                host.Run(new OsuTestBrowser());
+                host.Run(new KaraokeTestBrowser());
                 return 0;
             }
         }


### PR DESCRIPTION
Fix issue #878

Because customized shader should regist namespace store, and this font will use in lots of test cases.
So should make this ruleset's own test browser and inject the shader resources.