### PR TITLE
Implement note edit mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menu/LyricEditorModeMenu.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
             LyricEditorMode.EditRuby,
             LyricEditorMode.EditRomaji,
             LyricEditorMode.CreateTimeTag,
-            LyricEditorMode.CreateNote,
+            LyricEditorMode.EditNote,
             LyricEditorMode.Layout,
             LyricEditorMode.Singer,
         };
@@ -57,9 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menu
                 case LyricEditorMode.AdjustTimeTag:
                     return "Edit time tag";
 
-                case LyricEditorMode.CreateNote:
-                case LyricEditorMode.CreateNotePosition:
-                case LyricEditorMode.AdjustNote:
+                case LyricEditorMode.EditNote:
                     return "Edit note";
 
                 case LyricEditorMode.Layout:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -85,9 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagRowExtend(lyric);
 
-                    case LyricEditorMode.CreateNote:
-                    case LyricEditorMode.CreateNotePosition:
-                    case LyricEditorMode.AdjustNote:
+                    case LyricEditorMode.EditNote:
                         return new NoteRowExtend(lyric);
 
                     default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSection.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
     /// <summary>
-    /// In <see cref="LyricEditorMode.CreateNote"/> mode, able to let user generate notes by <see cref="TimeTag"/>
+    /// In <see cref="NoteEditMode.Generate"/> mode, able to let user generate notes by <see cref="TimeTag"/>
     /// But need to make sure that lyric should not have any <see cref="TimeTagIssue"/>
     /// If found any issue, will navigate to target lyric.
     /// </summary>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteConfigSection.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
     public class NoteConfigSection : Section
     {
-        protected override string Title => "Edit mode";
+        protected override string Title => "Config";
 
         [BackgroundDependencyLoader]
         private void load(IScrollingInfo scrollingInfo)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditMode.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
+{
+    public enum NoteEditMode
+    {
+        Generate,
+
+        Edit,
+
+        Verify
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
@@ -10,32 +12,45 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
-    public class NoteEditModeSection : LyricEditorEditModeSection
+    public class NoteEditModeSection : EditModeSection<NoteEditMode>
     {
+        [Resolved]
+        private Bindable<NoteEditMode> bindableEditMode { get; set; }
+
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Blue;
 
-        protected override Dictionary<LyricEditorMode, EditModeSelectionItem> CreateSelections()
+        protected override NoteEditMode DefaultMode()
+            => bindableEditMode.Value;
+
+        protected override Dictionary<NoteEditMode, EditModeSelectionItem> CreateSelections()
             => new()
             {
                 {
-                    LyricEditorMode.CreateNote, new EditModeSelectionItem("Create", "Using time-tag to create default notes.")
+                    NoteEditMode.Generate, new EditModeSelectionItem("Generate", "Using time-tag to create default notes.")
                 },
                 {
-                    LyricEditorMode.CreateNotePosition, new EditModeSelectionItem("Position", "Using singer voice data to adjust note position.")
+                    NoteEditMode.Edit, new EditModeSelectionItem("Edit", "Batch edit note property in here.")
                 },
                 {
-                    LyricEditorMode.AdjustNote, new EditModeSelectionItem("Adjust", "If you are note satisfied this result, you can adjust this by hands.")
+                    NoteEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid notes in here.")
                 }
             };
 
-        protected override Color4 GetColour(OsuColour colour, LyricEditorMode mode, bool active) =>
+        protected override Color4 GetColour(OsuColour colour, NoteEditMode mode, bool active) =>
             mode switch
             {
-                LyricEditorMode.CreateNote => active ? colour.Blue : colour.BlueDarker,
-                LyricEditorMode.CreateNotePosition => active ? colour.Red : colour.RedDarker,
-                LyricEditorMode.AdjustNote => active ? colour.Yellow : colour.YellowDarker,
+                NoteEditMode.Generate => active ? colour.Blue : colour.BlueDarker,
+                NoteEditMode.Edit => active ? colour.Red : colour.RedDarker,
+                NoteEditMode.Verify => active ? colour.Yellow : colour.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
+
+        protected override void UpdateEditMode(NoteEditMode mode)
+        {
+            bindableEditMode.Value = mode;
+
+            base.UpdateEditMode(mode);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -20,17 +20,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
     {
         protected override string Title => "Properties";
 
-        private readonly Bindable<Note[]> bindableNotes = new();
+        private readonly Bindable<Note[]> notes = new();
 
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap beatmap, LyricCaretState lyricCaretState, Bindable<NoteEditPropertyMode> bindableNoteEditPropertyMode)
         {
             bindableNoteEditPropertyMode.BindValueChanged(e =>
             {
+                // todo: use better way not to trigger bindable in disposed object.
+                // this only happened in here.
+                if (IsDisposed)
+                    return;
+
                 reCreateEditComponents();
             });
 
-            bindableNotes.BindValueChanged(e =>
+            notes.BindValueChanged(e =>
             {
                 reCreateEditComponents();
             });
@@ -38,17 +43,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
             {
                 var lyric = e.NewValue?.Lyric;
-                var notes = beatmap.HitObjects.OfType<Note>().Where(x => x.ParentLyric == lyric).ToList();
-                bindableNotes.Value = notes.ToArray();
+                notes.Value = beatmap.HitObjects.OfType<Note>().Where(x => x.ParentLyric == lyric).ToArray();
             }, true);
 
             void reCreateEditComponents()
             {
                 RemoveAll(x => x is LabelledObjectFieldTextBox<Note>);
                 RemoveAll(x => x is LabelledSwitchButton);
-                AddRange(bindableNotes.Value?.Select(x =>
+                AddRange(notes.Value?.Select(x =>
                 {
-                    var index = bindableNotes.Value.IndexOf(x);
+                    var index = notes.Value.IndexOf(x);
                     return bindableNoteEditPropertyMode.Value switch
                     {
                         NoteEditPropertyMode.Text => new LabelledNoteTextTextBox(x)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         Children = new Drawable[]
                         {
                             new NoteEditModeSection(),
+                            new NoteConfigSection(),
                             new NoteAutoGenerateSection(),
                         };
                         break;
@@ -47,7 +48,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         Children = new Drawable[]
                         {
                             new NoteEditModeSection(),
-                            new NoteConfigSection(),
                             new NoteIssueSection()
                         };
                         break;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -13,7 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         public override float ExtendWidth => 300;
 
-        private Bindable<LyricEditorMode> bindableMode;
+        [Cached]
+        private Bindable<NoteEditMode> bindableMode = new();
 
         [Cached]
         private readonly Bindable<NoteEditPropertyMode> noteEditPropertyMode = new();
@@ -21,12 +22,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state)
         {
-            bindableMode = state.BindableMode.GetBoundCopy();
             bindableMode.BindValueChanged(e =>
             {
                 switch (e.NewValue)
                 {
-                    case LyricEditorMode.CreateNote:
+                    case NoteEditMode.Generate:
                         Children = new Drawable[]
                         {
                             new NoteEditModeSection(),
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         };
                         break;
 
-                    case LyricEditorMode.CreateNotePosition:
+                    case NoteEditMode.Edit:
                         Children = new Drawable[]
                         {
                             new NoteEditModeSection(),
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         };
                         break;
 
-                    case LyricEditorMode.AdjustNote:
+                    case NoteEditMode.Verify:
                         Children = new Drawable[]
                         {
                             new NoteEditModeSection(),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
         private readonly Bindable<NoteEditPropertyMode> noteEditPropertyMode = new();
 
         [BackgroundDependencyLoader]
-        private void load(ILyricEditorState state)
+        private void load()
         {
             bindableMode.BindValueChanged(e =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -218,9 +218,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     case LyricEditorMode.AdjustTimeTag:
                         return new TimeTagExtend();
 
-                    case LyricEditorMode.CreateNote:
-                    case LyricEditorMode.CreateNotePosition:
-                    case LyricEditorMode.AdjustNote:
+                    case LyricEditorMode.EditNote:
                         return new NoteExtend();
 
                     case LyricEditorMode.Singer:
@@ -371,9 +369,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.AdjustTimeTag:
                     return false;
 
-                case LyricEditorMode.CreateNote:
-                case LyricEditorMode.CreateNotePosition:
-                case LyricEditorMode.AdjustNote:
+                case LyricEditorMode.EditNote:
                 case LyricEditorMode.Layout:
                 case LyricEditorMode.Singer:
                     return false;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
@@ -58,9 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.AdjustTimeTag:
                     return 33 / 360f; // orange
 
-                case LyricEditorMode.CreateNote:
-                case LyricEditorMode.CreateNotePosition:
-                case LyricEditorMode.AdjustNote:
+                case LyricEditorMode.EditNote:
                     return 203 / 360f; // blue
 
                 case LyricEditorMode.Layout:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
@@ -51,20 +51,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         AdjustTimeTag,
 
         /// <summary>
-        /// Enable to create/delete and reset note.
-        /// Also able to create default notes.
+        /// Enable to create/delete notes.
         /// </summary>
-        CreateNote,
-
-        /// <summary>
-        /// Auto adjust note position by singer voice data.
-        /// </summary>
-        CreateNotePosition,
-
-        /// <summary>
-        /// Adjust note position.
-        /// </summary>
-        AdjustNote,
+        EditNote,
 
         /// <summary>
         /// Can edit each lyric's layout.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -222,9 +222,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         case LyricEditorMode.AdjustTimeTag:
                             return new TimeTagInfo(Lyric);
 
-                        case LyricEditorMode.CreateNote:
-                        case LyricEditorMode.CreateNotePosition:
-                        case LyricEditorMode.AdjustNote:
+                        case LyricEditorMode.EditNote:
                             return null;
 
                         case LyricEditorMode.Layout:
@@ -381,9 +379,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                         break;
 
                     case LyricEditorMode.AdjustTimeTag:
-                    case LyricEditorMode.CreateNote:
-                    case LyricEditorMode.CreateNotePosition:
-                    case LyricEditorMode.AdjustNote:
+                    case LyricEditorMode.EditNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         lyricCaretState.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(Lyric));
@@ -523,9 +519,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                             return new DrawableTimeTagRecordCaret(isPreview);
 
                         case LyricEditorMode.AdjustTimeTag:
-                        case LyricEditorMode.CreateNote:
-                        case LyricEditorMode.CreateNotePosition:
-                        case LyricEditorMode.AdjustNote:
+                        case LyricEditorMode.EditNote:
                         case LyricEditorMode.Layout:
                         case LyricEditorMode.Singer:
                             return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -43,9 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                         return new TimeTagCaretPositionAlgorithm(lyrics) { Mode = movingTimeTagCaretMode };
 
                     case LyricEditorMode.AdjustTimeTag:
-                    case LyricEditorMode.CreateNote:
-                    case LyricEditorMode.CreateNotePosition:
-                    case LyricEditorMode.AdjustNote:
+                    case LyricEditorMode.EditNote:
                     case LyricEditorMode.Layout:
                     case LyricEditorMode.Singer:
                         return new NavigateCaretPositionAlgorithm(lyrics);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/139867549-1a641a90-7c87-490b-a7d0-dfa499041c76.png)
![image](https://user-images.githubusercontent.com/9100368/139867588-73fe3d83-d916-4d2b-ac6d-28c7b2e4b7c9.png)
Implement remain issue in #888 
What's done in this pr:
- make note edit mode into individual class.
- removed separated enum property in `LyricEditorMode`
- rename section.
- fix the bug that might change children in deleted component(see last two commits).