### PR TITLE
Refactor layout structor in karaoke skin.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeSkinDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeSkinDecoderTest.cs
@@ -61,13 +61,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                 Assert.AreEqual(firstDecodedLayout.HorizontalMargin, 30);
                 Assert.AreEqual(firstDecodedLayout.VerticalMargin, 45);
                 Assert.AreEqual(firstDecodedLayout.Continuous, false);
-                Assert.AreEqual(firstDecodedLayout.SmartHorizon, KaraokeTextSmartHorizon.Multi);
-                Assert.AreEqual(firstDecodedLayout.LyricsInterval, 4);
-                Assert.AreEqual(firstDecodedLayout.RubyInterval, 2);
-                Assert.AreEqual(firstDecodedLayout.RubyAlignment, LyricTextAlignment.Auto);
-                Assert.AreEqual(firstDecodedLayout.RomajiAlignment, LyricTextAlignment.Auto);
-                Assert.AreEqual(firstDecodedLayout.RubyMargin, 4);
-                Assert.AreEqual(firstDecodedLayout.RomajiMargin, 0);
+
+                // Test default lyric config test.
+                var defaultLyricConfig = skin.DefaultLyricConfig;
+                Assert.NotNull(defaultLyricConfig);
+                Assert.AreEqual(defaultLyricConfig.SmartHorizon, KaraokeTextSmartHorizon.Multi);
+                Assert.AreEqual(defaultLyricConfig.LyricsInterval, 4);
+                Assert.AreEqual(defaultLyricConfig.RubyInterval, 2);
+                Assert.AreEqual(defaultLyricConfig.RubyAlignment, LyricTextAlignment.Auto);
+                Assert.AreEqual(defaultLyricConfig.RomajiAlignment, LyricTextAlignment.Auto);
+                Assert.AreEqual(defaultLyricConfig.RubyMargin, 4);
+                Assert.AreEqual(defaultLyricConfig.RomajiMargin, 0);
 
                 // Checking note decode result
                 var firstDecodedNoteSkin = skin.NoteSkins.FirstOrDefault();

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/NicoKaraDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/NicoKaraDecoderTest.cs
@@ -41,11 +41,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                 Assert.AreEqual(firstLayout.HorizontalMargin, 30);
                 Assert.AreEqual(firstLayout.VerticalMargin, 45);
                 Assert.AreEqual(firstLayout.Continuous, false);
-                Assert.AreEqual(firstLayout.SmartHorizon, KaraokeTextSmartHorizon.Multi);
-                Assert.AreEqual(firstLayout.LyricsInterval, 4);
-                Assert.AreEqual(firstLayout.RubyInterval, 2);
-                Assert.AreEqual(firstLayout.RubyAlignment, LyricTextAlignment.Auto);
-                Assert.AreEqual(firstLayout.RubyMargin, 4);
 
                 // Testing style
                 var firstFont = skin.Styles.FirstOrDefault();
@@ -67,8 +62,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                 Assert.NotNull(shadowShader);
                 Assert.AreEqual(shadowShader.ShadowOffset, new Vector2(3));
 
+                // test lyric config
+                var defaultLyricConfig = skin.DefaultLyricConfig;
+                Assert.NotNull(defaultLyricConfig);
+                Assert.AreEqual(defaultLyricConfig.SmartHorizon, KaraokeTextSmartHorizon.Multi);
+                Assert.AreEqual(defaultLyricConfig.LyricsInterval, 4);
+                Assert.AreEqual(defaultLyricConfig.RubyInterval, 2);
+                Assert.AreEqual(defaultLyricConfig.RubyAlignment, LyricTextAlignment.Auto);
+                Assert.AreEqual(defaultLyricConfig.RubyMargin, 4);
+
                 // Test main text font
-                var mainTextFontInfo = firstFont.MainTextFont;
+                var mainTextFontInfo = defaultLyricConfig.MainTextFont;
                 Assert.AreEqual(mainTextFontInfo.Family, "游明朝 Demibold");
                 Assert.AreEqual(mainTextFontInfo.Weight, "Bold");
                 Assert.AreEqual(mainTextFontInfo.Size, 40);

--- a/osu.Game.Rulesets.Karaoke.Tests/Resources/Testing/Skin/default.skin
+++ b/osu.Game.Rulesets.Karaoke.Tests/Resources/Testing/Skin/default.skin
@@ -1,4 +1,23 @@
 {
+  "default_lyric_config": {
+    "smart_horizon": 2,
+    "lyrics_interval": 4,
+    "ruby_interval": 2,
+    "ruby_margin": 4,
+    "main_text_font": {
+      "family": "Torus",
+      "weight": "Bold",
+      "size": 48.0
+    },
+    "ruby_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    },
+    "romaji_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    }
+  },
   "styles": [
     {
       "left_lyric_text_shaders": [
@@ -46,19 +65,6 @@
         }
       ],
       "name": "標準配色",
-      "main_text_font": {
-        "family": "Torus",
-        "weight": "Bold",
-        "size": 48.0
-      },
-      "ruby_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      },
-      "romaji_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      }
     }
   ],
   "layouts": [
@@ -67,10 +73,6 @@
       "alignment": 36,
       "horizontal_margin": 30,
       "vertical_margin": 45,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
     }
   ],
   "note_skins": [

--- a/osu.Game.Rulesets.Karaoke.Tests/Resources/Testing/Skin/full.skin
+++ b/osu.Game.Rulesets.Karaoke.Tests/Resources/Testing/Skin/full.skin
@@ -1,4 +1,23 @@
 {
+  "default_lyric_config": {
+    "smart_horizon": 2,
+    "lyrics_interval": 4,
+    "ruby_interval": 2,
+    "ruby_margin": 4,
+    "main_text_font": {
+      "family": "Torus",
+      "weight": "Bold",
+      "size": 48.0
+    },
+    "ruby_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    },
+    "romaji_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    }
+  },
   "styles": [
     {
       "left_lyric_text_shaders": [
@@ -45,20 +64,7 @@
           ]
         }
       ],
-      "name": "標準配色",
-      "main_text_font": {
-        "family": "Torus",
-        "weight": "Bold",
-        "size": 48.0
-      },
-      "ruby_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      },
-      "romaji_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      }
+      "name": "標準配色"
     }
   ],
   "layouts": [
@@ -66,139 +72,90 @@
       "name": "下-1",
       "alignment": 36,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "name": "下-2",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 130,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 130
     },
     {
       "name": "下-3",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 215,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 215
     },
     {
       "name": "下-4",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 300,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 300
     },
     {
       "name": "上-1",
       "alignment": 9,
       "horizontal_margin": 30,
-      "vertical_margin": 115,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 115
     },
     {
       "name": "上-2",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 200,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 200
     },
     {
       "name": "上-3",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 285,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 285
     },
     {
       "name": "上-4",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 370,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 370
     },
     {
       "name": "中",
-      "alignment": 18,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "alignment": 18
     },
     {
       "name": "前行追随",
       "alignment": 12,
       "horizontal_margin": 30,
       "vertical_margin": 45,
-      "continuous": true,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "continuous": true
     },
     {
       "name": "情報-左上",
       "alignment": 9,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "name": "情報-右上",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "name": "情報-左下",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "name": "情報-右下",
       "alignment": 36,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "name": "情報-中央",
       "alignment": 18,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     }
   ],
   "note_skins": [

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeSkinDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeSkinDecoder.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                 return;
 
             // Copy property
+            output.DefaultLyricConfig = result.DefaultLyricConfig;
             output.Styles = result.Styles;
             output.Layouts = result.Layouts;
             output.NoteSkins = result.NoteSkins;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraDecoder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using NicoKaraParser;
 using NicoKaraParser.Model;
 using NicoKaraParser.Model.Font.Font;
@@ -43,9 +44,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
             foreach (var karaokeLayout in nicoKaraProject.KaraokeLayouts)
             {
-                Enum.TryParse(karaokeLayout.SmartHorizon.ToString(), out KaraokeTextSmartHorizon smartHorizon);
-                Enum.TryParse(karaokeLayout.RubyAlignment.ToString(), out LyricTextAlignment rubyAlignment);
-
                 output.Layouts.Add(new LyricLayout
                 {
                     Name = karaokeLayout.Name,
@@ -53,11 +51,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                     HorizontalMargin = karaokeLayout.HorizontalMargin,
                     VerticalMargin = karaokeLayout.VerticalMargin,
                     Continuous = karaokeLayout.Continuous,
-                    SmartHorizon = smartHorizon,
-                    LyricsInterval = karaokeLayout.LyricsInterval,
-                    RubyInterval = karaokeLayout.RubyInterval,
-                    RubyAlignment = rubyAlignment,
-                    RubyMargin = karaokeLayout.RubyMargin
                 });
             }
 
@@ -71,107 +64,126 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                     Name = nicoKaraFont.Name,
                     LeftLyricTextShaders = createShaders(nicoKaraFont, ApplyShaderPart.Left),
                     RightLyricTextShaders = createShaders(nicoKaraFont, ApplyShaderPart.Right),
-                    MainTextFont = convertFontInfo(nicoKaraFont.FontInfos[0]),
-                    RubyTextFont = convertFontInfo(nicoKaraFont.FontInfos[3]),
-                    RomajiTextFont = convertFontInfo(nicoKaraFont.FontInfos[3]),
                 });
             }
 
-            static Anchor convertAnchor(HorizontalAlignment horizontalAlignment, VerticalAlignment verticalAlignment)
-            {
-                Enum.TryParse((1 << ((int)horizontalAlignment + 3)).ToString(), out Anchor horizontalAnchor);
-                Enum.TryParse((1 << (int)verticalAlignment).ToString(), out Anchor verticalAnchor);
+            // assign default lyric config
+            var firstLayout = nicoKaraProject.KaraokeLayouts?.FirstOrDefault();
+            var firstFont = nicoKaraProject.KaraokeFonts?.FirstOrDefault();
 
-                return horizontalAnchor | verticalAnchor;
+            if (firstLayout == null || firstFont == null)
+                return;
+
+            Enum.TryParse(firstLayout.SmartHorizon.ToString(), out KaraokeTextSmartHorizon smartHorizon);
+            Enum.TryParse(firstLayout.RubyAlignment.ToString(), out LyricTextAlignment rubyAlignment);
+
+            output.DefaultLyricConfig = new LyricConfig
+            {
+                SmartHorizon = smartHorizon,
+                LyricsInterval = firstLayout.LyricsInterval,
+                RubyInterval = firstLayout.RubyInterval,
+                RubyAlignment = rubyAlignment,
+                RubyMargin = firstLayout.RubyMargin,
+                MainTextFont = convertFontInfo(firstFont.FontInfos[0]),
+                RubyTextFont = convertFontInfo(firstFont.FontInfos[3]),
+                RomajiTextFont = convertFontInfo(firstFont.FontInfos[3]),
+            };
+        }
+
+        private static Anchor convertAnchor(HorizontalAlignment horizontalAlignment, VerticalAlignment verticalAlignment)
+        {
+            Enum.TryParse((1 << ((int)horizontalAlignment + 3)).ToString(), out Anchor horizontalAnchor);
+            Enum.TryParse((1 << (int)verticalAlignment).ToString(), out Anchor verticalAnchor);
+
+            return horizontalAnchor | verticalAnchor;
+        }
+
+        private static List<IShader> createShaders(NicoKaraParser.Model.Font.KaraokeFont font, ApplyShaderPart part)
+        {
+            var fontInfo = font.FontInfos[0];
+            var brushInfos = getBrusnInfos(font, part);
+            var fontBrushInfo = brushInfos[0];
+            var borderBrushInfo = brushInfos[1];
+            var shaderBrushInfo = brushInfos[2];
+
+            var shaders = new List<IShader>();
+
+            // todo: implement change font color.
+            shaders.Add(createOutlineShader(borderBrushInfo, fontInfo));
+
+            var hasShadow = font.UseShadow;
+
+            if (hasShadow)
+            {
+                shaders.Add(createShadowShader(shaderBrushInfo, font.ShadowSlide));
             }
 
-            static List<IShader> createShaders(NicoKaraParser.Model.Font.KaraokeFont font, ApplyShaderPart part)
+            return shaders;
+        }
+
+        private static NicoKaraParser.Model.Font.Brush.BrushInfo[] getBrusnInfos(NicoKaraParser.Model.Font.KaraokeFont font, ApplyShaderPart part) =>
+            part switch
             {
-                var fontInfo = font.FontInfos[0];
-                var brushInfos = getBrusnInfos(font, part);
-                var fontBrushInfo = brushInfos[0];
-                var borderBrushInfo = brushInfos[1];
-                var shaderBrushInfo = brushInfos[2];
+                ApplyShaderPart.Left => font.BrushInfos.GetRange(0, 3).ToArray(),
+                ApplyShaderPart.Right => font.BrushInfos.GetRange(3, 3).ToArray(),
+                _ => throw new ArgumentOutOfRangeException(nameof(part))
+            };
 
-                var shaders = new List<IShader>();
+        private static OutlineShader createOutlineShader(NicoKaraParser.Model.Font.Brush.BrushInfo info, FontInfo fontInfo)
+        {
+            var color = convertColor(info);
+            var radius = convertEdgeSize(fontInfo);
 
-                // todo: implement change font color.
-                shaders.Add(createOutlineShader(borderBrushInfo, fontInfo));
-
-                var hasShadow = font.UseShadow;
-
-                if (hasShadow)
-                {
-                    shaders.Add(createShadowShader(shaderBrushInfo, font.ShadowSlide));
-                }
-
-                return shaders;
-            }
-
-            static NicoKaraParser.Model.Font.Brush.BrushInfo[] getBrusnInfos(NicoKaraParser.Model.Font.KaraokeFont font, ApplyShaderPart part) =>
-                part switch
-                {
-                    ApplyShaderPart.Left => font.BrushInfos.GetRange(0, 3).ToArray(),
-                    ApplyShaderPart.Right => font.BrushInfos.GetRange(3, 3).ToArray(),
-                    _ => throw new ArgumentOutOfRangeException(nameof(part))
-                };
-
-            static OutlineShader createOutlineShader(NicoKaraParser.Model.Font.Brush.BrushInfo info, FontInfo fontInfo)
+            return new OutlineShader
             {
-                var color = convertColor(info);
-                var radius = convertEdgeSize(fontInfo);
+                OutlineColour = color,
+                Radius = (int)radius,
+            };
 
-                return new OutlineShader
-                {
-                    OutlineColour = color,
-                    Radius = (int)radius,
-                };
+            static float convertEdgeSize(FontInfo info) => info.EdgeSize;
+        }
 
-                static float convertEdgeSize(FontInfo info) => info.EdgeSize;
-            }
+        private static ShadowShader createShadowShader(NicoKaraParser.Model.Font.Brush.BrushInfo info, ShadowSlide slide)
+        {
+            var color = convertColor(info);
+            var shadowOffset = convertShadowSlide(slide);
 
-            static ShadowShader createShadowShader(NicoKaraParser.Model.Font.Brush.BrushInfo info, ShadowSlide slide)
+            return new ShadowShader
             {
-                var color = convertColor(info);
-                var shadowOffset = convertShadowSlide(slide);
+                ShadowColour = color,
+                ShadowOffset = shadowOffset,
+            };
 
-                return new ShadowShader
-                {
-                    ShadowColour = color,
-                    ShadowOffset = shadowOffset,
-                };
+            static Vector2 convertShadowSlide(ShadowSlide side) => new(side.X, side.Y);
+        }
 
-                static Vector2 convertShadowSlide(ShadowSlide side) => new(side.X, side.Y);
-            }
+        private static Color4 convertColor(NicoKaraParser.Model.Font.Brush.BrushInfo info)
+        {
+            // todo: we only support pure colour conversion.
+            return convertSolidColor(info.SolidColor);
+            /*
+            Enum.TryParse(info.Type.ToString(), out BrushType type);
 
-            static Color4 convertColor(NicoKaraParser.Model.Font.Brush.BrushInfo info)
+            // Convert BrushGradient
+            var brushGradient = info.GradientPositions.Select((t, i) => new BrushInfo.BrushGradient { XPosition = t, Color = convertColor(info.GradientColors[i]) }).ToList();
+
+            return new BrushInfo
             {
-                // todo: we only support pure colour conversion.
-                return convertColor(info.SolidColor);
-                /*
-                Enum.TryParse(info.Type.ToString(), out BrushType type);
+                Type = type,
+                SolidColor = convertColor(info.SolidColor),
+                BrushGradients = brushGradient
+            };
+            */
 
-                // Convert BrushGradient
-                var brushGradient = info.GradientPositions.Select((t, i) => new BrushInfo.BrushGradient { XPosition = t, Color = convertColor(info.GradientColors[i]) }).ToList();
+            static Color4 convertSolidColor(Color color) => new(color.R, color.G, color.B, color.A);
+        }
 
-                return new BrushInfo
-                {
-                    Type = type,
-                    SolidColor = convertColor(info.SolidColor),
-                    BrushGradients = brushGradient
-                };
-                */
-
-                static Color4 convertColor(Color color) => new(color.R, color.G, color.B, color.A);
-            }
-
-            static FontUsage convertFontInfo(FontInfo info)
-            {
-                var family = info.FontName;
-                var size = Math.Max(info.CharSize, 8);
-                var weight = info.FontStyle == FontStyle.Regular ? "Regular" : "Bold";
-                return new FontUsage(family, size, weight);
-            }
+        private static FontUsage convertFontInfo(FontInfo info)
+        {
+            var family = info.FontName;
+            var size = Math.Max(info.CharSize, 8);
+            var weight = info.FontStyle == FontStyle.Regular ? "Regular" : "Bold";
+            return new FontUsage(family, size, weight);
         }
 
         private enum ApplyShaderPart

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraSkin.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 {
     public class NicoKaraSkin
     {
+        public LyricConfig DefaultLyricConfig { get; set; }
+
         public List<LayoutGroup> LayoutGroups { get; set; }
 
         public List<LyricStyle> Styles { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutAlignmentSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutAlignmentSection.cs
@@ -4,20 +4,18 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Layout
 {
-    internal class PositionSection : LayoutSection
+    internal class LayoutAlignmentSection : LayoutSection
     {
         private LabelledEnumDropdown<Anchor> alignmentDropdown;
         private LabelledRealTimeSliderBar<int> horizontalMarginSliderBar;
         private LabelledRealTimeSliderBar<int> verticalMarginSliderBar;
-        private LabelledEnumDropdown<KaraokeTextSmartHorizon> smartHorizonDropdown;
 
-        protected override string Title => "Position";
+        protected override string Title => "Layout";
 
         [BackgroundDependencyLoader]
         private void load(LayoutManager manager)
@@ -53,11 +51,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                         Default = 30
                     }
                 },
-                smartHorizonDropdown = new LabelledEnumDropdown<KaraokeTextSmartHorizon>
-                {
-                    Label = "Smart horizon",
-                    Description = "Smart horizon section",
-                }
             };
 
             manager.LoadedLayout.BindValueChanged(e =>
@@ -66,7 +59,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                 applyCurrent(alignmentDropdown.Current, layout.Alignment);
                 applyCurrent(horizontalMarginSliderBar.Current, layout.HorizontalMargin);
                 applyCurrent(verticalMarginSliderBar.Current, layout.VerticalMargin);
-                applyCurrent(smartHorizonDropdown.Current, layout.SmartHorizon);
 
                 static void applyCurrent<T>(Bindable<T> bindable, T value)
                     => bindable.Value = bindable.Default = value;
@@ -75,7 +67,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
             alignmentDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.Alignment = x.NewValue));
             horizontalMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.HorizontalMargin = x.NewValue));
             verticalMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.VerticalMargin = x.NewValue));
-            smartHorizonDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.SmartHorizon = x.NewValue));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Layout/LayoutScreen.cs
@@ -65,9 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                                     Size = new Vector2(1 / section_scale),
                                     Children = new LayoutSection[]
                                     {
-                                        new PositionSection(),
-                                        new IntervalSection(),
-                                        new RubyRomajiSection(),
+                                        new LayoutAlignmentSection(),
                                         new PreviewSection(),
                                     }
                                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/IntervalSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/IntervalSection.cs
@@ -5,9 +5,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Layout
+namespace osu.Game.Rulesets.Karaoke.Edit.LyricConfigs
 {
-    internal class IntervalSection : LayoutSection
+    internal class IntervalSection : LyricConfigSection
     {
         private LabelledRealTimeSliderBar<int> lyricIntervalSliderBar;
         private LabelledRealTimeSliderBar<int> rubyIntervalSliderBar;
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
         protected override string Title => "Interval";
 
         [BackgroundDependencyLoader]
-        private void load(LayoutManager manager)
+        private void load(LyricConfigManager manager)
         {
             Children = new[]
             {
@@ -58,20 +58,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                 }
             };
 
-            manager.LoadedLayout.BindValueChanged(e =>
+            manager.LoadedLyricConfig.BindValueChanged(e =>
             {
-                var layout = e.NewValue;
-                applyCurrent(lyricIntervalSliderBar.Current, layout.LyricsInterval);
-                applyCurrent(rubyIntervalSliderBar.Current, layout.RubyInterval);
-                applyCurrent(romajiIntervalSliderBar.Current, layout.RomajiInterval);
+                var lyricConfig = e.NewValue;
+                applyCurrent(lyricIntervalSliderBar.Current, lyricConfig.LyricsInterval);
+                applyCurrent(rubyIntervalSliderBar.Current, lyricConfig.RubyInterval);
+                applyCurrent(romajiIntervalSliderBar.Current, lyricConfig.RomajiInterval);
 
                 static void applyCurrent<T>(Bindable<T> bindable, T value)
                     => bindable.Value = bindable.Default = value;
             }, true);
 
-            lyricIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.LyricsInterval = x.NewValue));
-            rubyIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RubyInterval = x.NewValue));
-            romajiIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RomajiInterval = x.NewValue));
+            lyricIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.LyricsInterval = x.NewValue));
+            rubyIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RubyInterval = x.NewValue));
+            romajiIntervalSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RomajiInterval = x.NewValue));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/LyricConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/LyricConfigManager.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Skinning.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.LyricConfigs
+{
+    public class LyricConfigManager : Component
+    {
+        public readonly Bindable<LyricConfig> LoadedLyricConfig = new();
+
+        public void ApplyCurrentLyricConfigChange(Action<LyricConfig> action)
+        {
+            // todo: implement.
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/LyricConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/LyricConfigSection.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.LyricConfigs
+{
+    internal abstract class LyricConfigSection : Section
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/PositionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/PositionSection.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.LyricConfigs
+{
+    internal class PositionSection : LyricConfigSection
+    {
+        private LabelledEnumDropdown<KaraokeTextSmartHorizon> smartHorizonDropdown;
+
+        protected override string Title => "Position";
+
+        [BackgroundDependencyLoader]
+        private void load(LyricConfigManager manager)
+        {
+            Children = new Drawable[]
+            {
+                smartHorizonDropdown = new LabelledEnumDropdown<KaraokeTextSmartHorizon>
+                {
+                    Label = "Smart horizon",
+                    Description = "Smart horizon section",
+                }
+            };
+
+            manager.LoadedLyricConfig.BindValueChanged(e =>
+            {
+                var lyricConfig = e.NewValue;
+                applyCurrent(smartHorizonDropdown.Current, lyricConfig.SmartHorizon);
+
+                static void applyCurrent<T>(Bindable<T> bindable, T value)
+                    => bindable.Value = bindable.Default = value;
+            }, true);
+
+            smartHorizonDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.SmartHorizon = x.NewValue));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/RubyRomajiSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricConfigs/RubyRomajiSection.cs
@@ -8,9 +8,9 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Layout
+namespace osu.Game.Rulesets.Karaoke.Edit.LyricConfigs
 {
-    internal class RubyRomajiSection : LayoutSection
+    internal class RubyRomajiSection : LyricConfigSection
     {
         private LabelledEnumDropdown<LyricTextAlignment> rubyAlignmentDropdown;
         private LabelledEnumDropdown<LyricTextAlignment> romajiAlignmentDropdown;
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
         protected override string Title => "Ruby/Romaji";
 
         [BackgroundDependencyLoader]
-        private void load(LayoutManager manager)
+        private void load(LyricConfigManager manager)
         {
             Children = new Drawable[]
             {
@@ -60,22 +60,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Layout
                 }
             };
 
-            manager.LoadedLayout.BindValueChanged(e =>
+            manager.LoadedLyricConfig.BindValueChanged(e =>
             {
-                var layout = e.NewValue;
-                applyCurrent(rubyAlignmentDropdown.Current, layout.RubyAlignment);
-                applyCurrent(romajiAlignmentDropdown.Current, layout.RomajiAlignment);
-                applyCurrent(rubyMarginSliderBar.Current, layout.RubyMargin);
-                applyCurrent(romajiMarginSliderBar.Current, layout.RomajiMargin);
+                var lyricConfig = e.NewValue;
+                applyCurrent(rubyAlignmentDropdown.Current, lyricConfig.RubyAlignment);
+                applyCurrent(romajiAlignmentDropdown.Current, lyricConfig.RomajiAlignment);
+                applyCurrent(rubyMarginSliderBar.Current, lyricConfig.RubyMargin);
+                applyCurrent(romajiMarginSliderBar.Current, lyricConfig.RomajiMargin);
 
                 static void applyCurrent<T>(Bindable<T> bindable, T value)
                     => bindable.Value = bindable.Default = value;
             }, true);
 
-            rubyAlignmentDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RubyAlignment = x.NewValue));
-            romajiAlignmentDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RomajiAlignment = x.NewValue));
-            rubyMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RubyMargin = x.NewValue));
-            romajiMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLayoutChange(l => l.RomajiMargin = x.NewValue));
+            rubyAlignmentDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RubyAlignment = x.NewValue));
+            romajiAlignmentDropdown.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RomajiAlignment = x.NewValue));
+            rubyMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RubyMargin = x.NewValue));
+            romajiMarginSliderBar.Current.BindValueChanged(x => manager.ApplyCurrentLyricConfigChange(l => l.RomajiMargin = x.NewValue));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/KaraokeLyricEditorSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/KaraokeLyricEditorSkin.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     BindableLayouts.Add(i, new Bindable<LyricLayout>(karaokeSkin.Layouts[i]));
                 for (int i = 0; i < karaokeSkin.NoteSkins.Count; i++)
                     BindableNotes.Add(i, new Bindable<NoteSkin>(karaokeSkin.NoteSkins[i]));
+                BindableDefaultLyricConfig.Value = karaokeSkin.DefaultLyricConfig;
 
                 // Create lookups
                 BindableFontsLookup.Value = karaokeSkin.Styles.ToDictionary(k => karaokeSkin.Styles.IndexOf(k), y => y.Name);
@@ -67,7 +68,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             FontSize = 26;
         }
 
-        protected Bindable<LyricStyle> BindableFont => BindableStyles.Values.FirstOrDefault();
+        protected Bindable<LyricConfig> BindableFont => BindableDefaultLyricConfig;
 
         public float FontSize
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
@@ -139,11 +139,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
                 LeftLyricTextShaders = SkinConvertorTool.ConvertLeftSideShader(shaderManager, newStyle);
                 RightLyricTextShaders = SkinConvertorTool.ConvertRightSideShader(shaderManager, newStyle);
+            }, true);
+
+            skin.GetConfig<KaraokeSkinLookup, LyricConfig>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricConfig, HitObject.Singers))?.BindValueChanged(lyricConfig =>
+            {
+                var newConfig = lyricConfig.NewValue;
+                if (newConfig == null)
+                    return;
 
                 // Apply text font info
-                var lyricFont = newStyle.MainTextFont;
-                var rubyFont = newStyle.RubyTextFont;
-                var romajiFont = newStyle.RomajiTextFont;
+                var lyricFont = newConfig.MainTextFont;
+                var rubyFont = newConfig.RubyTextFont;
+                var romajiFont = newConfig.RomajiTextFont;
 
                 Font = getFont(lyricFont.Size);
                 RubyFont = getFont(rubyFont.Size);

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -119,12 +119,12 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
                 config.BindWith(KaraokeRulesetSetting.TranslateFont, translateFontUsageBindable);
             }
 
-            mainFontUsageBindable.BindValueChanged(_ => updateFontUsage());
-            rubyFontUsageBindable.BindValueChanged(_ => updateFontUsage());
-            rubyMarginBindable.BindValueChanged(_ => updateFontUsage());
-            romajiFontUsageBindable.BindValueChanged(_ => updateFontUsage());
-            romajiMarginBindable.BindValueChanged(_ => updateFontUsage());
-            translateFontUsageBindable.BindValueChanged(_ => updateFontUsage());
+            mainFontUsageBindable.BindValueChanged(_ => updateLyricConfig());
+            rubyFontUsageBindable.BindValueChanged(_ => updateLyricConfig());
+            rubyMarginBindable.BindValueChanged(_ => updateLyricConfig());
+            romajiFontUsageBindable.BindValueChanged(_ => updateLyricConfig());
+            romajiMarginBindable.BindValueChanged(_ => updateLyricConfig());
+            translateFontUsageBindable.BindValueChanged(_ => updateLyricConfig());
 
             // property in hitobject.
             singersBindable.BindValueChanged(_ => { updateFontStyle(); });
@@ -159,7 +159,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             base.ApplySkin(skin, allowFallback);
 
             updateFontStyle();
-            updateFontUsage();
+            updateLyricConfig();
             updateLayout();
         }
 
@@ -183,7 +183,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             }
         }
 
-        private void updateFontUsage()
+        private void updateLyricConfig()
         {
             if (CurrentSkin == null)
                 return;
@@ -191,23 +191,41 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var lyricStyle = CurrentSkin.GetConfig<KaraokeSkinLookup, LyricStyle>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricStyle, HitObject.Singers))?.Value;
+            var lyricConfig = CurrentSkin.GetConfig<KaraokeSkinLookup, LyricConfig>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricConfig, HitObject.Singers))?.Value;
 
             foreach (var lyricPiece in lyricPieces)
             {
                 // Apply text font info
-                var mainFont = lyricStyle?.MainTextFont;
+                var mainFont = lyricConfig?.MainTextFont;
                 lyricPiece.Font = getFont(KaraokeRulesetSetting.MainFont, mainFont);
 
-                var rubyFont = lyricStyle?.RubyTextFont;
+                var rubyFont = lyricConfig?.RubyTextFont;
                 lyricPiece.DisplayRuby = displayRubyBindable.Value;
                 lyricPiece.RubyFont = getFont(KaraokeRulesetSetting.RubyFont, rubyFont);
                 lyricPiece.RubyMargin = rubyMarginBindable.Value;
 
-                var romajiFont = lyricStyle?.RomajiTextFont;
+                var romajiFont = lyricConfig?.RomajiTextFont;
                 lyricPiece.DisplayRomaji = displayRomajiBindable.Value;
                 lyricPiece.RomajiFont = getFont(KaraokeRulesetSetting.RomajiFont, romajiFont);
                 lyricPiece.RomajiMargin = romajiMarginBindable.Value;
+
+                // todo: should make some config like KaraokeRulesetSetting.RomajiFont into KaraokeRulesetSetting.DefaultFontConfig.
+                if (lyricConfig == null)
+                    continue;
+
+                // Layout to text
+                lyricPiece.KaraokeTextSmartHorizon = lyricConfig.SmartHorizon;
+                lyricPiece.Spacing = new Vector2(lyricConfig.LyricsInterval, lyricPiece.Spacing.Y);
+
+                // Ruby
+                lyricPiece.RubySpacing = new Vector2(lyricConfig.RubyInterval, lyricPiece.RubySpacing.Y);
+                lyricPiece.RubyAlignment = lyricConfig.RubyAlignment;
+                lyricPiece.RubyMargin = lyricConfig.RubyMargin;
+
+                // Romaji
+                lyricPiece.RomajiSpacing = new Vector2(lyricConfig.RomajiInterval, lyricPiece.RomajiSpacing.Y);
+                lyricPiece.RomajiAlignment = lyricConfig.RomajiAlignment;
+                lyricPiece.RomajiMargin = lyricConfig.RomajiMargin;
             }
 
             // Apply translate font.
@@ -270,18 +288,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             {
                 // Layout to text
                 lyricPiece.Continuous = layout.Continuous;
-                lyricPiece.KaraokeTextSmartHorizon = layout.SmartHorizon;
-                lyricPiece.Spacing = new Vector2(layout.LyricsInterval, lyricPiece.Spacing.Y);
-
-                // Ruby
-                lyricPiece.RubySpacing = new Vector2(layout.RubyInterval, lyricPiece.RubySpacing.Y);
-                lyricPiece.RubyAlignment = layout.RubyAlignment;
-                lyricPiece.RubyMargin = layout.RubyMargin;
-
-                // Romaji
-                lyricPiece.RomajiSpacing = new Vector2(layout.RomajiInterval, lyricPiece.RomajiSpacing.Y);
-                lyricPiece.RomajiAlignment = layout.RomajiAlignment;
-                lyricPiece.RomajiMargin = layout.RomajiMargin;
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Resources/Skin/default.skin
+++ b/osu.Game.Rulesets.Karaoke/Resources/Skin/default.skin
@@ -1,4 +1,23 @@
 {
+  "default_lyric_config": {
+    "smart_horizon": 2,
+    "lyrics_interval": 4,
+    "ruby_interval": 2,
+    "ruby_margin": 4,
+    "main_text_font": {
+      "family": "Torus",
+      "weight": "Bold",
+      "size": 48.0
+    },
+    "ruby_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    },
+    "romaji_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    }
+  },
   "styles": [
     {
       "left_lyric_text_shaders": [
@@ -45,20 +64,7 @@
           ]
         }
       ],
-      "name": "標準配色",
-      "main_text_font": {
-        "family": "Torus",
-        "weight": "Bold",
-        "size": 48.0
-      },
-      "ruby_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      },
-      "romaji_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      }
+      "name": "標準配色"
     }
   ],
   "layout_groups": [
@@ -82,11 +88,7 @@
       "group": 1,
       "alignment": 36,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "id": 2,
@@ -94,85 +96,54 @@
       "group": 1,
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 130,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 130
     },
     {
       "id": 3,
       "name": "下-3",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 215,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 215
     },
     {
       "id": 4,
       "name": "下-4",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 300,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 300
     },
     {
       "id": 5,
       "name": "上-1",
       "alignment": 9,
       "horizontal_margin": 30,
-      "vertical_margin": 115,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 115
     },
     {
       "id": 6,
       "name": "上-2",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 200,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 200
     },
     {
       "id": 7,
       "name": "上-3",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 285,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 285
     },
     {
       "id": 8,
       "name": "上-4",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 370,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 370
     },
     {
       "id": 9,
       "name": "中",
-      "alignment": 18,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "alignment": 18
     },
     {
       "id": 10,
@@ -180,56 +151,42 @@
       "alignment": 12,
       "horizontal_margin": 30,
       "vertical_margin": 45,
-      "continuous": true,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "continuous": true
     },
     {
       "id": 11,
       "name": "情報-左上",
       "alignment": 9,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "id": 12,
       "name": "情報-右上",
       "alignment": 33,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "id": 13,
       "name": "情報-左下",
       "alignment": 12,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "id": 14,
       "name": "情報-右下",
       "alignment": 36,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     },
     {
       "id": 15,
       "name": "情報-中央",
       "alignment": 18,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     }
   ],
   "note_skins": [

--- a/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
+++ b/osu.Game.Rulesets.Karaoke/Resources/Skin/editor.skin
@@ -1,20 +1,26 @@
 {
+  "default_lyric_config": {
+    "smart_horizon": 2,
+    "lyrics_interval": 4,
+    "ruby_interval": 2,
+    "ruby_margin": 4,
+    "main_text_font": {
+      "family": "Torus",
+      "weight": "Bold",
+      "size": 48.0
+    },
+    "ruby_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    },
+    "romaji_text_font": {
+      "family": "Torus",
+      "weight": "Bold"
+    }
+  },
   "styles": [
     {
-      "name": "標準配色",
-      "main_text_font": {
-        "family": "Torus",
-        "weight": "Bold",
-        "size": 48.0
-      },
-      "ruby_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      },
-      "romaji_text_font": {
-        "family": "Torus",
-        "weight": "Bold"
-      }
+      "name": "標準配色"
     }
   ],
   "layouts": [
@@ -22,11 +28,7 @@
       "name": "下-1",
       "alignment": 36,
       "horizontal_margin": 30,
-      "vertical_margin": 45,
-      "smart_horizon": 2,
-      "lyrics_interval": 4,
-      "ruby_interval": 2,
-      "ruby_margin": 4
+      "vertical_margin": 45
     }
   ],
   "note_skins": [

--- a/osu.Game.Rulesets.Karaoke/Skinning/DefaultKaraokeSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/DefaultKaraokeSkin.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
                     BindableLayouts.Add(i, new Bindable<LyricLayout>(karaokeSkin.Layouts[i]));
                 for (int i = 0; i < karaokeSkin.NoteSkins.Count; i++)
                     BindableNotes.Add(i, new Bindable<NoteSkin>(karaokeSkin.NoteSkins[i]));
+                BindableDefaultLyricConfig.Value = karaokeSkin.DefaultLyricConfig;
 
                 // Create lookups
                 BindableFontsLookup.Value = karaokeSkin.Styles.ToDictionary(k => karaokeSkin.Styles.IndexOf(k), y => y.Name);

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
         public readonly IDictionary<int, Bindable<LyricLayout>> BindableLayouts = new Dictionary<int, Bindable<LyricLayout>>();
         public readonly IDictionary<int, Bindable<LayoutGroup>> BindableLayoutGroups = new Dictionary<int, Bindable<LayoutGroup>>();
         public readonly IDictionary<int, Bindable<NoteSkin>> BindableNotes = new Dictionary<int, Bindable<NoteSkin>>();
+        public readonly Bindable<LyricConfig> BindableDefaultLyricConfig = new();
 
         public readonly Bindable<IDictionary<int, string>> BindableFontsLookup = new();
         public readonly Bindable<IDictionary<int, string>> BindableLayoutsLookup = new();

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
                     {
                         KaraokeSkinConfiguration.LyricStyle => SkinUtils.As<TValue>(BindableStyles[lookupNumber]),
                         KaraokeSkinConfiguration.LyricLayout => SkinUtils.As<TValue>(BindableLayouts[lookupNumber]),
+                        KaraokeSkinConfiguration.LyricConfig => SkinUtils.As<TValue>(BindableDefaultLyricConfig),
                         KaraokeSkinConfiguration.NoteStyle => SkinUtils.As<TValue>(BindableNotes[lookupNumber]),
                         _ => throw new InvalidEnumArgumentException(nameof(config))
                     };

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinConfiguration.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
 
         LyricLayout,
 
+        LyricConfig,
+
         NoteStyle,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinLookup.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkinLookup.cs
@@ -26,8 +26,16 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
         public KaraokeSkinLookup(KaraokeSkinConfiguration config, int[] singers)
             : this(config, SingerUtils.GetShiftingStyleIndex(singers))
         {
-            if (config != KaraokeSkinConfiguration.LyricStyle && config != KaraokeSkinConfiguration.NoteStyle)
-                throw new InvalidEnumArgumentException($"Only {KaraokeSkinConfiguration.LyricStyle} and {KaraokeSkinConfiguration.NoteStyle} can call this ctor.");
+            switch (config)
+            {
+                case KaraokeSkinConfiguration.LyricStyle:
+                case KaraokeSkinConfiguration.LyricConfig:
+                case KaraokeSkinConfiguration.NoteStyle:
+                    return;
+
+                default:
+                    throw new InvalidEnumArgumentException($"Cannot call lookup with {config}");
+            }
         }
 
         public KaraokeSkinLookup(KaraokeSkinConfiguration config, int lookup)

--- a/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/Layouts/LyricLayout.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/Layouts/LyricLayout.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts
 {
@@ -42,53 +41,5 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts
         /// ???
         /// </summary>
         public bool Continuous { get; set; }
-
-        /// <summary>
-        /// ???
-        /// todo: should be moved into config.
-        /// </summary>
-        public KaraokeTextSmartHorizon SmartHorizon { get; set; } = KaraokeTextSmartHorizon.None;
-
-        /// <summary>
-        /// Interval between lyric texts
-        /// todo: should be moved into config.
-        /// </summary>
-        public int LyricsInterval { get; set; }
-
-        /// <summary>
-        /// Interval between lyric rubies
-        /// todo: should be moved into config.
-        /// </summary>
-        public int RubyInterval { get; set; }
-
-        /// <summary>
-        /// Interval between lyric romaji
-        /// todo: should be moved into config.
-        /// </summary>
-        public int RomajiInterval { get; set; }
-
-        /// <summary>
-        /// Ruby position alignment
-        /// todo: should be moved into config.
-        /// </summary>
-        public LyricTextAlignment RubyAlignment { get; set; } = LyricTextAlignment.Auto;
-
-        /// <summary>
-        /// Ruby position alignment
-        /// todo: should be moved into config.
-        /// </summary>
-        public LyricTextAlignment RomajiAlignment { get; set; } = LyricTextAlignment.Auto;
-
-        /// <summary>
-        /// Interval between lyric text and ruby
-        /// todo: should be moved into config.
-        /// </summary>
-        public int RubyMargin { get; set; }
-
-        /// <summary>
-        /// (Additional) Interval between lyric text and romaji
-        /// todo: should be moved into config.
-        /// </summary>
-        public int RomajiMargin { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/Layouts/LyricLayout.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/Layouts/LyricLayout.cs
@@ -45,41 +45,49 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas.Layouts
 
         /// <summary>
         /// ???
+        /// todo: should be moved into config.
         /// </summary>
         public KaraokeTextSmartHorizon SmartHorizon { get; set; } = KaraokeTextSmartHorizon.None;
 
         /// <summary>
         /// Interval between lyric texts
+        /// todo: should be moved into config.
         /// </summary>
         public int LyricsInterval { get; set; }
 
         /// <summary>
         /// Interval between lyric rubies
+        /// todo: should be moved into config.
         /// </summary>
         public int RubyInterval { get; set; }
 
         /// <summary>
         /// Interval between lyric romaji
+        /// todo: should be moved into config.
         /// </summary>
         public int RomajiInterval { get; set; }
 
         /// <summary>
         /// Ruby position alignment
+        /// todo: should be moved into config.
         /// </summary>
         public LyricTextAlignment RubyAlignment { get; set; } = LyricTextAlignment.Auto;
 
         /// <summary>
         /// Ruby position alignment
+        /// todo: should be moved into config.
         /// </summary>
         public LyricTextAlignment RomajiAlignment { get; set; } = LyricTextAlignment.Auto;
 
         /// <summary>
         /// Interval between lyric text and ruby
+        /// todo: should be moved into config.
         /// </summary>
         public int RubyMargin { get; set; }
 
         /// <summary>
         /// (Additional) Interval between lyric text and romaji
+        /// todo: should be moved into config.
         /// </summary>
         public int RomajiMargin { get; set; }
     }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/LyricConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/LyricConfig.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas
+{
+    public class LyricConfig
+    {
+        public string Name { get; set; }
+
+        /// <summary>
+        /// ???
+        /// </summary>
+        public KaraokeTextSmartHorizon SmartHorizon { get; set; } = KaraokeTextSmartHorizon.None;
+
+        /// <summary>
+        /// Interval between lyric texts
+        /// </summary>
+        public int LyricsInterval { get; set; }
+
+        /// <summary>
+        /// Interval between lyric rubies
+        /// </summary>
+        public int RubyInterval { get; set; }
+
+        /// <summary>
+        /// Interval between lyric romaji
+        /// </summary>
+        public int RomajiInterval { get; set; }
+
+        /// <summary>
+        /// Ruby position alignment
+        /// </summary>
+        public LyricTextAlignment RubyAlignment { get; set; } = LyricTextAlignment.Auto;
+
+        /// <summary>
+        /// Ruby position alignment
+        /// </summary>
+        public LyricTextAlignment RomajiAlignment { get; set; } = LyricTextAlignment.Auto;
+
+        /// <summary>
+        /// Interval between lyric text and ruby
+        /// </summary>
+        public int RubyMargin { get; set; }
+
+        /// <summary>
+        /// (Additional) Interval between lyric text and romaji
+        /// </summary>
+        public int RomajiMargin { get; set; }
+
+        /// <summary>
+        /// Main text font
+        /// </summary>
+        public FontUsage MainTextFont { get; set; } = new("Torus", 48, "Bold");
+
+        /// <summary>
+        /// Ruby text font
+        /// </summary>
+        public FontUsage RubyTextFont { get; set; } = new("Torus", 20, "Bold");
+
+        /// <summary>
+        /// Romaji text font
+        /// </summary>
+        public FontUsage RomajiTextFont { get; set; } = new("Torus", 20, "Bold");
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/LyricStyle.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Metadatas/LyricStyle.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas
 {
@@ -20,14 +19,5 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Metadatas
         ///  todo: should use <see cref="ICustomizedShader"/> instead because we should save <see cref="StepShader"/> also.
         /// </summary>
         public List<IShader> RightLyricTextShaders = new();
-
-        // todo: should be moved into config.
-        public FontUsage MainTextFont { get; set; } = new("Torus", 48, "Bold");
-
-        // todo: should be moved into config.
-        public FontUsage RubyTextFont { get; set; } = new("Torus", 20, "Bold");
-
-        // todo: should be moved into config.
-        public FontUsage RomajiTextFont { get; set; } = new("Torus", 20, "Bold");
     }
 }


### PR DESCRIPTION
Move some lyric font releated config into lyric config class.
It can be counted as part implementation of #901

As now:
- Lyric layout: focus on lyric position
- Lyric style: focus on shader effect.
- Lyric config: focus on other remain setting about font or char spacing. All lyric will use same config now.