### PR TITLE
Refactor caret state 

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ApplySelectingArea.cs
@@ -171,10 +171,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
                 // should update background if mode changed.
-                bindableMode.BindValueChanged(_ =>
+                bindableMode.BindValueChanged(e =>
                 {
-                    background.Colour = colourProvider.Dark2(state.Mode);
-                    allSelectedCheckbox.AccentColour = colourProvider.Colour2(state.Mode);
+                    background.Colour = colourProvider.Dark2(e.NewValue);
+                    allSelectedCheckbox.AccentColour = colourProvider.Colour2(e.NewValue);
                 }, true);
 
                 // should disable selection if current lyric is disabled.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -226,37 +226,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     throw new ArgumentOutOfRangeException(nameof(extendArea.Direction));
             }
 
-            EditExtend getExtendArea()
-            {
-                switch (Mode)
+            EditExtend getExtendArea() =>
+                Mode switch
                 {
-                    case LyricEditorMode.Language:
-                        return new LanguageExtend();
-
-                    case LyricEditorMode.EditRuby:
-                        return new RubyTagExtend();
-
-                    case LyricEditorMode.EditRomaji:
-                        return new RomajiTagExtend();
-
-                    case LyricEditorMode.CreateTimeTag:
-                    case LyricEditorMode.RecordTimeTag:
-                    case LyricEditorMode.AdjustTimeTag:
-                        return new TimeTagExtend();
-
-                    case LyricEditorMode.EditNote:
-                        return new NoteExtend();
-
-                    case LyricEditorMode.Singer:
-                        return new SingerExtend();
-
-                    case LyricEditorMode.Layout:
-                        return new LayoutExtend();
-
-                    default:
-                        return null;
-                }
-            }
+                    LyricEditorMode.Language => new LanguageExtend(),
+                    LyricEditorMode.EditRuby => new RubyTagExtend(),
+                    LyricEditorMode.EditRomaji => new RomajiTagExtend(),
+                    LyricEditorMode.CreateTimeTag => new TimeTagExtend(),
+                    LyricEditorMode.RecordTimeTag => new TimeTagExtend(),
+                    LyricEditorMode.AdjustTimeTag => new TimeTagExtend(),
+                    LyricEditorMode.EditNote => new NoteExtend(),
+                    LyricEditorMode.Singer => new SingerExtend(),
+                    LyricEditorMode.Layout => new LayoutExtend(),
+                    _ => null
+                };
 
             bool checkDuplicatedWithExistExtend(EditExtend extend)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -73,8 +73,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public IBindable<LyricEditorMode> BindableMode => bindableMode;
 
         private readonly Bindable<float> bindableFontSize = new();
-        private readonly Bindable<MovingTimeTagCaretMode> bindableCreateMovingCaretMode = new();
-        private readonly Bindable<MovingTimeTagCaretMode> bindableRecordingMovingCaretMode = new();
         private readonly BindableList<Lyric> bindableLyrics = new();
 
         private readonly GridContainer gridContainer;
@@ -89,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         public LyricEditor()
         {
             AddInternal(lyricSelectionState = new LyricSelectionState());
-            AddInternal(lyricCaretState = new LyricCaretState());
+            AddInternal(lyricCaretState = new LyricCaretState(bindableLyrics));
             AddInternal(blueprintSelectionState = new BlueprintSelectionState());
 
             Add(gridContainer = new GridContainer
@@ -142,17 +140,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 lyricsChangeHandler?.ChangeOrder(nowOrder);
             };
 
-            lyricCaretState.MoveCaret(MovingCaretAction.First);
-
             BindableMode.BindValueChanged(e =>
             {
-                // should wait until beatmap has been loaded.
-                Schedule(() =>
-                {
-                    initialCaretPositionAlgorithm();
-                    lyricCaretState.ResetPosition(e.NewValue);
-                });
-
                 // display add new lyric only with edit mode.
                 container.DisplayBottomDrawable = e.NewValue == LyricEditorMode.Manage;
 
@@ -166,20 +155,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             bindableFontSize.BindValueChanged(e =>
             {
                 skin.FontSize = e.NewValue;
-            });
-
-            bindableCreateMovingCaretMode.BindValueChanged(_ =>
-            {
-                initialCaretPositionAlgorithm();
-
-                lyricCaretState.ResetPosition(Mode);
-            });
-
-            bindableRecordingMovingCaretMode.BindValueChanged(_ =>
-            {
-                initialCaretPositionAlgorithm();
-
-                lyricCaretState.ResetPosition(Mode);
             });
 
             lyricSelectionState.Selecting.BindValueChanged(_ =>
@@ -269,8 +244,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         private void load(EditorBeatmap beatmap)
         {
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.LyricEditorFontSize, bindableFontSize);
-            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode, bindableCreateMovingCaretMode);
-            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagMovingCaretMode, bindableRecordingMovingCaretMode);
 
             // set-up divisor.
             beatDivisor.Value = beatmap.BeatmapInfo.BeatDivisor;
@@ -297,8 +270,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     // insert to first.
                     bindableLyrics.Insert(0, lyric);
                 }
-
-                initialCaretPositionAlgorithm();
             };
             beatmap.HitObjectRemoved += e =>
             {
@@ -306,20 +277,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return;
 
                 bindableLyrics.Remove(lyric);
-                initialCaretPositionAlgorithm();
             };
-
-            initialCaretPositionAlgorithm();
-        }
-
-        private void initialCaretPositionAlgorithm()
-        {
-            var state = Mode;
-            var recordingMovingCaretMode = Mode == LyricEditorMode.RecordTimeTag
-                ? bindableRecordingMovingCaretMode.Value
-                : bindableCreateMovingCaretMode.Value;
-
-            lyricCaretState.ChangePositionAlgorithm(state, recordingMovingCaretMode);
         }
 
         public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/LyricEditorRow.cs
@@ -107,10 +107,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
                 selectedLyrics.BindTo(lyricSelectionState.SelectedLyrics);
 
                 // should update background if mode changed.
-                bindableMode.BindValueChanged(_ =>
+                bindableMode.BindValueChanged(e =>
                 {
-                    background.Colour = colourProvider.Dark2(state.Mode);
-                    selectedCheckbox.AccentColour = colourProvider.Colour2(state.Mode);
+                    background.Colour = colourProvider.Dark2(e.NewValue);
+                    selectedCheckbox.AccentColour = colourProvider.Colour2(e.NewValue);
                 }, true);
 
                 // show this area only if in selecting.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         IBindable<ICaretPosition> BindableCaretPosition { get; }
 
-        void ChangePositionAlgorithm(LyricEditorMode lyricEditorMode, MovingTimeTagCaretMode movingTimeTagCaretMode);
-
         bool MoveCaret(MovingCaretAction action);
 
         void MoveCaretToTargetPosition(Lyric lyric);
@@ -24,8 +22,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         void MoveHoverCaretToTargetPosition(ICaretPosition position);
 
         void ClearHoverCaretPosition();
-
-        void ResetPosition(LyricEditorMode mode);
 
         bool CaretPositionMovable(ICaretPosition position);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -39,6 +39,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             this.lyrics = lyrics;
             this.lyrics.BindCollectionChanged((a, b) =>
             {
+                // should reset caret position if not in the list.
+                var caretLyric = BindableCaretPosition.Value?.Lyric;
+
+                // should adjust hover lyric if lyric has been deleted.
+                if (caretLyric != null && !lyrics.Contains(caretLyric))
+                {
+                    // if delete the current lyric, most of cases should move up.
+                    MoveCaret(MovingCaretAction.Up);
+                }
+
                 refreshAlgorithmAndCaretPosition();
             });
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -6,10 +6,12 @@ using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using Component = osu.Framework.Graphics.Component;
 
@@ -18,25 +20,70 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
     public class LyricCaretState : Component, ILyricCaretState
     {
         public IBindable<ICaretPosition> BindableHoverCaretPosition => bindableHoverCaretPosition;
-
         public IBindable<ICaretPosition> BindableCaretPosition => bindableCaretPosition;
 
         private readonly Bindable<ICaretPosition> bindableHoverCaretPosition = new();
-
         private readonly Bindable<ICaretPosition> bindableCaretPosition = new();
 
         private ICaretPositionAlgorithm algorithm;
 
-        [Resolved]
-        private EditorBeatmap beatmap { get; set; }
+        private readonly BindableList<HitObject> selectedHitObjects = new();
+        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+        private readonly IBindable<MovingTimeTagCaretMode> bindableCreateMovingCaretMode = new Bindable<MovingTimeTagCaretMode>();
+        private readonly IBindable<MovingTimeTagCaretMode> bindableRecordingMovingCaretMode = new Bindable<MovingTimeTagCaretMode>();
 
-        public void ChangePositionAlgorithm(LyricEditorMode lyricEditorMode, MovingTimeTagCaretMode movingTimeTagCaretMode)
+        private readonly IBindableList<Lyric> lyrics;
+
+        public LyricCaretState(IBindableList<Lyric> lyrics)
         {
-            var lyrics = beatmap.HitObjects.OfType<Lyric>().ToArray();
-            algorithm = getAlgorithmByMode(lyricEditorMode);
+            this.lyrics = lyrics;
+            this.lyrics.BindCollectionChanged((a, b) =>
+            {
+                refreshAlgorithmAndCaretPosition();
+            });
 
-            ICaretPositionAlgorithm getAlgorithmByMode(LyricEditorMode mode) =>
-                mode switch
+            bindableMode.BindValueChanged(e =>
+            {
+                // Should refresh algorithm until all component loaded.
+                Schedule(refreshAlgorithmAndCaretPosition);
+            });
+
+            bindableCreateMovingCaretMode.BindValueChanged(_ =>
+            {
+                refreshAlgorithmAndCaretPosition();
+            });
+
+            bindableRecordingMovingCaretMode.BindValueChanged(_ =>
+            {
+                refreshAlgorithmAndCaretPosition();
+            });
+
+            refreshAlgorithmAndCaretPosition();
+
+            // should move the caret to first.
+            MoveCaret(MovingCaretAction.First);
+        }
+
+        private void refreshAlgorithmAndCaretPosition()
+        {
+            var mode = bindableMode.Value;
+            var recordingMovingCaretMode = mode == LyricEditorMode.RecordTimeTag
+                ? bindableRecordingMovingCaretMode.Value
+                : bindableCreateMovingCaretMode.Value;
+
+            // refresh algorithm
+            algorithm = getAlgorithmByMode(lyrics.ToArray(), mode, recordingMovingCaretMode);
+
+            // refresh caret position
+            var lyric = bindableCaretPosition.Value?.Lyric;
+            bindableCaretPosition.Value = getCaretPosition(algorithm, lyric);
+            bindableHoverCaretPosition.Value = getCaretPosition(algorithm, lyric);
+
+            // should update selection if selected lyric changed.
+            updateEditorBeatmapSelectedHitObject(bindableCaretPosition.Value?.Lyric);
+
+            static ICaretPositionAlgorithm getAlgorithmByMode(Lyric[] lyrics, LyricEditorMode lyricEditorMode, MovingTimeTagCaretMode movingTimeTagCaretMode) =>
+                lyricEditorMode switch
                 {
                     LyricEditorMode.Manage => new CuttingCaretPositionAlgorithm(lyrics),
                     LyricEditorMode.Typing => new TypingCaretPositionAlgorithm(lyrics),
@@ -50,6 +97,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                     LyricEditorMode.Singer => new NavigateCaretPositionAlgorithm(lyrics),
                     _ => null
                 };
+
+            static ICaretPosition getCaretPosition(ICaretPositionAlgorithm algorithm, Lyric lyric)
+            {
+                if (algorithm == null)
+                    return null;
+
+                if (lyric == null)
+                    return algorithm.CallMethod<ICaretPosition>("MoveToFirst");
+
+                return algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
+            }
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(EditorBeatmap beatmap, ILyricEditorState state, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
+        {
+            selectedHitObjects.BindTo(beatmap.SelectedHitObjects);
+            bindableMode.BindTo(state.BindableMode);
+
+            bindableCreateMovingCaretMode.BindTo(lyricEditorConfigManager.GetBindable<MovingTimeTagCaretMode>(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode));
+            bindableRecordingMovingCaretMode.BindTo(lyricEditorConfigManager.GetBindable<MovingTimeTagCaretMode>(KaraokeRulesetLyricEditorSetting.RecordingTimeTagMovingCaretMode));
         }
 
         public bool MoveCaret(MovingCaretAction action)
@@ -148,32 +216,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             bindableHoverCaretPosition.Value = null;
         }
 
-        public void ResetPosition(LyricEditorMode mode)
-        {
-            var lyric = bindableCaretPosition.Value?.Lyric;
-
-            if (algorithm != null)
-            {
-                if (lyric != null)
-                {
-                    bindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
-                    bindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition, Lyric>("MoveToTarget", lyric);
-                }
-                else
-                {
-                    bindableCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
-                    bindableHoverCaretPosition.Value = algorithm.CallMethod<ICaretPosition>("MoveToFirst");
-                }
-            }
-            else
-            {
-                bindableCaretPosition.Value = null;
-                bindableHoverCaretPosition.Value = null;
-            }
-
-            updateEditorBeatmapSelectedHitObject(lyric);
-        }
-
         public bool CaretPositionMovable(ICaretPosition position)
         {
             return algorithm?.CallMethod<bool, ICaretPosition>("PositionMovable", position) ?? false;
@@ -181,12 +223,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public bool CaretEnabled => algorithm != null;
 
-        private void updateEditorBeatmapSelectedHitObject(Lyric lyric)
+        private void updateEditorBeatmapSelectedHitObject(HitObject hitObject)
         {
-            beatmap.SelectedHitObjects.Clear();
+            selectedHitObjects.Clear();
 
-            if (lyric != null)
-                beatmap.SelectedHitObjects.Add(lyric);
+            if (hitObject != null)
+                selectedHitObjects.Add(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 return;
 
             // should sync selection to editor beatmap because auto-generate will be apply to those lyric that being selected.
-            var selectedLyrics = this.bindableSelectedLyrics.ToArray();
+            var selectedLyrics = bindableSelectedLyrics.ToArray();
             beatmap.SelectedHitObjects.Clear();
             beatmap.SelectedHitObjects.AddRange(selectedLyrics);
 


### PR DESCRIPTION
What's done in this pr:
- clean-up code.
- move some logic about caret position from the lyric editor into the caret state.
- remove some public interfaces like "reset algorithm" or "change caret by mode" because it's dangerous.
- should move up the caret if the caret has hovered on the deleted lyric. (typing to fix issue #1006 but seems not working on this mode.)

Events can see:
![image](https://user-images.githubusercontent.com/9100368/148649843-d8ca7127-8b38-4564-b415-a9c3ffc97255.png)
https://miro.com/app/board/uXjVOXWzV6Y=/?invite_link_id=649464354309