### PR TITLE
Remove lyric editor prefix step

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/KaraokeEditorScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/KaraokeEditorScreenTestScene.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -26,21 +25,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             editorBeatmap = new EditorBeatmap(CreateBeatmap());
         }
 
-        [Test]
-        public void TestKaraoke() => runForRuleset(new KaraokeRuleset().RulesetInfo);
-
-        private void runForRuleset(RulesetInfo rulesetInfo)
+        protected override void LoadComplete()
         {
-            AddStep("create screen", () =>
+            editorBeatmap.BeatmapInfo.Ruleset = new KaraokeRuleset().RulesetInfo;
+
+            Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+
+            Child = CreateEditorScreen().With(x =>
             {
-                editorBeatmap.BeatmapInfo.Ruleset = rulesetInfo;
-
-                Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
-
-                Child = CreateEditorScreen().With(x =>
-                {
-                    x.State.Value = Visibility.Visible;
-                });
+                x.State.Value = Visibility.Visible;
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/KaraokeSkinEditorScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/KaraokeSkinEditorScreenTestScene.cs
@@ -1,7 +1,6 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -29,17 +28,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens
             karaokeSkin = skinManager.CurrentSkin.Value as KaraokeSkin;
         }
 
-        [Test]
-        public void TestKaraoke() => runForRuleset(new KaraokeRuleset().RulesetInfo);
-
-        private void runForRuleset(RulesetInfo rulesetInfo)
+        protected override void LoadComplete()
         {
-            AddStep("create screen", () =>
+            Child = CreateEditorScreen(karaokeSkin).With(x =>
             {
-                Child = CreateEditorScreen(karaokeSkin).With(x =>
-                {
-                    x.State.Value = Visibility.Visible;
-                });
+                x.State.Value = Visibility.Visible;
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("カラオケ", new[] { "[3,end]:1000" }, false)]
         [TestCase("カラオケ", new[] { "[-1,start]:1000", "[3,end]:2000" }, false)] // out of range end time-tag should be count as missing.
         [TestCase("", new[] { "[0,start]:1000", "[0,end]:2000" }, false)] // empty lyric should always count as missing.
+        [TestCase("カラオケ", null, false)] // empty time-tag should always count as missing.
         public void TestHasStartTimeTagInLyric(string text, string[] timeTagTexts, bool actual)
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -273,6 +273,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode, bindableCreateMovingCaretMode);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagMovingCaretMode, bindableRecordingMovingCaretMode);
 
+            // if caret position changed, should add into editor beatmap selected hit objects.
+            lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
+            {
+                beatmap.SelectedHitObjects.Clear();
+
+                var lyric = e.NewValue?.Lyric;
+
+                if (lyric != null)
+                    beatmap.SelectedHitObjects.Add(lyric);
+            });
+
             // set-up divisor.
             beatDivisor.Value = beatmap.BeatmapInfo.BeatDivisor;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            lyricCaretState.MoveCaretToTargetPosition(new NavigateCaretPosition(Lyric));
+            lyricCaretState.MoveCaretToTargetPosition(Lyric);
             return base.OnMouseDown(e);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TimeTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TimeTagBlueprintContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            lyricCaretState.MoveCaretToTargetPosition(new NavigateCaretPosition(Lyric));
+            lyricCaretState.MoveCaretToTargetPosition(Lyric);
             return base.OnMouseDown(e);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
@@ -77,6 +78,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             MoveCaretToTargetPosition(position);
             return true;
+        }
+
+        public void MoveCaretToTargetPosition(Lyric lyric)
+        {
+            if (lyric == null)
+                throw new ArgumentNullException(nameof(lyric));
+
+            if (algorithm == null)
+                throw new InvalidOperationException($"{nameof(algorithm)} cannot be null.");
+
+            BindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
+            BindableHoverCaretPosition.Value = null;
         }
 
         public void MoveCaretToTargetPosition(ICaretPosition position)

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <param name="timeTags"></param>
         /// <param name="lyric"></param>
         public static bool HasStartTimeTagInLyric(TimeTag[] timeTags, string lyric)
-            => !string.IsNullOrEmpty(lyric) && timeTags.Any(x => x.Index.State == TextIndex.IndexState.Start && x.Index.Index == 0);
+            => !string.IsNullOrEmpty(lyric) && timeTags != null && timeTags.Any(x => x.Index.State == TextIndex.IndexState.Start && x.Index.Index == 0);
 
         /// <summary>
         /// Check lyric has end time-tag


### PR DESCRIPTION
It's the prefix step for remove `LyricManager` class, the last step of #952

what's changed in this class:
- fix might cause crash while calling `HasStartTimeTagInLyric` if time-tag is null.
- adjust base editor screen test for better testing experience.
- use elegance way to navigate caret.
- should trigger selected hit object changed in editor beatmap if caret changed in lyric editor.