### PR TITLE
Fix navigation bar not change text in some cases.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -12,9 +14,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
         private const string cutting_mode = "CUTTING_MODE";
         private const string typing_mode = "TYPING_MODE";
 
+        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+
         public EditLyricNavigation(EditLyricStepScreen screen)
             : base(screen)
         {
+            bindableMode.BindValueChanged(_ =>
+            {
+                // should update the display text in navigation bar if mode change.
+                TriggerStateChange();
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ILyricEditorState state)
+        {
+            bindableMode.BindTo(state.BindableMode);
         }
 
         protected override NavigationTextContainer CreateTextContainer()

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
@@ -12,6 +12,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     public abstract class LyricImporterStepScreenWithLyricEditor : LyricImporterStepScreenWithTopNavigation
     {
+        // it's a tricky way to let navigation bar able to get the lyric state.
+        // not a good solution, but have no better way now.
+        [Cached(typeof(ILyricEditorState))]
         private ImportLyricEditor lyricEditor { get; set; }
 
         [Cached(typeof(ILockChangeHandler))]

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/TopNavigation.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/TopNavigation.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         [Resolved]
         private OsuColour colours { get; set; }
 
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         protected LyricImporterStepScreen Screen { get; }
 
         private readonly CornerBackground background;
@@ -81,15 +84,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
             // use transaction ended for some reason.
             // 1. seems customized beatmap cannot get hit object updated event(not really sure why).
             // 2. object updated event will trigger hit object updated event lots of time.
-            editorBeatmap.TransactionEnded += updateState;
+            editorBeatmap.TransactionEnded += TriggerStateChange;
 
-            updateState();
+            TriggerStateChange();
+        }
 
-            void updateState()
-            {
-                state = GetState(editorBeatmap.HitObjects.OfType<Lyric>().ToArray());
-                updateNavigationDisplayInfo(state);
-            }
+        protected void TriggerStateChange()
+        {
+            state = GetState(editorBeatmap.HitObjects.OfType<Lyric>().ToArray());
+            updateNavigationDisplayInfo(state);
         }
 
         private void updateNavigationDisplayInfo(NavigationState value)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
@@ -1,0 +1,24 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
+{
+    public class RomajiTagEditModeSection : TextTagEditModeSection
+    {
+        protected override Dictionary<TextTagEditMode, EditModeSelectionItem> CreateSelections()
+            => new()
+            {
+                {
+                    TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate romajies in the lyric.")
+                },
+                {
+                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric romajies in here.")
+                },
+                {
+                    TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid romajies in here.")
+                }
+            };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Generate:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RomajiTagEditModeSection(),
                             new RomajiTagAutoGenerateSection(),
                         };
                         break;
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Edit:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RomajiTagEditModeSection(),
                             new RomajiTagEditSection(),
                         };
                         break;
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Verify:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RomajiTagEditModeSection(),
                             new RomajiTagIssueSection(),
                         };
                         break;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
@@ -1,0 +1,24 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
+{
+    public class RubyTagEditModeSection : TextTagEditModeSection
+    {
+        protected override Dictionary<TextTagEditMode, EditModeSelectionItem> CreateSelections()
+            => new()
+            {
+                {
+                    TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate rubies in the lyric.")
+                },
+                {
+                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric rubies in here.")
+                },
+                {
+                    TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid rubies in here.")
+                }
+            };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Generate:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RubyTagEditModeSection(),
                             new RubyTagAutoGenerateSection(),
                         };
                         break;
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Edit:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RubyTagEditModeSection(),
                             new RubyTagEditSection(),
                         };
                         break;
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     case TextTagEditMode.Verify:
                         Children = new Drawable[]
                         {
-                            new TextTagEditModeSection(),
+                            new RubyTagEditModeSection(),
                             new RubyTagIssueSection(),
                         };
                         break;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Graphics;
@@ -12,7 +11,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class TextTagEditModeSection : EditModeSection<TextTagEditMode>
+    public abstract class TextTagEditModeSection : EditModeSection<TextTagEditMode>
     {
         [Resolved]
         private Bindable<TextTagEditMode> bindableEditMode { get; set; }
@@ -22,20 +21,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         protected override TextTagEditMode DefaultMode()
             => bindableEditMode.Value;
-
-        protected override Dictionary<TextTagEditMode, EditModeSelectionItem> CreateSelections()
-            => new()
-            {
-                {
-                    TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate ruby/romaji tag.")
-                },
-                {
-                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric text tag in here.")
-                },
-                {
-                    TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid text tag in here.")
-                }
-            };
 
         protected override Color4 GetColour(OsuColour colour, TextTagEditMode mode, bool active) =>
             mode switch


### PR DESCRIPTION
What's fixed in this PR:
- fix navigation bar not update mode if lyric editor mode changed.
- make ruby/romaji extend area has its own text for better regonized.