### PR TITLE
Fix FontUsageConvertorTest run failed in osx.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/BaseSingleConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/BaseSingleConverterTest.cs
@@ -11,6 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
         protected JsonSerializerSettings CreateSettings()
         {
             var globalSetting = JsonSerializableExtensions.CreateGlobalSettings();
+            globalSetting.Formatting = Formatting.None; // do not change new line in testing.
             globalSetting.Converters = new JsonConverter[] { new TConverter() };
             return globalSetting;
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/FontUsageConvertorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/FontUsageConvertorTest.cs
@@ -11,16 +11,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
     public class FontUsageConvertorTest : BaseSingleConverterTest<FontUsageConvertor>
     {
         [TestCase("", 20, "", false, false, "{}")]
-        [TestCase("OpenSans", 20, "", false, false, "{\"family\": \"OpenSans\"}")]
-        [TestCase("OpenSans", 30, "", false, false, "{\"family\": \"OpenSans\",\"size\": 30.0}")]
-        [TestCase("OpenSans", 30, "RegularItalic", false, false, "{\"family\": \"OpenSans\",\"weight\": \"RegularItalic\",\"size\": 30.0}")]
-        [TestCase("OpenSans", 30, "RegularItalic", true, false, "{\"family\": \"OpenSans\",\"weight\": \"RegularItalic\",\"size\": 30.0,\"italics\": true}")]
-        [TestCase("OpenSans", 30, "RegularItalic", true, true, "{\"family\": \"OpenSans\",\"weight\": \"RegularItalic\",\"size\": 30.0,\"italics\": true,\"fixedWidth\": true}")]
+        [TestCase("OpenSans", 20, "", false, false, "{\"family\":\"OpenSans\"}")]
+        [TestCase("OpenSans", 30, "", false, false, "{\"family\":\"OpenSans\",\"size\":30.0}")]
+        [TestCase("OpenSans", 30, "RegularItalic", false, false, "{\"family\":\"OpenSans\",\"weight\":\"RegularItalic\",\"size\":30.0}")]
+        [TestCase("OpenSans", 30, "RegularItalic", true, false, "{\"family\":\"OpenSans\",\"weight\":\"RegularItalic\",\"size\":30.0,\"italics\":true}")]
+        [TestCase("OpenSans", 30, "RegularItalic", true, true, "{\"family\":\"OpenSans\",\"weight\":\"RegularItalic\",\"size\":30.0,\"italics\":true,\"fixedWidth\":true}")]
         public void TestSerialize(string family, float size, string weight, bool italics, bool fixedWidth, string json)
         {
             var font = new FontUsage(family, size, weight, italics, fixedWidth);
             var result = JsonConvert.SerializeObject(font, CreateSettings());
-            result = result.Replace("\r\n  ", "").Replace("\r\n", "");
             Assert.AreEqual(result, json);
         }
 


### PR DESCRIPTION
because the new line is not the same between windows (\r\n) and osx (\n)
the better way should be to generate JSON in a single line.