### PR TITLE
Prevent change property directly in lyric editor state.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private const float spacing = 10;
         private const float button_width = 100;
 
-        private Bindable<bool> selecting;
+        private IBindable<bool> selecting;
         private BindableList<Lyric> selectedLyrics;
 
         private ActionButton applyButton;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private LyricEditorColourProvider colourProvider { get; set; }
 
         private readonly Bindable<LyricEditorMode> bindableMode = new();
-        private readonly Bindable<ICaretPosition> bindableHoverCaretPosition = new();
-        private readonly Bindable<ICaretPosition> bindableCaretPosition = new();
+        private readonly IBindable<ICaretPosition> bindableHoverCaretPosition = new Bindable<ICaretPosition>();
+        private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
 
         public DrawableLyricEditListItem(Lyric item)
             : base(item)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 {
     public class SelectLyricButton : OsuButton
     {
-        private Bindable<bool> selecting;
+        private IBindable<bool> selecting;
 
         protected virtual string StandardText => "Select lyric";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
@@ -226,13 +226,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                     Action = () =>
                     {
                         // navigate to current lyric.
-                        lyricCaretState.BindableCaretPosition.Value = state.Mode switch
+                        ICaretPosition caretPosition = state.Mode switch
                         {
                             LyricEditorMode.CreateTimeTag => new TimeTagIndexCaretPosition(lyric, timeTag?.Index ?? new TextIndex()),
                             LyricEditorMode.RecordTimeTag => new TimeTagCaretPosition(lyric, timeTag),
                             LyricEditorMode.AdjustTimeTag => new NavigateCaretPosition(lyric),
                             _ => throw new ArgumentOutOfRangeException(nameof(state.Mode))
                         };
+
+                        lyricCaretState.MoveCaretToTargetPosition(caretPosition);
 
                         // set current time-tag as selected.
                         selectedTimeTags.Clear();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableCaret.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
 {
     public abstract class DrawableCaret<TCaret> : DrawableCaret where TCaret : class, ICaretPosition
     {
-        private Bindable<ICaretPosition> caretPosition;
+        private IBindable<ICaretPosition> caretPosition;
 
         protected DrawableCaret(bool preview)
             : base(preview)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
 
         private class CurrentRecordingTimeTagVisualization : CompositeDrawable
         {
-            private Bindable<ICaretPosition> position;
+            private IBindable<ICaretPosition> position;
 
             private readonly Lyric lyric;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
         public class SelectArea : CompositeDrawable
         {
             private Bindable<LyricEditorMode> mode;
-            private Bindable<bool> selecting;
+            private IBindable<bool> selecting;
             private BindableDictionary<Lyric, string> disableSelectingLyrics;
             private BindableList<Lyric> selectedLyrics;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -9,9 +9,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 {
     public interface ILyricCaretState
     {
-        Bindable<ICaretPosition> BindableHoverCaretPosition { get; }
+        IBindable<ICaretPosition> BindableHoverCaretPosition { get; }
 
-        Bindable<ICaretPosition> BindableCaretPosition { get; }
+        IBindable<ICaretPosition> BindableCaretPosition { get; }
 
         void ChangePositionAlgorithm(LyricEditorMode lyricEditorMode, MovingTimeTagCaretMode movingTimeTagCaretMode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricSelectionState.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 {
     public interface ILyricSelectionState
     {
-        BindableBool Selecting { get; }
+        IBindable<bool> Selecting { get; }
 
         BindableDictionary<Lyric, string> DisableSelectingLyric { get; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -17,9 +17,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 {
     public class LyricCaretState : Component, ILyricCaretState
     {
-        public Bindable<ICaretPosition> BindableHoverCaretPosition { get; } = new();
+        public IBindable<ICaretPosition> BindableHoverCaretPosition => bindableHoverCaretPosition;
 
-        public Bindable<ICaretPosition> BindableCaretPosition { get; } = new();
+        public IBindable<ICaretPosition> BindableCaretPosition => bindableCaretPosition;
+
+        private readonly Bindable<ICaretPosition> bindableHoverCaretPosition = new();
+
+        private readonly Bindable<ICaretPosition> bindableCaretPosition = new();
 
         private ICaretPositionAlgorithm algorithm;
 
@@ -53,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (algorithm == null)
                 return false;
 
-            var currentPosition = BindableCaretPosition.Value;
+            var currentPosition = bindableCaretPosition.Value;
 
             var position = action switch
             {
@@ -93,8 +97,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (caretPosition == null)
                 return;
 
-            BindableHoverCaretPosition.Value = null;
-            BindableCaretPosition.Value = caretPosition;
+            bindableHoverCaretPosition.Value = null;
+            bindableCaretPosition.Value = caretPosition;
         }
 
         public void MoveCaretToTargetPosition(ICaretPosition position)
@@ -121,8 +125,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (!movable)
                 return;
 
-            BindableHoverCaretPosition.Value = null;
-            BindableCaretPosition.Value = position;
+            bindableHoverCaretPosition.Value = null;
+            bindableCaretPosition.Value = position;
         }
 
         public void MoveHoverCaretToTargetPosition(ICaretPosition position)
@@ -136,35 +140,35 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (!CaretPositionMovable(position))
                 return;
 
-            BindableHoverCaretPosition.Value = position;
+            bindableHoverCaretPosition.Value = position;
         }
 
         public void ClearHoverCaretPosition()
         {
-            BindableHoverCaretPosition.Value = null;
+            bindableHoverCaretPosition.Value = null;
         }
 
         public void ResetPosition(LyricEditorMode mode)
         {
-            var lyric = BindableCaretPosition.Value?.Lyric;
+            var lyric = bindableCaretPosition.Value?.Lyric;
 
             if (algorithm != null)
             {
                 if (lyric != null)
                 {
-                    BindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
-                    BindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
+                    bindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
+                    bindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
                 }
                 else
                 {
-                    BindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
-                    BindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
+                    bindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
+                    bindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
                 }
             }
             else
             {
-                BindableCaretPosition.Value = null;
-                BindableHoverCaretPosition.Value = null;
+                bindableCaretPosition.Value = null;
+                bindableHoverCaretPosition.Value = null;
             }
 
             updateEditorBeatmapSelectedHitObject(lyric);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 {
     public class LyricSelectionState : Component, ILyricSelectionState
     {
-        public BindableBool Selecting { get; } = new();
+        public IBindable<bool> Selecting => selecting;
 
         public BindableDictionary<Lyric, string> DisableSelectingLyric { get; } = new();
 
@@ -24,15 +24,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
+        private readonly BindableBool selecting = new();
+
         public void StartSelecting()
         {
             SelectedLyrics.Clear();
-            Selecting.Value = true;
+            selecting.Value = true;
         }
 
         public void EndSelecting(LyricEditorSelectingAction action)
         {
-            Selecting.Value = false;
+            selecting.Value = false;
 
             if (beatmap == null)
                 return;


### PR DESCRIPTION
Separate implementation of #972.
.
In some case, we do not want user to change the value directly in bindable.
so make them into bindable interface instead.
