### PR TITLE
Should use change handler if change text-tag properties.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRomajiTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRomajiTagsChangeHandler.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricRomajiChangeHandler : IAutoGenerateChangeHandler
+    public interface ILyricRomajiTagsChangeHandler : IAutoGenerateChangeHandler
     {
         bool CanGenerate();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRomajiTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRomajiTagsChangeHandler.cs
@@ -1,9 +1,11 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Objects;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricRomajiTagsChangeHandler : IAutoGenerateChangeHandler
+    public interface ILyricRomajiTagsChangeHandler : ILyricTextTagsChangeHandler<RomajiTag>, IAutoGenerateChangeHandler
     {
         bool CanGenerate();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRubyTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRubyTagsChangeHandler.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricRubyChangeHandler : IAutoGenerateChangeHandler
+    public interface ILyricRubyTagsChangeHandler : IAutoGenerateChangeHandler
     {
         bool CanGenerate();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRubyTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricRubyTagsChangeHandler.cs
@@ -1,9 +1,11 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Objects;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricRubyTagsChangeHandler : IAutoGenerateChangeHandler
+    public interface ILyricRubyTagsChangeHandler : ILyricTextTagsChangeHandler<RubyTag>, IAutoGenerateChangeHandler
     {
         bool CanGenerate();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
@@ -1,0 +1,18 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
+{
+    public interface ILyricTextTagsChangeHandler<in TTextTag> where TTextTag : ITextTag
+    {
+        void Add(TTextTag textTag);
+
+        void Remove(TTextTag textTag);
+
+        void SetPosition(TTextTag textTag, int? startIndex, int? endIndex);
+
+        void SetText(TTextTag textTag, string text);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricRomajiChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRomajiChangeHandler
+    public class LyricRomajiTagsChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRomajiTagsChangeHandler
     {
         public void AutoGenerate()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
@@ -4,10 +4,11 @@
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricRomajiTagsChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRomajiTagsChangeHandler
+    public class LyricRomajiTagsChangeHandler : LyricTextTagsChangeHandler<RomajiTag>, ILyricRomajiTagsChangeHandler
     {
         public void AutoGenerate()
         {
@@ -23,6 +24,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             var selector = new RomajiTagGeneratorSelector();
             return HitObjects.Any(lyric => selector.CanGenerate(lyric));
+        }
+
+        protected override bool ContainsInLyric(Lyric lyric, RomajiTag textTag)
+            => lyric.RomajiTags.Contains(textTag);
+
+        protected override void AddToLyric(Lyric lyric, RomajiTag textTag)
+        {
+            var romajiTags = lyric.RomajiTags.ToList();
+            romajiTags.Add(textTag);
+
+            lyric.RomajiTags = TextTagsUtils.Sort(romajiTags);
+        }
+
+        protected override void RemoveFromLyric(Lyric lyric, RomajiTag textTag)
+        {
+            var romajiTags = lyric.RomajiTags.ToList();
+            romajiTags.Remove(textTag);
+
+            lyric.RomajiTags = romajiTags.ToArray();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
@@ -4,10 +4,11 @@
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricRubyTagsChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRubyTagsChangeHandler
+    public class LyricRubyTagsChangeHandler : LyricTextTagsChangeHandler<RubyTag>, ILyricRubyTagsChangeHandler
     {
         public void AutoGenerate()
         {
@@ -23,6 +24,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             var selector = new RubyTagGeneratorSelector();
             return HitObjects.Any(lyric => selector.CanGenerate(lyric));
+        }
+
+        protected override bool ContainsInLyric(Lyric lyric, RubyTag textTag)
+            => lyric.RubyTags.Contains(textTag);
+
+        protected override void AddToLyric(Lyric lyric, RubyTag textTag)
+        {
+            var rubyTags = lyric.RubyTags.ToList();
+            rubyTags.Add(textTag);
+
+            lyric.RubyTags = TextTagsUtils.Sort(rubyTags);
+        }
+
+        protected override void RemoveFromLyric(Lyric lyric, RubyTag textTag)
+        {
+            var rubyTags = lyric.RubyTags.ToList();
+            rubyTags.Remove(textTag);
+
+            lyric.RubyTags = rubyTags.ToArray();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricRubyChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRubyChangeHandler
+    public class LyricRubyTagsChangeHandler : HitObjectChangeHandler<Lyric>, ILyricRubyTagsChangeHandler
     {
         public void AutoGenerate()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -1,0 +1,70 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
+{
+    public abstract class LyricTextTagsChangeHandler<TTextTag> : HitObjectChangeHandler<Lyric>, ILyricTextTagsChangeHandler<TTextTag> where TTextTag : ITextTag
+    {
+        public void Add(TTextTag textTag)
+        {
+            PerformOnSelection(lyric =>
+            {
+                bool containsInLyric = ContainsInLyric(lyric, textTag);
+                if (containsInLyric == false)
+                    throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                AddToLyric(lyric, textTag);
+            });
+        }
+
+        public void Remove(TTextTag textTag)
+        {
+            PerformOnSelection(lyric =>
+            {
+                bool containsInLyric = ContainsInLyric(lyric, textTag);
+                if (containsInLyric == false)
+                    throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                RemoveFromLyric(lyric, textTag);
+            });
+        }
+
+        public void SetPosition(TTextTag textTag, int? startIndex, int? endIndex)
+        {
+            PerformOnSelection(lyric =>
+            {
+                bool containsInLyric = ContainsInLyric(lyric, textTag);
+                if (containsInLyric == false)
+                    throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                if (startIndex != null)
+                    textTag.StartIndex = startIndex.Value;
+
+                if (endIndex != null)
+                    textTag.EndIndex = endIndex.Value;
+            });
+        }
+
+        public void SetText(TTextTag textTag, string text)
+        {
+            PerformOnSelection(lyric =>
+            {
+                bool containsInLyric = ContainsInLyric(lyric, textTag);
+                if (containsInLyric == false)
+                    throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                textTag.Text = text;
+            });
+        }
+
+        protected abstract bool ContainsInLyric(Lyric lyric, TTextTag textTag);
+
+        protected abstract void AddToLyric(Lyric lyric, TTextTag textTag);
+
+        protected abstract void RemoveFromLyric(Lyric lyric, TTextTag textTag);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
@@ -23,8 +23,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         [Cached(typeof(ILyricLanguageChangeHandler))]
         private readonly LyricLanguageChangeHandler lyricLanguageChangeHandler;
 
-        [Cached(typeof(ILyricRubyChangeHandler))]
-        private readonly LyricRubyChangeHandler lyricRubyChangeHandler;
+        [Cached(typeof(ILyricRubyTagsChangeHandler))]
+        private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
         [Cached(typeof(ILyricRomajiChangeHandler))]
         private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         public AssignLanguageStepScreen()
         {
             AddInternal(lyricLanguageChangeHandler = new LyricLanguageChangeHandler());
-            AddInternal(lyricRubyChangeHandler = new LyricRubyChangeHandler());
+            AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
             AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
         }
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         public override void Complete()
         {
             // Check is need to go to generate ruby/romaji step or just skip.
-            if (lyricRubyChangeHandler.CanGenerate() || lyricRomajiChangeHandler.CanGenerate())
+            if (lyricRubyTagsChangeHandler.CanGenerate() || lyricRomajiChangeHandler.CanGenerate())
             {
                 ScreenStack.Push(LyricImporterStep.GenerateRuby);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
@@ -26,14 +26,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         [Cached(typeof(ILyricRubyTagsChangeHandler))]
         private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
-        [Cached(typeof(ILyricRomajiChangeHandler))]
-        private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
+        [Cached(typeof(ILyricRomajiTagsChangeHandler))]
+        private readonly LyricRomajiTagsChangeHandler lyricRomajiTagsChangeHandler;
 
         public AssignLanguageStepScreen()
         {
             AddInternal(lyricLanguageChangeHandler = new LyricLanguageChangeHandler());
             AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
-            AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
+            AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());
         }
 
         protected override TopNavigation CreateNavigation()
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         public override void Complete()
         {
             // Check is need to go to generate ruby/romaji step or just skip.
-            if (lyricRubyTagsChangeHandler.CanGenerate() || lyricRomajiChangeHandler.CanGenerate())
+            if (lyricRubyTagsChangeHandler.CanGenerate() || lyricRomajiTagsChangeHandler.CanGenerate())
             {
                 ScreenStack.Push(LyricImporterStep.GenerateRuby);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
@@ -23,13 +23,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
         [Cached(typeof(ILyricRubyTagsChangeHandler))]
         private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
-        [Cached(typeof(ILyricRomajiChangeHandler))]
-        private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
+        [Cached(typeof(ILyricRomajiTagsChangeHandler))]
+        private readonly LyricRomajiTagsChangeHandler lyricRomajiTagsChangeHandler;
 
         public GenerateRubyRomajiStepScreen()
         {
             AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
-            AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
+            AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());
         }
 
         protected override TopNavigation CreateNavigation()
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
             // Asking auto-generate ruby or romaji.
             if (lyricRubyTagsChangeHandler.CanGenerate())
                 AskForAutoGenerateRuby();
-            else if (lyricRomajiChangeHandler.CanGenerate())
+            else if (lyricRomajiTagsChangeHandler.CanGenerate())
                 AskForAutoGenerateRomaji();
         }
 
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
 
                 // todo: select all lyrics or switch to select mode.
 
-                lyricRomajiChangeHandler.AutoGenerate();
+                lyricRomajiTagsChangeHandler.AutoGenerate();
                 Navigation.State = NavigationState.Done;
             }));
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
@@ -20,15 +20,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
 
         public override IconUsage Icon => FontAwesome.Solid.Gem;
 
-        [Cached(typeof(ILyricRubyChangeHandler))]
-        private readonly LyricRubyChangeHandler lyricRubyChangeHandler;
+        [Cached(typeof(ILyricRubyTagsChangeHandler))]
+        private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
         [Cached(typeof(ILyricRomajiChangeHandler))]
         private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
 
         public GenerateRubyRomajiStepScreen()
         {
-            AddInternal(lyricRubyChangeHandler = new LyricRubyChangeHandler());
+            AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
             AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
         }
 
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
             Navigation.State = NavigationState.Initial;
 
             // Asking auto-generate ruby or romaji.
-            if (lyricRubyChangeHandler.CanGenerate())
+            if (lyricRubyTagsChangeHandler.CanGenerate())
                 AskForAutoGenerateRuby();
             else if (lyricRomajiChangeHandler.CanGenerate())
                 AskForAutoGenerateRomaji();
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
 
                 // todo: select all lyrics or switch to select mode.
 
-                lyricRubyChangeHandler.AutoGenerate();
+                lyricRubyTagsChangeHandler.AutoGenerate();
                 Navigation.State = NavigationState.Done;
             }));
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -38,8 +38,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached]
         private readonly FontManager fontManager;
 
-        [Cached(typeof(ILyricRubyChangeHandler))]
-        private readonly LyricRubyChangeHandler lyricRubyChangeHandler;
+        [Cached(typeof(ILyricRubyTagsChangeHandler))]
+        private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
         [Cached(typeof(ILyricRomajiChangeHandler))]
         private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             // Duplicated registration because selection handler need to use it.
             AddInternal(fontManager = new FontManager());
 
-            AddInternal(lyricRubyChangeHandler = new LyricRubyChangeHandler());
+            AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
             AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());
             AddInternal(notesChangeHandler = new NotesChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -41,8 +41,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached(typeof(ILyricRubyTagsChangeHandler))]
         private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
-        [Cached(typeof(ILyricRomajiChangeHandler))]
-        private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
+        [Cached(typeof(ILyricRomajiTagsChangeHandler))]
+        private readonly LyricRomajiTagsChangeHandler lyricRomajiTagsChangeHandler;
 
         [Cached(typeof(INotePositionInfo))]
         private readonly NotePositionInfo notePositionInfo;
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(fontManager = new FontManager());
 
             AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
-            AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
+            AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());
             AddInternal(notesChangeHandler = new NotesChangeHandler());
             AddInternal(lyricSingerChangeHandler = new LyricSingerChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -68,11 +68,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
             });
         }
 
-        protected override string GetFieldValue(T item)
+        protected sealed override string GetFieldValue(T item)
             => item.Text;
 
-        protected override void ApplyValue(T item, string value)
-            => item.Text = value;
+        protected sealed override void ApplyValue(T item, string value)
+        {
+            if (item.Text == value)
+                return;
+
+            SetText(item, value);
+        }
+
+        protected abstract void SetText(T item, string value);
 
         protected override void OnFocus(FocusEvent e)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagAutoGenerateSection.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
     public class RomajiTagAutoGenerateSection : TextTagAutoGenerateSection
     {
         [Resolved]
-        private ILyricRomajiChangeHandler romajiChangeHandler { get; set; }
+        private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
 
         protected override Dictionary<Lyric, string> GetDisableSelectingLyrics(IEnumerable<Lyric> lyrics)
             => lyrics.Where(x => x.Language == null)
                      .ToDictionary(k => k, _ => "Before generate romaji-tag, need to assign language first.");
 
         protected override void Apply()
-            => romajiChangeHandler.AutoGenerate();
+            => romajiTagsChangeHandler.AutoGenerate();
 
         protected override ConfigButton CreateConfigButton()
             => new RomajiTagAutoGenerateConfigButton();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -36,9 +37,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         protected class LabelledRomajiTagTextBox : LabelledTextTagTextBox<RomajiTag>
         {
+            [Resolved]
+            private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
+
             public LabelledRomajiTagTextBox(RomajiTag textTag)
                 : base(textTag)
             {
+            }
+
+            protected override void SetText(RomajiTag item, string value)
+            {
+                romajiTagsChangeHandler.SetText(item, value);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagAutoGenerateSection.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
     public class RubyTagAutoGenerateSection : TextTagAutoGenerateSection
     {
         [Resolved]
-        private ILyricRubyChangeHandler rubyChangeHandler { get; set; }
+        private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
 
         protected override Dictionary<Lyric, string> GetDisableSelectingLyrics(IEnumerable<Lyric> lyrics)
             => lyrics.Where(x => x.Language == null)
                      .ToDictionary(k => k, _ => "Before generate ruby-tag, need to assign language first.");
 
         protected override void Apply()
-            => rubyChangeHandler.AutoGenerate();
+            => rubyTagsChangeHandler.AutoGenerate();
 
         protected override ConfigButton CreateConfigButton()
             => new RubyTagAutoGenerateConfigButton();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -36,9 +37,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         protected class LabelledRubyTagTextBox : LabelledTextTagTextBox<RubyTag>
         {
+            [Resolved]
+            private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
+
             public LabelledRubyTagTextBox(RubyTag textTag)
                 : base(textTag)
             {
+            }
+
+            protected override void SetText(RubyTag item, string value)
+            {
+                rubyTagsChangeHandler.SetText(item, value);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(ILyricRubyTagsChangeHandler))]
         private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
-        [Cached(typeof(ILyricRomajiChangeHandler))]
-        private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
+        [Cached(typeof(ILyricRomajiTagsChangeHandler))]
+        private readonly LyricRomajiTagsChangeHandler lyricRomajiTagsChangeHandler;
 
         [Cached(typeof(ILyricTimeTagsChangeHandler))]
         private readonly LyricTimeTagsChangeHandler lyricTimeTagsChangeHandler;
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             AddInternal(lyricTextChangeHandler = new LyricTextChangeHandler());
             AddInternal(lyricLanguageChangeHandler = new LyricLanguageChangeHandler());
             AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
-            AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
+            AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());
             AddInternal(lyricTimeTagsChangeHandler = new LyricTimeTagsChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());
             AddInternal(notesChangeHandler = new NotesChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(ILyricLanguageChangeHandler))]
         private readonly LyricLanguageChangeHandler lyricLanguageChangeHandler;
 
-        [Cached(typeof(ILyricRubyChangeHandler))]
-        private readonly LyricRubyChangeHandler lyricRubyChangeHandler;
+        [Cached(typeof(ILyricRubyTagsChangeHandler))]
+        private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
         [Cached(typeof(ILyricRomajiChangeHandler))]
         private readonly LyricRomajiChangeHandler lyricRomajiChangeHandler;
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             AddInternal(lyricsChangeHandler = new LyricsChangeHandler());
             AddInternal(lyricTextChangeHandler = new LyricTextChangeHandler());
             AddInternal(lyricLanguageChangeHandler = new LyricLanguageChangeHandler());
-            AddInternal(lyricRubyChangeHandler = new LyricRubyChangeHandler());
+            AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
             AddInternal(lyricRomajiChangeHandler = new LyricRomajiChangeHandler());
             AddInternal(lyricTimeTagsChangeHandler = new LyricTimeTagsChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Blueprints;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -14,6 +15,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 {
     public class RomajiBlueprintContainer : TextTagBlueprintContainer<RomajiTag>
     {
+        [Resolved]
+        private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
+
         [UsedImplicitly]
         private readonly Bindable<RomajiTag[]> romajiTags;
 
@@ -37,13 +41,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
         protected override SelectionBlueprint<RomajiTag> CreateBlueprintFor(RomajiTag item)
             => new RomajiTagSelectionBlueprint(item);
 
+        protected override void SetTextTagPosition(RomajiTag textTag, int startPosition, int endPosition)
+            => romajiTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+
         protected class RomajiTagSelectionHandler : TextTagSelectionHandler
         {
+            [Resolved]
+            private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
+
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
                 SelectedItems.BindTo(blueprintSelectionState.SelectedRomajiTags);
             }
+
+            protected override void SetTextTagPosition(RomajiTag textTag, int? startPosition, int? endPosition)
+                => romajiTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Blueprints;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -14,6 +15,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 {
     public class RubyBlueprintContainer : TextTagBlueprintContainer<RubyTag>
     {
+        [Resolved]
+        private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
+
         [UsedImplicitly]
         private readonly Bindable<RubyTag[]> rubyTags;
 
@@ -37,13 +41,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
         protected override SelectionBlueprint<RubyTag> CreateBlueprintFor(RubyTag item)
             => new RubyTagSelectionBlueprint(item);
 
+        protected override void SetTextTagPosition(RubyTag textTag, int startPosition, int endPosition)
+            => rubyTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+
         protected class RubyTagSelectionHandler : TextTagSelectionHandler
         {
+            [Resolved]
+            private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
+
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
                 SelectedItems.BindTo(blueprintSelectionState.SelectedRubyTags);
             }
+
+            protected override void SetTextTagPosition(RubyTag textTag, int? startPosition, int? endPosition)
+                => rubyTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -61,17 +61,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 if (!LyricUtils.AbleToInsertTextTagAtIndex(Lyric, newStartIndex) || !LyricUtils.AbleToInsertTextTagAtIndex(Lyric, newEndIndex))
                     continue;
 
-                item.StartIndex = newStartIndex;
-                item.EndIndex = newEndIndex;
+                SetTextTagPosition(item, newStartIndex, newEndIndex);
             }
 
             return true;
         }
 
+        protected abstract void SetTextTagPosition(T textTag, int startPosition, int endPosition);
+
         protected override IEnumerable<SelectionBlueprint<T>> SortForMovement(IReadOnlyList<SelectionBlueprint<T>> blueprints)
             => blueprints.OrderBy(b => b.Item.StartIndex);
 
-        protected class TextTagSelectionHandler : ExtendSelectionHandler<T>
+        protected abstract class TextTagSelectionHandler : ExtendSelectionHandler<T>
         {
             [Resolved]
             private EditorLyricPiece editorLyricPiece { get; set; }
@@ -112,7 +113,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                         if (startIndex >= selectedTextTag.EndIndex)
                             return false;
 
-                        selectedTextTag.StartIndex = startIndex;
+                        SetTextTagPosition(selectedTextTag, startIndex, null);
                         return true;
 
                     case Anchor.CentreRight:
@@ -121,13 +122,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                         if (endIndex <= selectedTextTag.StartIndex)
                             return false;
 
-                        selectedTextTag.EndIndex = endIndex;
+                        SetTextTagPosition(selectedTextTag, null, endIndex);
                         return true;
 
                     default:
                         return false;
                 }
             }
+
+            protected abstract void SetTextTagPosition(T textTag, int? startPosition, int? endPosition);
 
             protected override void OnSelectionChanged()
             {


### PR DESCRIPTION
What's added in this PR:
- Change the name in exist ruby/romaji handler.
- Add base interface/class for text-tag.
- Able to create, remove, set-index, and set text in ruby/romaji change handler(most logics implemented in the base class).
- Handle text change by the change handler.
- Handler index change by the change handler.