### PR TITLE
implement bindables utils to sync data with two different type of bindable list.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/BindablesUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/BindablesUtilsTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Utils
+{
+    public class BindablesUtilsTest
+    {
+        [TestCase(null, null, new[] { 1 }, null, new[] { 1 }, new[] { 1 })]
+        [TestCase(null, null, null, new[] { 1 }, new[] { 1 }, new[] { 1 })]
+        [TestCase(null, null, new[] { 1 }, new[] { 2 }, new[] { 1, 2 }, new[] { 1, 2 })]
+        [TestCase(new[] { 1 }, new[] { 2 }, null, null, new[] { 1, 2 }, new[] { 2, 1 })]
+        [TestCase(new[] { 1 }, new[] { 2 }, new[] { 3 }, null, new[] { 1, 2, 3 }, new[] { 2, 1, 3 })]
+        [TestCase(new[] { 1 }, new[] { 2 }, null, new[] { 3 }, new[] { 1, 2, 3 }, new[] { 2, 1, 3 })]
+        public void TestSyncWithAddItems(int[] firstDefaultValues, int[] secondDefaultValues, int[] firstNewValues, int[] secondNewValues, int[] actualFirstValues, int[] actualSecondValues)
+        {
+            var firstBindableList = new BindableList<int>(firstDefaultValues);
+            var secondBindableList = new BindableList<int>(secondDefaultValues);
+
+            BindablesUtils.Sync(firstBindableList, secondBindableList);
+
+            if (firstNewValues != null)
+                firstBindableList.AddRange(firstNewValues);
+
+            if (secondNewValues != null)
+                secondBindableList.AddRange(secondNewValues);
+
+            Assert.AreEqual(firstBindableList.ToArray(), actualFirstValues);
+            Assert.AreEqual(secondBindableList.ToArray(), actualSecondValues);
+        }
+
+        [TestCase(null, null, new[] { 1 }, null, new int[] { }, new int[] { })] // should not clear if has no values.
+        [TestCase(null, null, null, new[] { 1 }, new int[] { }, new int[] { })]
+        [TestCase(null, null, new[] { 1 }, new[] { 2 }, new int[] { }, new int[] { })]
+        [TestCase(new[] { 1 }, new[] { 2 }, new[] { 1 }, null, new[] { 2 }, new[] { 2 })] // matched value should be clear
+        [TestCase(new[] { 1 }, new[] { 2 }, null, new[] { 1 }, new[] { 2 }, new[] { 2 })]
+        [TestCase(new[] { 1 }, new[] { 2 }, new[] { 1 }, new[] { 2 }, new int[] { }, new int[] { })] // all value should be clear
+        [TestCase(new[] { 1 }, new[] { 2 }, new[] { 2 }, new[] { 1 }, new int[] { }, new int[] { })]
+        [TestCase(new[] { 1 }, new[] { 2 }, new[] { 3 }, null, new[] { 1, 2 }, new[] { 2, 1 })] // should not clear value if not contains.
+        [TestCase(new[] { 1 }, new[] { 2 }, null, new[] { 3 }, new[] { 1, 2 }, new[] { 2, 1 })]
+        public void TestSyncWithRemoveItems(int[] firstDefaultValues, int[] secondDefaultValues, int[] firstRemoveValues, int[] secondRemoveValues, int[] actualFirstValues, int[] actualSecondValues)
+        {
+            var firstBindableList = new BindableList<int>(firstDefaultValues);
+            var secondBindableList = new BindableList<int>(secondDefaultValues);
+
+            BindablesUtils.Sync(firstBindableList, secondBindableList);
+
+            if (firstRemoveValues != null)
+                firstBindableList.RemoveAll(firstRemoveValues.Contains);
+
+            if (secondRemoveValues != null)
+                secondBindableList.RemoveAll(secondRemoveValues.Contains);
+
+            Assert.AreEqual(firstBindableList.ToArray(), actualFirstValues);
+            Assert.AreEqual(secondBindableList.ToArray(), actualSecondValues);
+        }
+
+        [TestCase(new[] { 1 }, null, null, new[] { 1 })] // should sync default value also.
+        [TestCase(new[] { 1 }, null, new[] { 2 }, new[] { 1, 2 })]
+        [TestCase(null, null, new[] { 2 }, new[] { 2 })]
+        [TestCase(new[] { 1 }, new[] { 1 }, null, new[] { 1 })]
+        [TestCase(new[] { 1, 2 }, new[] { 1 }, null, new[] { 1, 2 })]
+        [TestCase(new[] { 1, 1 }, new[] { 1 }, null, new[] { 1 })]
+        [TestCase(new[] { 1, 1 }, new[] { 2 }, null, new[] { 2, 1 })] // it's ok if has duplicated value in default value.
+        [TestCase(new[] { 1 }, new[] { 1 }, new[] { 1 }, new[] { 1 })] // should not sync to second list if add the same value.
+        public void TestOnyWaySyncWithAddItems(int[] defaultValuesInFirstBindable, int[] defaultValuesInSecondBindable, int[] newValues, int[] actualValuesInSecondBindable)
+        {
+            var firstBindableList = new BindableList<int>(defaultValuesInFirstBindable);
+            var secondBindableList = new BindableList<int>(defaultValuesInSecondBindable);
+
+            BindablesUtils.OnyWaySync(firstBindableList, secondBindableList);
+
+            if (newValues != null)
+                firstBindableList.AddRange(newValues);
+
+            Assert.AreEqual(secondBindableList.ToArray(), actualValuesInSecondBindable);
+        }
+
+        [TestCase(new[] { 1, 2, 3 }, null, new[] { 1 }, new[] { 2, 3 })]
+        [TestCase(new[] { 1 }, null, new[] { 1 }, new int[] { })] // remove all values
+        [TestCase(null, null, new[] { 2 }, new int[] { })] // remove value that is not exist.
+        [TestCase(new[] { 1, 2 }, new[] { 3 }, new[] { 3 }, new[] { 3, 1, 2 })] // cannot remove value from second list if remove value is not in the first list.
+        public void TestOnyWaySyncWithRemoveItems(int[] defaultValuesInFirstBindable, int[] defaultValuesInSecondBindable, int[] removeValues, int[] actualValuesInSecondBindable)
+        {
+            var firstBindableList = new BindableList<int>(defaultValuesInFirstBindable);
+            var secondBindableList = new BindableList<int>(defaultValuesInSecondBindable);
+
+            BindablesUtils.OnyWaySync(firstBindableList, secondBindableList);
+
+            if (removeValues != null)
+                firstBindableList.RemoveAll(removeValues.Contains);
+
+            Assert.AreEqual(secondBindableList.ToArray(), actualValuesInSecondBindable);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Utils/BindablesUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/BindablesUtils.cs
@@ -1,0 +1,43 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Rulesets.Karaoke.Utils
+{
+    public static class BindablesUtils
+    {
+        public static void Sync<T1, T2>(BindableList<T1> firstBindableList, BindableList<T2> secondBindableList)
+        {
+            OnyWaySync(firstBindableList, secondBindableList);
+            OnyWaySync(secondBindableList, firstBindableList);
+        }
+
+        public static void OnyWaySync<T1, T2>(BindableList<T1> firstBindableList, BindableList<T2> secondBindableList)
+        {
+            // add objects to second list if has default value in first list.
+            var defaultItems = firstBindableList.OfType<T2>().Except(secondBindableList);
+            secondBindableList.AddRange(defaultItems);
+
+            firstBindableList.CollectionChanged += (_, args) =>
+            {
+                var newItems = args.NewItems?.OfType<T2>().Except(secondBindableList);
+                var oldItems = args.OldItems;
+
+                if (newItems != null && newItems.Any())
+                {
+                    // add objects to second list if new items have been added.
+                    secondBindableList.AddRange(newItems);
+                }
+
+                if (oldItems != null && oldItems.Any())
+                {
+                    // remove objects from second list if exist items has been removed.
+                    secondBindableList.RemoveAll(x => args.OldItems.Contains(x));
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
It's the needed implementation of #952 
because we need to sync all the note object selection into selectionHitObjects in editor beatmap.
but we cannot just use bindable because `SelectedItems` in `NoteEditorSelectionHandler` is `BindableList<Note>`
and `SelectedHitObjects` in `EditorBeatmap` is `BindableList<HitObject>`