### PR TITLE
fix the weird ruby/romaji position issue.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="osu.Framework.KaraokeFont" Version="2021.1204.0" />
+    <PackageReference Include="osu.Framework.KaraokeFont" Version="2021.1222.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2021.1204.0" />
     <PackageReference Include="ppy.osu.Game" Version="2021.1218.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/147103085-4df5d63d-a086-4e98-bb95-53d2267669f0.png)

update the package to fix the weird ruby/romaji position issue.
seems great now.

changes:
https://github.com/karaoke-dev/osu-framework-font/pull/101