### PR TITLE
Refactor lyric selection state logic in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private const float button_width = 100;
 
         private IBindable<bool> selecting;
-        private BindableList<Lyric> selectedLyrics;
+        private IBindableList<Lyric> selectedLyrics;
 
         private ActionButton applyButton;
 
@@ -132,8 +132,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public class SelectArea : CompositeDrawable
         {
             private IBindable<LyricEditorMode> bindableMode;
-            private BindableDictionary<Lyric, string> disableSelectingLyrics;
-            private BindableList<Lyric> selectedLyrics;
+            private IBindableDictionary<Lyric, string> disableSelectingLyrics;
+            private IBindableList<Lyric> selectedLyrics;
 
             private readonly Box background;
             private readonly CircleCheckbox allSelectedCheckbox;
@@ -212,14 +212,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
                     checkboxClicking = true;
 
-                    selectedLyrics.Clear();
-
                     if (e.NewValue)
-                    {
-                        var disableSelectingLyrics = lyricSelectionState.DisableSelectingLyric.Keys;
-                        var lyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => !disableSelectingLyrics.Contains(x));
-                        selectedLyrics.AddRange(lyrics);
-                    }
+                        lyricSelectionState.SelectAll();
+                    else
+                        lyricSelectionState.UnSelectAll();
 
                     checkboxClicking = false;
                 });

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
@@ -23,8 +23,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private const float spacing = 10;
         private const float button_width = 100;
 
-        private IBindable<bool> selecting;
-        private IBindableList<Lyric> selectedLyrics;
+        private readonly IBindable<bool> selecting = new Bindable<bool>();
+        private readonly IBindableList<Lyric> selectedLyrics = new BindableList<Lyric>();
 
         private ActionButton applyButton;
 
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 }
             };
 
-            selecting = lyricSelectionState.Selecting.GetBoundCopy();
+            selecting.BindTo(lyricSelectionState.Selecting);
             selecting.BindValueChanged(e =>
             {
                 if (e.NewValue)
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             }, true);
 
             // get bindable and update bindable if select or not select all.
-            selectedLyrics = lyricSelectionState.SelectedLyrics.GetBoundCopy();
+            selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
             selectedLyrics.BindCollectionChanged((_, _) =>
             {
@@ -131,9 +131,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         public class SelectArea : CompositeDrawable
         {
-            private IBindable<LyricEditorMode> bindableMode;
-            private IBindableDictionary<Lyric, string> disableSelectingLyrics;
-            private IBindableList<Lyric> selectedLyrics;
+            private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+            private readonly IBindableDictionary<Lyric, string> disableSelectingLyrics = new BindableDictionary<Lyric, string>();
+            private readonly IBindableList<Lyric> selectedLyrics = new BindableList<Lyric>();
 
             private readonly Box background;
             private readonly CircleCheckbox allSelectedCheckbox;
@@ -167,9 +167,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             [BackgroundDependencyLoader]
             private void load(ILyricEditorState state, ILyricSelectionState lyricSelectionState, LyricEditorColourProvider colourProvider, EditorBeatmap beatmap)
             {
-                bindableMode = state.BindableMode.GetBoundCopy();
-                disableSelectingLyrics = lyricSelectionState.DisableSelectingLyric.GetBoundCopy();
-                selectedLyrics = lyricSelectionState.SelectedLyrics.GetBoundCopy();
+                bindableMode.BindTo(state.BindableMode);
+                disableSelectingLyrics.BindTo(lyricSelectionState.DisableSelectingLyric);
+                selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
                 // should update background if mode changed.
                 bindableMode.BindValueChanged(_ =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
@@ -107,6 +107,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             };
 
             selecting.BindTo(lyricSelectionState.Selecting);
+            selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
+
             selecting.BindValueChanged(e =>
             {
                 if (e.NewValue)
@@ -118,9 +120,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     Hide();
                 }
             }, true);
-
-            // get bindable and update bindable if select or not select all.
-            selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
             selectedLyrics.BindCollectionChanged((_, _) =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
@@ -48,18 +48,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
                 }
                 else
                 {
-                    lyricSelectionState.DisableSelectingLyric.Clear();
-
+                    // update disabled lyrics list.
                     var disableLyrics = StartSelecting?.Invoke();
+                    lyricSelectionState.UpdateDisableLyricList(disableLyrics);
 
-                    if (disableLyrics != null)
-                    {
-                        foreach ((var lyric, string reason) in disableLyrics)
-                        {
-                            lyricSelectionState.DisableSelectingLyric.Add(lyric, reason);
-                        }
-                    }
-
+                    // then start selecting.
                     lyricSelectionState.StartSelecting();
                 }
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
@@ -61,10 +61,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
 
         public class SelectArea : CompositeDrawable
         {
-            private IBindable<LyricEditorMode> bindableMode;
-            private IBindable<bool> selecting;
-            private IBindableDictionary<Lyric, string> disableSelectingLyrics;
-            private IBindableList<Lyric> selectedLyrics;
+            private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+            private readonly IBindable<bool> selecting = new Bindable<bool>();
+            private readonly IBindableDictionary<Lyric, string> disableSelectingLyrics = new BindableDictionary<Lyric, string>();
+            private readonly IBindableList<Lyric> selectedLyrics = new BindableList<Lyric>();
 
             private readonly Box background;
             private readonly CircleCheckbox selectedCheckbox;
@@ -101,10 +101,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
             [BackgroundDependencyLoader]
             private void load(ILyricEditorState state, ILyricSelectionState lyricSelectionState, LyricEditorColourProvider colourProvider)
             {
-                bindableMode = state.BindableMode.GetBoundCopy();
-                selecting = lyricSelectionState.Selecting.GetBoundCopy();
-                disableSelectingLyrics = lyricSelectionState.DisableSelectingLyric.GetBoundCopy();
-                selectedLyrics = lyricSelectionState.SelectedLyrics.GetBoundCopy();
+                bindableMode.BindTo(state.BindableMode);
+                selecting.BindTo(lyricSelectionState.Selecting);
+                disableSelectingLyrics.BindTo(lyricSelectionState.DisableSelectingLyric);
+                selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
                 // should update background if mode changed.
                 bindableMode.BindValueChanged(_ =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -62,8 +63,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
         {
             private IBindable<LyricEditorMode> bindableMode;
             private IBindable<bool> selecting;
-            private BindableDictionary<Lyric, string> disableSelectingLyrics;
-            private BindableList<Lyric> selectedLyrics;
+            private IBindableDictionary<Lyric, string> disableSelectingLyrics;
+            private IBindableList<Lyric> selectedLyrics;
 
             private readonly Box background;
             private readonly CircleCheckbox selectedCheckbox;
@@ -147,12 +148,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                 {
                     if (e.NewValue)
                     {
-                        if (!selectedLyrics.Contains(lyric))
-                            selectedLyrics.Add(lyric);
+                        lyricSelectionState.Select(lyric);
                     }
                     else
                     {
-                        selectedLyrics.Remove(lyric);
+                        lyricSelectionState.UnSelect(lyric);
                     }
                 });
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricSelectionState.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -11,14 +12,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
     {
         IBindable<bool> Selecting { get; }
 
-        BindableDictionary<Lyric, string> DisableSelectingLyric { get; }
+        IBindableDictionary<Lyric, string> DisableSelectingLyric { get; }
 
-        BindableList<Lyric> SelectedLyrics { get; }
+        IBindableList<Lyric> SelectedLyrics { get; }
 
         Action<LyricEditorSelectingAction> Action { get; set; }
 
         void StartSelecting();
 
         void EndSelecting(LyricEditorSelectingAction action);
+
+        void Select(Lyric lyric);
+
+        void UnSelect(Lyric lyric);
+
+        void SelectAll();
+
+        void UnSelectAll();
+
+        void UpdateDisableLyricList(IDictionary<Lyric, string> disableLyrics);
     }
 }


### PR DESCRIPTION
Should use the interface instead of real class in `ILyricSelectionState`.