### PR TITLE
Implement delete range of ruby romaji

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         void RemoveAll(IEnumerable<TTextTag> textTags);
 
-        void SetPosition(TTextTag textTag, int? startIndex, int? endIndex);
+        void SetIndex(TTextTag textTag, int? startIndex, int? endIndex);
 
         void SetText(TTextTag textTag, string text);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
@@ -10,6 +11,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         void Add(TTextTag textTag);
 
         void Remove(TTextTag textTag);
+
+        void RemoveAll(IEnumerable<TTextTag> textTags);
 
         void SetPosition(TTextTag textTag, int? startIndex, int? endIndex);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
-        public void SetPosition(TTextTag textTag, int? startIndex, int? endIndex)
+        public void SetIndex(TTextTag textTag, int? startIndex, int? endIndex)
         {
             PerformOnSelection(lyric =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
@@ -30,6 +32,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                     throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
 
                 RemoveFromLyric(lyric, textTag);
+            });
+        }
+
+        public void RemoveAll(IEnumerable<TTextTag> textTags)
+        {
+            PerformOnSelection(lyric =>
+            {
+                // should convert to array because enumerable might change while deleting.
+                foreach (var textTag in textTags.ToArray())
+                {
+                    bool containsInLyric = ContainsInLyric(lyric, textTag);
+                    if (containsInLyric == false)
+                        throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                    RemoveFromLyric(lyric, textTag);
+                }
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             protected override void DeleteItems(IEnumerable<RomajiTag> items)
                 => romajiTagsChangeHandler.RemoveAll(items);
 
-            protected override void SetTextTagPosition(RomajiTag textTag, int? startPosition, int? endPosition)
+            protected override void SetTextTagIndex(RomajiTag textTag, int? startPosition, int? endPosition)
                 => romajiTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             => new RomajiTagSelectionBlueprint(item);
 
         protected override void SetTextTagPosition(RomajiTag textTag, int startPosition, int endPosition)
-            => romajiTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+            => romajiTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
 
         protected class RomajiTagSelectionHandler : TextTagSelectionHandler
         {
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 => romajiTagsChangeHandler.RemoveAll(items);
 
             protected override void SetTextTagPosition(RomajiTag textTag, int? startPosition, int? endPosition)
-                => romajiTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+                => romajiTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -54,6 +55,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             {
                 SelectedItems.BindTo(blueprintSelectionState.SelectedRomajiTags);
             }
+
+            protected override void DeleteItems(IEnumerable<RomajiTag> items)
+                => romajiTagsChangeHandler.RemoveAll(items);
 
             protected override void SetTextTagPosition(RomajiTag textTag, int? startPosition, int? endPosition)
                 => romajiTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             protected override void DeleteItems(IEnumerable<RubyTag> items)
                 => rubyTagsChangeHandler.RemoveAll(items);
 
-            protected override void SetTextTagPosition(RubyTag textTag, int? startPosition, int? endPosition)
+            protected override void SetTextTagIndex(RubyTag textTag, int? startPosition, int? endPosition)
                 => rubyTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             => new RubyTagSelectionBlueprint(item);
 
         protected override void SetTextTagPosition(RubyTag textTag, int startPosition, int endPosition)
-            => rubyTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+            => rubyTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
 
         protected class RubyTagSelectionHandler : TextTagSelectionHandler
         {
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 => rubyTagsChangeHandler.RemoveAll(items);
 
             protected override void SetTextTagPosition(RubyTag textTag, int? startPosition, int? endPosition)
-                => rubyTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);
+                => rubyTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -54,6 +56,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             {
                 SelectedItems.BindTo(blueprintSelectionState.SelectedRubyTags);
             }
+
+            protected override void DeleteItems(IEnumerable<RubyTag> items)
+                => rubyTagsChangeHandler.RemoveAll(items);
 
             protected override void SetTextTagPosition(RubyTag textTag, int? startPosition, int? endPosition)
                 => rubyTagsChangeHandler.SetPosition(textTag, startPosition, endPosition);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -80,11 +80,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
             public override bool HandleMovement(MoveSelectionEvent<T> moveEvent) => true;
 
-            protected override void DeleteItems(IEnumerable<T> items)
-            {
-                // todo : delete ruby or romaji
-            }
-
             private float deltaPosition;
 
             protected override void OnOperationBegan()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                         if (startIndex >= selectedTextTag.EndIndex)
                             return false;
 
-                        SetTextTagPosition(selectedTextTag, startIndex, null);
+                        SetTextTagIndex(selectedTextTag, startIndex, null);
                         return true;
 
                     case Anchor.CentreRight:
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                         if (endIndex <= selectedTextTag.StartIndex)
                             return false;
 
-                        SetTextTagPosition(selectedTextTag, null, endIndex);
+                        SetTextTagIndex(selectedTextTag, null, endIndex);
                         return true;
 
                     default:
@@ -125,7 +125,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 }
             }
 
-            protected abstract void SetTextTagPosition(T textTag, int? startPosition, int? endPosition);
+            protected abstract void SetTextTagIndex(T textTag, int? startPosition, int? endPosition);
 
             protected override void OnSelectionChanged()
             {


### PR DESCRIPTION
What's done in this PR:
- implement remove the list of rubies/romajes by right-clicking the selection handler.
- remove some parts from position to index.