### PR TITLE
Adjust struct in karaoke skin editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/KaraokeSkinEditorScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/KaraokeSkinEditorScreenTestScene.cs
@@ -2,15 +2,35 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Screens.Skin;
+using osu.Game.Rulesets.Karaoke.Skinning;
+using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens
 {
     public abstract class KaraokeSkinEditorScreenTestScene<T> : EditorClockTestScene where T : KaraokeSkinEditorScreen
     {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Pink);
+
+        private KaraokeSkin karaokeSkin;
+
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skinManager)
+        {
+            // because skin is compared by id, so should change id to let skin manager info knows that skin has been changed.
+            var defaultSkin = DefaultKaraokeSkin.Default;
+            defaultSkin.ID = 100;
+            skinManager.CurrentSkinInfo.Value = defaultSkin;
+
+            karaokeSkin = skinManager.CurrentSkin.Value as KaraokeSkin;
+        }
+
         [Test]
         public void TestKaraoke() => runForRuleset(new KaraokeRuleset().RulesetInfo);
 
@@ -18,13 +38,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens
         {
             AddStep("create screen", () =>
             {
-                Child = CreateEditorScreen().With(x =>
+                Child = CreateEditorScreen(karaokeSkin).With(x =>
                 {
                     x.State.Value = Visibility.Visible;
                 });
             });
         }
 
-        protected abstract T CreateEditorScreen();
+        protected abstract T CreateEditorScreen(KaraokeSkin karaokeSkin);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneConfigScreen.cs
@@ -2,11 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Config;
+using osu.Game.Rulesets.Karaoke.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens
 {
     public class TestSceneConfigScreen : KaraokeSkinEditorScreenTestScene<ConfigScreen>
     {
-        protected override ConfigScreen CreateEditorScreen() => new();
+        protected override ConfigScreen CreateEditorScreen(KaraokeSkin karaokeSkin) => new(karaokeSkin);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneKaraokeSkinEditor.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneKaraokeSkinEditor.cs
@@ -4,7 +4,9 @@
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Screens.Skin;
+using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Screens.Edit;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens
 {
@@ -14,13 +16,22 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens
         [Cached(typeof(EditorBeatmap))]
         private readonly EditorBeatmap editorBeatmap = new(new KaraokeBeatmap());
 
-        protected override KaraokeSkinEditor CreateScreen() => new();
+        private KaraokeSkin karaokeSkin;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(SkinManager skinManager)
         {
             // todo: karaoke skin editor might not need editor click eventually?
             Dependencies.Cache(new EditorClock());
+
+            // because skin is compared by id, so should change id to let skin manager info knows that skin has been changed.
+            var defaultSkin = DefaultKaraokeSkin.Default;
+            defaultSkin.ID = 100;
+            skinManager.CurrentSkinInfo.Value = defaultSkin;
+
+            karaokeSkin = skinManager.CurrentSkin.Value as KaraokeSkin;
         }
+
+        protected override KaraokeSkinEditor CreateScreen() => new(karaokeSkin);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneLayoutScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneLayoutScreen.cs
@@ -2,25 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Layout;
 using osu.Game.Rulesets.Karaoke.Skinning;
-using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens
 {
     [TestFixture]
     public class TestSceneLayoutScreen : KaraokeSkinEditorScreenTestScene<LayoutScreen>
     {
-        protected override LayoutScreen CreateEditorScreen() => new();
-
-        [BackgroundDependencyLoader]
-        private void load(SkinManager skinManager)
-        {
-            // because skin is compared by id, so should change id to let skin manager info knows that skin has been changed.
-            var defaultSkin = DefaultKaraokeSkin.Default;
-            defaultSkin.ID = 100;
-            skinManager.CurrentSkinInfo.Value = defaultSkin;
-        }
+        protected override LayoutScreen CreateEditorScreen(KaraokeSkin karaokeSkin) => new(karaokeSkin);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneStyleScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/TestSceneStyleScreen.cs
@@ -2,25 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Style;
 using osu.Game.Rulesets.Karaoke.Skinning;
-using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens
 {
     [TestFixture]
     public class TestSceneStyleScreen : KaraokeSkinEditorScreenTestScene<StyleScreen>
     {
-        protected override StyleScreen CreateEditorScreen() => new();
-
-        [BackgroundDependencyLoader]
-        private void load(SkinManager skinManager)
-        {
-            // because skin is compared by id, so should change id to let skin manager info knows that skin has been changed.
-            var defaultSkin = DefaultKaraokeSkin.Default;
-            defaultSkin.ID = 100;
-            skinManager.CurrentSkinInfo.Value = defaultSkin;
-        }
+        protected override StyleScreen CreateEditorScreen(KaraokeSkin karaokeSkin) => new(karaokeSkin);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorScreen.cs
@@ -5,12 +5,9 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit
 {
-    /// <summary>
-    /// TODO: eventually make this inherit Screen and add a local screen stack inside the Editor.
-    /// </summary>
-    public class KaraokeEditorScreen : GenericEditorScreen<KaraokeEditorScreenMode>
+    public abstract class KaraokeEditorScreen : GenericEditorScreen<KaraokeEditorScreenMode>
     {
-        public KaraokeEditorScreen(KaraokeEditorScreenMode type)
+        protected KaraokeEditorScreen(KaraokeEditorScreenMode type)
             : base(type)
         {
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Config/ConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Config/ConfigScreen.cs
@@ -1,13 +1,36 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Skinning;
+
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Config
 {
     public class ConfigScreen : KaraokeSkinEditorScreen
     {
-        public ConfigScreen()
-            : base(KaraokeSkinEditorScreenMode.Config)
+        [Cached]
+        protected readonly LyricConfigManager ConfigManager;
+
+        public ConfigScreen(KaraokeSkin skin)
+            : base(skin, KaraokeSkinEditorScreenMode.Config)
         {
+            AddInternal(ConfigManager = new LyricConfigManager());
         }
+
+        protected override Section[] CreateSelectionContainer()
+            => new Section[] { };
+
+        protected override Section[] CreatePropertiesContainer()
+            => new Section[]
+            {
+                new IntervalSection(),
+                new PositionSection(),
+                new RubyRomajiSection(),
+            };
+
+        protected override Container CreatePreviewArea()
+            => new();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Config/LyricConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Config/LyricConfigManager.cs
@@ -2,19 +2,43 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Skinning;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Config
 {
     public class LyricConfigManager : Component
     {
+        public readonly BindableList<LyricConfig> Configs = new();
+
         public readonly Bindable<LyricConfig> LoadedLyricConfig = new();
+
+        public readonly Bindable<LyricConfig> EditLyricConfig = new();
+
+        [Resolved]
+        private ISkinSource source { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var lookup = new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricConfig, 0);
+            var lyricConfig = source.GetConfig<KaraokeSkinLookup, LyricConfig>(lookup)?.Value;
+            if (lyricConfig != null)
+                Configs.Add(lyricConfig);
+
+            LoadedLyricConfig.Value = Configs.FirstOrDefault();
+            EditLyricConfig.Value = Configs.FirstOrDefault();
+        }
 
         public void ApplyCurrentLyricConfigChange(Action<LyricConfig> action)
         {
-            // todo: implement.
+            action?.Invoke(LoadedLyricConfig.Value);
+            LoadedLyricConfig.TriggerChange();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditor.cs
@@ -2,28 +2,41 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Screens.Edit;
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Config;
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Layout;
 using osu.Game.Rulesets.Karaoke.Screens.Skin.Style;
+using osu.Game.Rulesets.Karaoke.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin
 {
     public class KaraokeSkinEditor : GenericEditor<KaraokeSkinEditorScreenMode>
     {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Pink);
+
+        private readonly KaraokeSkin skin;
+
+        public KaraokeSkinEditor(KaraokeSkin skin)
+        {
+            this.skin = skin;
+        }
+
         protected override GenericEditorScreen<KaraokeSkinEditorScreenMode> GenerateScreen(KaraokeSkinEditorScreenMode screenMode)
         {
             switch (screenMode)
             {
                 case KaraokeSkinEditorScreenMode.Config:
-                    return new ConfigScreen();
+                    return new ConfigScreen(skin);
 
                 case KaraokeSkinEditorScreenMode.Layout:
-                    return new LayoutScreen();
+                    return new LayoutScreen(skin);
 
                 case KaraokeSkinEditorScreenMode.Style:
-                    return new StyleScreen();
+                    return new StyleScreen(skin);
 
                 default:
                     throw new InvalidOperationException("Editor menu bar switched to an unsupported mode");

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditorScreen.cs
@@ -5,9 +5,9 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin
 {
-    public class KaraokeSkinEditorScreen : GenericEditorScreen<KaraokeSkinEditorScreenMode>
+    public abstract class KaraokeSkinEditorScreen : GenericEditorScreen<KaraokeSkinEditorScreenMode>
     {
-        public KaraokeSkinEditorScreen(KaraokeSkinEditorScreenMode type)
+        protected KaraokeSkinEditorScreen(KaraokeSkinEditorScreenMode type)
             : base(type)
         {
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/KaraokeSkinEditorScreen.cs
@@ -1,15 +1,123 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Screens.Edit;
+using osu.Game.Rulesets.Karaoke.Skinning;
+using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin
 {
     public abstract class KaraokeSkinEditorScreen : GenericEditorScreen<KaraokeSkinEditorScreenMode>
     {
-        protected KaraokeSkinEditorScreen(KaraokeSkinEditorScreenMode type)
+        private const float section_scale = 0.75f;
+        private const float left_column_width = 200;
+        private const float right_column_width = 300;
+
+        private readonly KaraokeSkin skin;
+
+        protected KaraokeSkinEditorScreen(KaraokeSkin skin, KaraokeSkinEditorScreenMode type)
             : base(type)
         {
+            this.skin = skin;
         }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            AddInternal(new SkinProvidingContainer(skin)
+            {
+                Children = new[]
+                {
+                    new Container
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Width = left_column_width,
+                        RelativeSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Name = "Background",
+                                Colour = colourProvider.Background2,
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            new OsuScrollContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Scale = new Vector2(section_scale),
+                                Size = new Vector2(1 / section_scale),
+                                Child = new FillFlowContainer<Section>
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = CreateSelectionContainer(),
+                                }
+                            }
+                        }
+                    },
+                    new Container
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Width = right_column_width,
+                        RelativeSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Name = "Background",
+                                Colour = colourProvider.Background2,
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            new OsuScrollContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Scale = new Vector2(section_scale),
+                                Size = new Vector2(1 / section_scale),
+                                Child = new FillFlowContainer<Section>
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = CreatePropertiesContainer(),
+                                }
+                            }
+                        }
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = left_column_width, Right = right_column_width },
+                        Child = CreatePreviewArea(),
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Create all sections with selectable options.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Section[] CreateSelectionContainer();
+
+        /// <summary>
+        /// Create properties for the skin part.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Section[] CreatePropertiesContainer();
+
+        /// <summary>
+        /// Create preview container.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Container CreatePreviewArea();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutScreen.cs
@@ -4,103 +4,41 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics.Containers;
-using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Layout
 {
     public class LayoutScreen : KaraokeSkinEditorScreen
     {
-        private const float section_scale = 0.75f;
-
-        [Cached]
-        protected readonly OverlayColourProvider ColourProvider;
-
         [Cached]
         protected readonly LayoutManager LayoutManager;
 
-        public LayoutScreen()
-            : base(KaraokeSkinEditorScreenMode.Layout)
+        public LayoutScreen(KaraokeSkin skin)
+            : base(skin, KaraokeSkinEditorScreenMode.Layout)
         {
-            ColourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
             AddInternal(LayoutManager = new LayoutManager());
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AddInternal(new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(50),
-                Child = new GridContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    ColumnDimensions = new[]
-                    {
-                        new Dimension(GridSizeMode.Relative, 0.3f),
-                        new Dimension()
-                    },
-                    Content = new[]
-                    {
-                        new Drawable[]
-                        {
-                            new Container
-                            {
-                                Name = "Layout adjustment area",
-                                RelativeSizeAxes = Axes.Both,
-                                Masking = true,
-                                CornerRadius = 10,
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        Colour = ColourProvider.Background2,
-                                        RelativeSizeAxes = Axes.Both,
-                                    },
-                                    new SectionsContainer<LayoutSection>
-                                    {
-                                        FixedHeader = new LayoutScreenHeader(),
-                                        RelativeSizeAxes = Axes.Both,
-                                        Scale = new Vector2(section_scale),
-                                        Size = new Vector2(1 / section_scale),
-                                        Children = new LayoutSection[]
-                                        {
-                                            new LayoutAlignmentSection(),
-                                            new PreviewSection(),
-                                        }
-                                    }
-                                }
-                            },
-                            new LayoutPreview
-                            {
-                                Name = "Layout preview area",
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                Size = new Vector2(0.95f),
-                                RelativeSizeAxes = Axes.Both
-                            },
-                        }
-                    },
-                }
-            });
-        }
+        protected override Section[] CreateSelectionContainer()
+            => new Section[] { };
 
-        internal class LayoutScreenHeader : OverlayHeader
-        {
-            protected override OverlayTitle CreateTitle() => new LayoutScreenTitle();
-
-            private class LayoutScreenTitle : OverlayTitle
+        protected override Section[] CreatePropertiesContainer()
+            => new Section[]
             {
-                public LayoutScreenTitle()
-                {
-                    Title = "layout";
-                    Description = "create layout of your beatmap";
-                    IconTexture = "Icons/Hexacons/social";
-                }
-            }
-        }
+                new LayoutAlignmentSection(),
+                new PreviewSection(),
+            };
+
+        protected override Container CreatePreviewArea()
+            => new LayoutPreview
+            {
+                Name = "Layout preview area",
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(0.95f),
+                RelativeSizeAxes = Axes.Both
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Style/StyleScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Style/StyleScreen.cs
@@ -3,13 +3,9 @@
 
 using System.ComponentModel;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Skinning;
 using osuTK;
 using Container = osu.Framework.Graphics.Containers.Container;
 
@@ -18,162 +14,50 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Style
     public class StyleScreen : KaraokeSkinEditorScreen
     {
         [Cached]
-        protected readonly OverlayColourProvider ColourProvider;
-
-        [Cached]
         protected readonly StyleManager StyleManager;
 
-        private StyleSectionsContainer styleSections;
-        private Container previewContainer;
-
-        public StyleScreen()
-            : base(KaraokeSkinEditorScreenMode.Style)
+        public StyleScreen(KaraokeSkin skin)
+            : base(skin, KaraokeSkinEditorScreenMode.Style)
         {
-            ColourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
             AddInternal(StyleManager = new StyleManager());
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AddInternal(new Container
+        protected override Section[] CreateSelectionContainer()
+            => new Section[] { };
+
+        protected override Section[] CreatePropertiesContainer()
+            => new Section[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(50),
-                Child = new GridContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    ColumnDimensions = new[]
-                    {
-                        new Dimension(GridSizeMode.Relative, 0.3f),
-                        new Dimension()
-                    },
-                    Content = new[]
-                    {
-                        new Drawable[]
-                        {
-                            new Container
-                            {
-                                Name = "Layout adjustment area",
-                                RelativeSizeAxes = Axes.Both,
-                                Masking = true,
-                                CornerRadius = 10,
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        Colour = ColourProvider.Background2,
-                                        RelativeSizeAxes = Axes.Both,
-                                    },
-                                    styleSections = new StyleSectionsContainer
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                    }
-                                }
-                            },
-                            previewContainer = new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                            }
-                        }
-                    },
-                }
-            });
+                // style
+                new LyricColorSection(),
+                new LyricFontSection(),
+                new LyricShadowSection(),
+                // note
+                new NoteColorSection(),
+                new NoteFontSection(),
+            };
 
-            styleSections.BindableStyle.BindValueChanged(e =>
+        protected override Container CreatePreviewArea()
+            => new LyricStylePreview
             {
-                previewContainer.Child = e.NewValue switch
-                {
-                    Style.Lyric => new LyricStylePreview
-                    {
-                        Name = "Lyric style preview area",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Size = new Vector2(0.95f),
-                        RelativeSizeAxes = Axes.Both
-                    },
-                    Style.Note => new NoteStylePreview
-                    {
-                        Name = "Note style preview area",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Size = new Vector2(0.95f),
-                        RelativeSizeAxes = Axes.Both
-                    },
-                    _ => previewContainer.Child
-                };
-            }, true);
-        }
+                Name = "Lyric style preview area",
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(0.95f),
+                RelativeSizeAxes = Axes.Both
+            };
 
-        internal class StyleSectionsContainer : SectionsContainer<StyleSection>
-        {
-            private readonly StyleScreenHeader header;
-
-            private const float section_scale = 0.75f;
-
-            public IBindable<Style> BindableStyle => header.BindableStyle;
-
-            public StyleSectionsContainer()
+        /*
+        protected override Container CreatePreviewArea()
+            => new NoteStylePreview
             {
-                FixedHeader = header = new StyleScreenHeader();
-
-                Scale = new Vector2(section_scale);
-                Size = new Vector2(1 / section_scale);
-
-                header.BindableStyle.BindValueChanged(e =>
-                {
-                    Children = e.NewValue switch
-                    {
-                        Style.Lyric => new StyleSection[]
-                        {
-                            new LyricColorSection(),
-                            new LyricFontSection(),
-                            new LyricShadowSection(),
-                        },
-                        Style.Note => new StyleSection[]
-                        {
-                            new NoteColorSection(),
-                            new NoteFontSection(),
-                        },
-                        _ => Children
-                    };
-                }, true);
-            }
-
-            internal class StyleScreenHeader : OverlayHeader
-            {
-                public Bindable<Style> BindableStyle = new();
-
-                protected override OverlayTitle CreateTitle() => new LayoutScreenTitle();
-
-                protected override Drawable CreateTitleContent()
-                {
-                    return new Container
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Padding = new MarginPadding { Left = 100 },
-                        Height = 40,
-                        Child = new OsuEnumDropdown<Style>
-                        {
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            RelativeSizeAxes = Axes.X,
-                            Current = BindableStyle,
-                        }
-                    };
-                }
-
-                private class LayoutScreenTitle : OverlayTitle
-                {
-                    public LayoutScreenTitle()
-                    {
-                        Title = "style";
-                        Description = "create style of your beatmap";
-                        IconTexture = "Icons/Hexacons/social";
-                    }
-                }
-            }
-        }
+                Name = "Note style preview area",
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(0.95f),
+                RelativeSizeAxes = Axes.Both
+            };
+        */
     }
 
     public enum Style


### PR DESCRIPTION
The first implementation of #930.
This is the first implementation of the karaoke skin editor.
What's added in this PR:
- Implemented base karaoke skin editor sub-screen.
- change all existing components into skin editor style
- fix all related test cases broken.

![image](https://user-images.githubusercontent.com/9100368/144057493-6faa8204-0f4a-4af0-89a4-1a7b7fb7f3e8.png)
![image](https://user-images.githubusercontent.com/9100368/144057541-31c9675f-8530-4e4d-8565-894777a473ea.png)
![image](https://user-images.githubusercontent.com/9100368/144057572-fe709b58-47be-4aa6-bf6b-e25bc48feb0b.png)
All screen broken can be ignored because they will be re-design eventually.