### PR TITLE
Fix cannot change order issue in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditList.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         }
 
         [BackgroundDependencyLoader]
-        private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager, ILyricCaretState lyricCaretState)
+        private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager, ILyricCaretState lyricCaretState, ILyricEditorState state)
         {
             // update selected style to child
             lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
@@ -62,6 +62,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 var oldLyric = e.OldValue?.Lyric;
                 var newLyric = e.NewValue?.Lyric;
                 if (newLyric == null)
+                    return;
+
+                // should not move the position in manage lyric mode.
+                if (state.Mode == LyricEditorMode.Manage)
                     return;
 
                 // move to target position if auto focus.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -29,6 +29,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Resolved]
         private LyricEditorColourProvider colourProvider { get; set; }
 
+        [Resolved]
+        private ILyricCaretState lyricCaretState { get; set; }
+
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
         private readonly IBindable<ICaretPosition> bindableHoverCaretPosition = new Bindable<ICaretPosition>();
         private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
@@ -134,7 +137,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         }
 
         [BackgroundDependencyLoader]
-        private void load(ILyricEditorState state, ILyricCaretState lyricCaretState)
+        private void load(ILyricEditorState state)
         {
             bindableMode.BindTo(state.BindableMode);
             bindableHoverCaretPosition.BindTo(lyricCaretState.BindableHoverCaretPosition);
@@ -152,6 +155,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             isDragging = true;
             updateBackgroundColour();
+
+            // should mark object as selecting while dragging.
+            lyricCaretState.MoveCaretToTargetPosition(Model);
 
             return true;
         }


### PR DESCRIPTION
Close issue #997

What's fixed in this PR:
- should mark lyric as seleced while dragging.
- should adjust scrollbar position while change selected lyric in manage lyric mode because seems annoying.