### PR TITLE
Click the note to open the pop-over in editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
@@ -23,9 +23,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
             Assert.AreEqual(result, new CultureInfo(language));
         }
 
-        private static LanguageDetectorConfig generateConfig()
-        {
-            return new();
-        }
+        private static LanguageDetectorConfig generateConfig() => new();
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Layouts/LayoutGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Layouts/LayoutGeneratorTest.cs
@@ -38,12 +38,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Layouts
             Assert.AreEqual(lyrics.Select(x => $"[{x.StartTime},{x.EndTime}]").ToArray(), actualTimes);
         }
 
-        private static LayoutGeneratorConfig generatorConfig()
-        {
-            return new()
+        private static LayoutGeneratorConfig generatorConfig() =>
+            new()
             {
                 NewLyricLineTime = 15000,
             };
-        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
@@ -43,15 +43,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("karaoke", "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
         [TestCase("", "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
         [TestCase(null, "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
-        public void TestDisplayText(string text, string alternativeText, bool useAlternativeTextIfHave, string actual)
+        public void TestDisplayText(string text, string rubyText, bool useRubyTextIfHave, string actual)
         {
             var note = new Note
             {
                 Text = text,
-                AlternativeText = alternativeText
+                RubyText = rubyText
             };
 
-            var result = NoteUtils.DisplayText(note, useAlternativeTextIfHave);
+            var result = NoteUtils.DisplayText(note, useRubyTextIfHave);
             Assert.AreEqual(result, actual);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
@@ -33,5 +33,26 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
                 Assert.IsNull(actualTime);
             }
         }
+
+        [TestCase("karaoke", "", false, "karaoke")]
+        [TestCase("karaoke", "ka- ra- o- ke-", false, "karaoke")]
+        [TestCase("", "ka- ra- o- ke-", false, "")]
+        [TestCase(null, "ka- ra- o- ke-", false, null)]
+        [TestCase("karaoke", "", true, "karaoke")]
+        [TestCase("karaoke", null, true, "karaoke")]
+        [TestCase("karaoke", "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
+        [TestCase("", "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
+        [TestCase(null, "ka- ra- o- ke-", true, "ka- ra- o- ke-")]
+        public void TestDisplayText(string text, string alternativeText, bool useAlternativeTextIfHave, string actual)
+        {
+            var note = new Note
+            {
+                Text = text,
+                AlternativeText = alternativeText
+            };
+
+            var result = NoteUtils.DisplayText(note, useAlternativeTextIfHave);
+            Assert.AreEqual(result, actual);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
                             string tone;
                             float percentage = (float)Math.Round((float)1 / rubyNotes.Length, 2, MidpointRounding.AwayFromZero);
-                            string ruby = defaultNote.AlternativeText?.ElementAtOrDefault(j).ToString();
+                            string ruby = defaultNote.RubyText?.ElementAtOrDefault(j).ToString();
 
                             // Format like [1;0.5;か]
                             if (note.StartsWith("[", StringComparison.Ordinal) && note.EndsWith("]", StringComparison.Ordinal))

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             // Visual
             SetDefault(KaraokeRulesetSetting.ScrollTime, 5000.0, 1000.0, 10000.0, 100.0);
             SetDefault(KaraokeRulesetSetting.ScrollDirection, KaraokeScrollingDirection.Left);
-            SetDefault(KaraokeRulesetSetting.DisplayAlternativeText, false);
+            SetDefault(KaraokeRulesetSetting.DisplayRubyText, false);
             SetDefault(KaraokeRulesetSetting.ShowCursor, false);
             SetDefault(KaraokeRulesetSetting.NoteAlpha, 1, 0.2, 1, 0.01);
             SetDefault(KaraokeRulesetSetting.LyricAlpha, 1, 0.2, 1, 0.01);
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         // Visual
         ScrollTime,
         ScrollDirection,
-        DisplayAlternativeText,
+        DisplayRubyText,
         ShowCursor,
         NoteAlpha,
         LyricAlpha,

--- a/osu.Game.Rulesets.Karaoke/Edit/Blueprints/Notes/NoteSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Blueprints/Notes/NoteSelectionBlueprint.cs
@@ -2,10 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.UI;
@@ -15,7 +19,7 @@ using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes
 {
-    public class NoteSelectionBlueprint : KaraokeSelectionBlueprint<Note>
+    public class NoteSelectionBlueprint : KaraokeSelectionBlueprint<Note>, IHasPopover
     {
         [Resolved]
         private NoteManager noteManager { get; set; }
@@ -59,5 +63,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes
             new OsuMenuItem(HitObject.Display ? "Hide" : "Show", HitObject.Display ? MenuItemType.Destructive : MenuItemType.Standard, () => noteManager.ChangeDisplay(HitObject, !HitObject.Display)),
             new OsuMenuItem("Split", MenuItemType.Destructive, () => noteManager.SplitNote(HitObject)),
         };
+
+        public Popover GetPopover() => new NoteEditPopover(HitObject);
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            this.ShowPopover();
+            return base.OnClick(e);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterface/DeleteIconButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterface/DeleteIconButton.cs
@@ -8,7 +8,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterface
 {
     public class DeleteIconButton : IconButton
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -23,8 +23,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                     {
                         new LabelledTextBox
                         {
+                            Label = "Text",
+                            Description = "The text display on the note.",
+                            Current = note.TextBindable
+                        },
+                        new LabelledTextBox
+                        {
                             Label = "Alternative text",
-                            Description = "Will show this text if have.",
+                            Description = "Should placing something like ruby, 拼音 or ふりがな.",
                             Current = note.AlternativeTextBindable
                         },
                         new LabelledSwitchButton

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -23,12 +23,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                     {
                         new LabelledTextBox
                         {
-                            Label = "Display text",
+                            Label = "Alternative text",
+                            Description = "Will show this text if have.",
                             Current = note.AlternativeTextBindable
                         },
                         new LabelledSwitchButton
                         {
                             Label = "Display",
+                            Description = "This note will be hidden and not scorable if not display.",
                             Current = note.DisplayBindable,
                         }
                     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
+{
+    public class NoteEditPopover : OsuPopover
+    {
+        public NoteEditPopover(Note note)
+        {
+            Children = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    Width = 200,
+                    Direction = FillDirection.Vertical,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        new LabelledTextBox
+                        {
+                            Label = "Display text",
+                            Current = note.AlternativeTextBindable
+                        },
+                        new LabelledSwitchButton
+                        {
+                            Label = "Display",
+                            Current = note.DisplayBindable,
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -29,9 +29,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                         },
                         new LabelledTextBox
                         {
-                            Label = "Alternative text",
+                            Label = "Ruby text",
                             Description = "Should placing something like ruby, 拼音 or ふりがな.",
-                            Current = note.AlternativeTextBindable
+                            Current = note.RubyTextBindable
                         },
                         new LabelledSwitchButton
                         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Configs/Generator/Languages/AcceptLanguagesSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Configs/Generator/Languages/AcceptLanguagesSection.cs
@@ -10,7 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Languages;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
                         StartIndex = startIndex,
                         EndIndex = endIndex,
                         Text = text,
-                        AlternativeText = ruby,
+                        RubyText = ruby,
                         ParentLyric = lyric
                     });
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -10,7 +10,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osuTK;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Notes/NoteEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Notes/NoteEditorHitObjectBlueprint.cs
@@ -3,12 +3,16 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.UI.Position;
@@ -21,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Notes
     /// <summary>
     /// Copy from <see cref="NoteSelectionBlueprint"/>
     /// </summary>
-    public class NoteEditorHitObjectBlueprint : SelectionBlueprint<Note>
+    public class NoteEditorHitObjectBlueprint : SelectionBlueprint<Note>, IHasPopover
     {
         private readonly IBindable<double> timeRange = new BindableDouble();
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
@@ -100,5 +104,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Notes
             new OsuMenuItem(Item.Display ? "Hide" : "Show", Item.Display ? MenuItemType.Destructive : MenuItemType.Standard, () => noteManager.ChangeDisplay(Item, !Item.Display)),
             new OsuMenuItem("Split", MenuItemType.Destructive, () => noteManager.SplitNote(Item)),
         };
+
+        public Popover GetPopover() => new NoteEditPopover(Item);
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            this.ShowPopover();
+            return base.OnClick(e);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Rulesets.Karaoke.Skinning.Default;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Notes;
 using osu.Game.Rulesets.Karaoke.UI.Position;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -152,7 +153,8 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
         private void changeText(Note note)
         {
-            textPiece.Text = note.AlternativeText ?? note.Text;
+            // todo: should apply the setting.
+            textPiece.Text = NoteUtils.DisplayText(note, true);
         }
 
         protected void BeginSing()

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
         private readonly IBindable<NotePositionCalculator> positionBindable = new Bindable<NotePositionCalculator>();
 
         public readonly IBindable<string> TextBindable = new Bindable<string>();
-        public readonly IBindable<string> AlternativeTextBindable = new Bindable<string>();
+        public readonly IBindable<string> RubyTextBindable = new Bindable<string>();
         public readonly IBindable<int[]> SingersBindable = new Bindable<int[]>();
         public readonly IBindable<bool> DisplayBindable = new Bindable<bool>();
         public readonly IBindable<Tone> ToneBindable = new Bindable<Tone>();
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
 
             positionBindable.BindValueChanged(_ => updateNotePositionAndHeight());
             TextBindable.BindValueChanged(_ => { changeText(HitObject); });
-            AlternativeTextBindable.BindValueChanged(_ => { changeText(HitObject); });
+            RubyTextBindable.BindValueChanged(_ => { changeText(HitObject); });
             SingersBindable.BindValueChanged(_ => { ApplySkin(CurrentSkin, false); });
             DisplayBindable.BindValueChanged(e => { (Result.Judgement as KaraokeNoteJudgement).Saitenable = e.NewValue; });
             ToneBindable.BindValueChanged(_ => updateNotePositionAndHeight());
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             base.OnApply();
 
             TextBindable.BindTo(HitObject.TextBindable);
-            AlternativeTextBindable.BindTo(HitObject.AlternativeTextBindable);
+            RubyTextBindable.BindTo(HitObject.RubyTextBindable);
             DisplayBindable.BindTo(HitObject.DisplayBindable);
             ToneBindable.BindTo(HitObject.ToneBindable);
 
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             base.OnFree();
 
             TextBindable.UnbindFrom(HitObject.TextBindable);
-            AlternativeTextBindable.UnbindFrom(HitObject.AlternativeTextBindable);
+            RubyTextBindable.UnbindFrom(HitObject.RubyTextBindable);
             DisplayBindable.UnbindFrom(HitObject.DisplayBindable);
             ToneBindable.UnbindFrom(HitObject.ToneBindable);
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -17,8 +17,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         public readonly Bindable<string> TextBindable = new();
 
         /// <summary>
-        /// Text display on the note
+        /// Text display on the note.
         /// </summary>
+        /// <example>
+        /// 花
+        /// </example>
         public string Text
         {
             get => TextBindable.Value;
@@ -29,8 +32,13 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         public readonly Bindable<string> AlternativeTextBindable = new();
 
         /// <summary>
-        /// Will be display if <see cref="KaraokeRulesetSetting.DisplayAlternativeText"/> is true
+        /// Alternative text.
+        /// Should placing something like ruby, 拼音 or ふりがな.
+        /// Will be display only if <see cref="KaraokeRulesetSetting.DisplayAlternativeText"/> is true.
         /// </summary>
+        /// <example>
+        /// はな
+        /// </example>
         public string AlternativeText
         {
             get => AlternativeTextBindable.Value;

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -29,20 +29,20 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         }
 
         [JsonIgnore]
-        public readonly Bindable<string> AlternativeTextBindable = new();
+        public readonly Bindable<string> RubyTextBindable = new();
 
         /// <summary>
-        /// Alternative text.
+        /// Ruby text.
         /// Should placing something like ruby, 拼音 or ふりがな.
-        /// Will be display only if <see cref="KaraokeRulesetSetting.DisplayAlternativeText"/> is true.
+        /// Will be display only if <see cref="KaraokeRulesetSetting.DisplayRubyText"/> is true.
         /// </summary>
         /// <example>
         /// はな
         /// </example>
-        public string AlternativeText
+        public string RubyText
         {
-            get => AlternativeTextBindable.Value;
-            set => AlternativeTextBindable.Value = value;
+            get => RubyTextBindable.Value;
+            set => RubyTextBindable.Value = value;
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Gameplay/NoteSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Config/Sections/Gameplay/NoteSettings.cs
@@ -36,8 +36,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Config.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Display alternative text",
-                    Current = Config.GetBindable<bool>(KaraokeRulesetSetting.DisplayAlternativeText)
+                    LabelText = "Display ruby text",
+                    Current = Config.GetBindable<bool>(KaraokeRulesetSetting.DisplayRubyText)
                 },
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Legacy/LegacyNotePiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Legacy/LegacyNotePiece.cs
@@ -135,9 +135,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
             }
         }
 
-        private LayerContainer createLayer(string name, ISkin skin, LegacyKaraokeSkinNoteLayer layer)
-        {
-            return new()
+        private LayerContainer createLayer(string name, ISkin skin, LegacyKaraokeSkinNoteLayer layer) =>
+            new()
             {
                 RelativeSizeAxes = Axes.Both,
                 Name = name,
@@ -178,7 +177,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
                     }),
                 }
             };
-        }
 
         private static Sprite getSpriteFromLookup(ISkin skin, LegacyKaraokeSkinConfigurationLookups lookup, LegacyKaraokeSkinNoteLayer layer)
         {

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -19,9 +19,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             return CopyByTime(note, startTime, duration);
         }
 
-        public static Note CopyByTime(Note originNote, double startTime, double duration)
-        {
-            return new()
+        public static Note CopyByTime(Note originNote, double startTime, double duration) =>
+            new()
             {
                 StartTime = startTime,
                 Duration = duration,
@@ -32,7 +31,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 Tone = originNote.Tone,
                 ParentLyric = originNote.ParentLyric
             };
-        }
 
         /// <summary>
         /// Get the display text while gameplay or in editor.

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -38,14 +38,14 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// Get the display text while gameplay or in editor.
         /// </summary>
         /// <param name="note">Note</param>
-        /// <param name="useAlternativeTextIfHave">Should use alternative text first if have.</param>
+        /// <param name="useRubyTextIfHave">Should use ruby text first if have.</param>
         /// <returns>Text should be display.</returns>
-        public static string DisplayText(Note note, bool useAlternativeTextIfHave = false)
+        public static string DisplayText(Note note, bool useRubyTextIfHave = false)
         {
-            if (!useAlternativeTextIfHave)
+            if (!useRubyTextIfHave)
                 return note.Text;
 
-            return string.IsNullOrEmpty(note.AlternativeText) ? note.Text : note.AlternativeText;
+            return string.IsNullOrEmpty(note.RubyText) ? note.Text : note.RubyText;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -33,5 +33,19 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 ParentLyric = originNote.ParentLyric
             };
         }
+
+        /// <summary>
+        /// Get the display text while gameplay or in editor.
+        /// </summary>
+        /// <param name="note">Note</param>
+        /// <param name="useAlternativeTextIfHave">Should use alternative text first if have.</param>
+        /// <returns>Text should be display.</returns>
+        public static string DisplayText(Note note, bool useAlternativeTextIfHave = false)
+        {
+            if (!useAlternativeTextIfHave)
+                return note.Text;
+
+            return string.IsNullOrEmpty(note.AlternativeText) ? note.Text : note.AlternativeText;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -18,15 +18,13 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             return textTag;
         }
 
-        public static T Shifting<T>(T textTag, int shifting) where T : ITextTag, new()
-        {
-            return new()
+        public static T Shifting<T>(T textTag, int shifting) where T : ITextTag, new() =>
+            new()
             {
                 StartIndex = textTag.StartIndex + shifting,
                 EndIndex = textTag.EndIndex + shifting,
                 Text = textTag.Text
             };
-        }
 
         public static bool OutOfRange<T>(T textTag, string lyric) where T : ITextTag
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/139587611-5698f75e-d433-4015-a7aa-c89907cd076d.png)
![image](https://user-images.githubusercontent.com/9100368/139587633-3facf3cb-500b-4415-ac2c-9ab6d28823f0.png)
What's done in this PR:
- Implement almost all parts in #883 (tiggle parts can be igored now).
- Apply in main editor and note editor in lyric editor.
- Add utils to decide should show the text from text or ruby text.
- Rename from AlternativeText to Ruby class for let use knows what this field do.
- Little clean-up code.