### PR TITLE
Fix tooltip not show properly

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -33,8 +33,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             };
         }
 
+        private Issue[] lastIssues;
+
         public override void SetContent(Issue[] content)
         {
+            if (content == lastIssues)
+                return;
+
+            lastIssues = content;
+
             // clear exist warning.
             invalidMessage.Clear();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/InvalidLyricToolTip.cs
@@ -35,17 +35,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
         private Issue[] lastIssues;
 
-        public override void SetContent(Issue[] content)
+        public override void SetContent(Issue[] issues)
         {
-            if (content == lastIssues)
+            if (issues == lastIssues)
                 return;
 
-            lastIssues = content;
+            lastIssues = issues;
 
             // clear exist warning.
             invalidMessage.Clear();
 
-            foreach (var issue in content)
+            foreach (var issue in issues)
             {
                 switch (issue)
                 {
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             }
 
             // show no problem message
-            if (content.Length == 0)
+            if (issues.Length == 0)
                 invalidMessage.AddSuccessParagraph("Seems no issue in this lyric.");
 
             void createTimeInvalidMessage(TimeInvalid timeInvalid)

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
@@ -31,20 +31,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
         private Lyric lastLyric;
 
-        public override void SetContent(Lyric content)
+        public override void SetContent(Lyric lyric)
         {
-            if (content == lastLyric)
+            if (lyric == lastLyric)
                 return;
 
-            lastLyric = content;
+            lastLyric = lyric;
 
             // Get layout
-            int layoutIndex = content.LayoutIndex;
+            int layoutIndex = lyric.LayoutIndex;
             var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricLayout, layoutIndex)).Value;
 
             // Display in content\
             preview.Layout = layout;
-            preview.Lyric = content;
+            preview.Lyric = lyric;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
@@ -29,8 +29,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             };
         }
 
+        private Lyric lastLyric;
+
         public override void SetContent(Lyric content)
         {
+            if (content == lastLyric)
+                return;
+
+            lastLyric = content;
+
             // Get layout
             int layoutIndex = content.LayoutIndex;
             var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(KaraokeSkinConfiguration.LyricLayout, layoutIndex)).Value;

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/TimeTagTooltip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/TimeTagTooltip.cs
@@ -85,16 +85,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
         private TimeTag lastTimeTag;
 
-        public override void SetContent(TimeTag content)
+        public override void SetContent(TimeTag timeTag)
         {
-            if (content == lastTimeTag)
+            if (timeTag == lastTimeTag)
                 return;
 
-            lastTimeTag = content;
+            lastTimeTag = timeTag;
 
-            trackTimer.Text = TimeTagUtils.FormattedString(content);
-            index.Text = $"Position: {content.Index.Index}";
-            indexState.Text = content.Index.State == TextIndex.IndexState.Start ? "Start" : "End";
+            trackTimer.Text = TimeTagUtils.FormattedString(timeTag);
+            index.Text = $"Position: {timeTag.Index.Index}";
+            indexState.Text = timeTag.Index.State == TextIndex.IndexState.Start ? "Start" : "End";
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/TimeTagTooltip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/TimeTagTooltip.cs
@@ -83,8 +83,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
             };
         }
 
+        private TimeTag lastTimeTag;
+
         public override void SetContent(TimeTag content)
         {
+            if (content == lastTimeTag)
+                return;
+
+            lastTimeTag = content;
+
             trackTimer.Text = TimeTagUtils.FormattedString(content);
             index.Text = $"Position: {content.Index.Index}";
             indexState.Text = content.Index.State == TextIndex.IndexState.Start ? "Start" : "End";

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
@@ -11,14 +11,14 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
     {
         private Lyric lastLyric;
 
-        public override void SetContent(Lyric content)
+        public override void SetContent(Lyric lyric)
         {
-            if (content == lastLyric)
+            if (lyric == lastLyric)
                 return;
 
-            lastLyric = content;
+            lastLyric = lyric;
 
-            Child = new PreviewLyricSpriteText(content)
+            Child = new PreviewLyricSpriteText(lyric)
             {
                 Margin = new MarginPadding(10),
                 Font = new FontUsage(size: 32),

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
@@ -9,8 +9,15 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
 {
     public class LyricTooltip : BackgroundToolTip<Lyric>
     {
+        private Lyric lastLyric;
+
         public override void SetContent(Lyric content)
         {
+            if (content == lastLyric)
+                return;
+
+            lastLyric = content;
+
             Child = new PreviewLyricSpriteText(content)
             {
                 Margin = new MarginPadding(10),

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
@@ -78,18 +78,18 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
 
         private Singer lastSinger;
 
-        public override void SetContent(Singer content)
+        public override void SetContent(Singer singer)
         {
-            if (content == lastSinger)
+            if (singer == lastSinger)
                 return;
 
-            lastSinger = content;
+            lastSinger = singer;
 
-            avatar.Singer = content;
-            singerName.Text = content.Name;
-            singerEnglishName.Text = content.EnglishName != null ? $"({content.EnglishName})" : "";
-            singerRomajiName.Text = content.RomajiName;
-            singerDescription.Text = content.Description ?? "<No description>";
+            avatar.Singer = singer;
+            singerName.Text = singer.Name;
+            singerEnglishName.Text = singer.EnglishName != null ? $"({singer.EnglishName})" : "";
+            singerRomajiName.Text = singer.RomajiName;
+            singerDescription.Text = singer.Description ?? "<No description>";
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
@@ -76,8 +76,15 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
             };
         }
 
+        private Singer lastSinger;
+
         public override void SetContent(Singer content)
         {
+            if (content == lastSinger)
+                return;
+
+            lastSinger = content;
+
             avatar.Singer = content;
             singerName.Text = content.Name;
             singerEnglishName.Text = content.EnglishName != null ? $"({content.EnglishName})" : "";


### PR DESCRIPTION
Fix tooltip cannot show the whole error message because it might call "SetContent" each frame.
So should find a way to prevent that.

Also revert the naming change in https://github.com/karaoke-dev/karaoke/pull/948/commits/63ee11965b0c3db0f40410a449b74dfa52e40a99 (#948)