### PR TITLE
Fix cannot release issue.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 {
@@ -103,7 +104,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
                 base.OnFocusLost(e);
             }
 
-            private SRGBColour standardBorderColour;
+            private Color4 standardBorderColour;
 
             [BackgroundDependencyLoader]
             private void load()


### PR DESCRIPTION
Use color4 instead.
Because it will cause this issue:
```
Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs(118,36): error CS0172: Type of conditional expression cannot be determined because 'Color4' and 'SRGBColour' implicitly convert to one another [/home/runner/work/karaoke/karaoke/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj]
```

Action:
https://github.com/karaoke-dev/karaoke/runs/4082888688