### PR TITLE
Fix ruby/romaji cannot drag. 

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
@@ -228,8 +228,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(new[] { "[0,0]:ruby" }, new[] { "[0,0]:ルビ" }, new[] { "[0,0]:ruby", "[7,7]:ルビ" })]
         [TestCase(new[] { "[0,0]:" }, new[] { "[0,0]:" }, new[] { "[0,0]:", "[7,7]:" })]
         [TestCase(new[] { "[0,3]:" }, new[] { "[0,3]:" }, new[] { "[0,3]:", "[7,10]:" })]
-        [TestCase(new[] { "[0,10]:" }, new[] { "[0,10]:" }, new[] { "[0,10]:", "[7,17]:" })] // deal with the case out of range.
-        [TestCase(new[] { "[-10,0]:" }, new[] { "[-10,0]:" }, new[] { "[-10,0]:", "[-3,7]:" })] // deal with the case out of range.
+        [TestCase(new[] { "[0,10]:" }, new[] { "[0,10]:" }, new[] { "[0,10]:", "[7,14]:" })] // will auto-fix ruby index.
+        [TestCase(new[] { "[-10,0]:" }, new[] { "[-10,0]:" }, new[] { "[-10,0]:", "[0,7]:" })] // will auto-fix ruby index.
         public void TestCombineLyricRubyTag(string[] firstRubyTags, string[] secondRubyTags, string[] actualRubyTags)
         {
             var lyric1 = new Lyric
@@ -251,8 +251,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(new[] { "[0,0]:romaji" }, new[] { "[0,0]:ローマ字" }, new[] { "[0,0]:romaji", "[7,7]:ローマ字" })]
         [TestCase(new[] { "[0,0]:" }, new[] { "[0,0]:" }, new[] { "[0,0]:", "[7,7]:" })]
         [TestCase(new[] { "[0,3]:" }, new[] { "[0,3]:" }, new[] { "[0,3]:", "[7,10]:" })]
-        [TestCase(new[] { "[0,10]:" }, new[] { "[0,10]:" }, new[] { "[0,10]:", "[7,17]:" })] // deal with the case out of range.
-        [TestCase(new[] { "[-10,0]:" }, new[] { "[-10,0]:" }, new[] { "[-10,0]:", "[-3,7]:" })] // deal with the case out of range.
+        [TestCase(new[] { "[0,10]:" }, new[] { "[0,10]:" }, new[] { "[0,10]:", "[7,14]:" })] // will auto-fix romaji index.
+        [TestCase(new[] { "[-10,0]:" }, new[] { "[-10,0]:" }, new[] { "[-10,0]:", "[0,7]:" })] // will auto-fix romaji index.
         public void TestCombineLyricRomajiTag(string[] firstRomajiTags, string[] secondRomajiTags, string[] actualRomajiTags)
         {
             var lyric1 = new Lyric

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("[0,1]:ka", "", true)]
         [TestCase("[0,1]:ka", null, true)]
         [TestCase("[0,-1]:ka", "karaoke", true)]
+        [TestCase("[1,0]:ka", "karaoke", false)] // should not be counted as out of range if index is not ordered.
         [TestCase("[0,0]:ka", "", true)] // should be counted as out of range if lyric is empty
         [TestCase("[0,0]:ka", null, true)] // should be counted as out of range if lyric is null
         public void TestOutOfRange(string textTag, string lyric, bool outOfRange)
@@ -99,8 +100,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("[0,1]:", "empty(0 ~ 1)")]
         [TestCase("[-1,1]:ka", "ka(-1 ~ 1)")]
         [TestCase("[-1,-1]:ka", "ka(-1 ~ -1)")]
-        [TestCase("[-1,-2]:ka", "ka(-2 ~ -1)")]
-        [TestCase("[2,1]:ka", "ka(1 ~ 2)")]
+        [TestCase("[-1,-2]:ka", "ka(-1 ~ -2)")] // will not fix the order in display.
+        [TestCase("[2,1]:ka", "ka(2 ~ 1)")] // will not fix the order in display.
         public void TestPositionFormattedString(string textTag, string actual)
         {
             var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase("[0,1]:ka", "", -1, "[0,0]:ka")]
         [TestCase("[0,1]:ka", null, -1, "[0,0]:ka")]
         [TestCase("[0,1]:ka", null, 1, "[0,0]:ka")]
-        [TestCase("[1,0]:ka", "karaoke", 1, "[2,1]:ka")] // do not check order in here.
+        [TestCase("[1,0]:ka", "karaoke", 0, "[0,1]:ka")] // will auto fix the position
+        [TestCase("[1,0]:ka", "karaoke", 1, "[1,2]:ka")]
         public void TestGetShiftingIndex(string textTag, string lyric, int shifting, string actualTag)
         {
             // test ruby tag.

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -30,21 +32,35 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             TextTagAssert.ArePropertyEqual(TextTagUtils.FixTimeTagPosition(romajiTag), actualRomaji);
         }
 
-        [TestCase("[0,1]:ka", 1, "[1,2]:ka")]
-        [TestCase("[0,1]:", 1, "[1,2]:")]
-        [TestCase("[0,1]:ka", -1, "[-1,0]:ka")] // do not check out of range in here.
-        [TestCase("[1,0]:ka", 1, "[2,1]:ka")] // do not check order in here.
-        public void TestShifting(string textTag, int shifting, string actualTag)
+        [TestCase("[0,1]:ka", "karaoke", 1, "[1,2]:ka")]
+        [TestCase("[0,1]:", "karaoke", 1, "[1,2]:")]
+        [TestCase("[0,1]:ka", "karaoke", -1, "[0,0]:ka")]
+        [TestCase("[0,1]:ka", "", -1, "[0,0]:ka")]
+        [TestCase("[0,1]:ka", null, -1, "[0,0]:ka")]
+        [TestCase("[0,1]:ka", null, 1, "[0,0]:ka")]
+        [TestCase("[1,0]:ka", "karaoke", 1, "[2,1]:ka")] // do not check order in here.
+        public void TestGetShiftingIndex(string textTag, string lyric, int shifting, string actualTag)
         {
             // test ruby tag.
             var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
-            TextTagAssert.ArePropertyEqual(TextTagUtils.Shifting(rubyTag, shifting), actualRubyTag);
+            TextTagAssert.ArePropertyEqual(generateShiftingTag(rubyTag, lyric, shifting), actualRubyTag);
 
             // test romaji tag.
             var romajiTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRomaji = TestCaseTagHelper.ParseRubyTag(actualTag);
-            TextTagAssert.ArePropertyEqual(TextTagUtils.Shifting(romajiTag, shifting), actualRomaji);
+            TextTagAssert.ArePropertyEqual(generateShiftingTag(romajiTag, lyric, shifting), actualRomaji);
+
+            static T generateShiftingTag<T>(T textTag, string lyric, int shifting) where T : ITextTag, new()
+            {
+                (int startIndex, int endIndex) = TextTagUtils.GetShiftingIndex(textTag, lyric, shifting);
+                return new T
+                {
+                    Text = textTag.Text,
+                    StartIndex = startIndex,
+                    EndIndex = endIndex
+                };
+            }
         }
 
         [TestCase("[0,1]:ka", "karaoke", false)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -13,23 +13,34 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
     [TestFixture]
     public class TextTagUtilsTest
     {
-        [TestCase("[0,1]:ka", "[0,1]:ka")]
-        [TestCase("[0,1]:", "[0,1]:")]
-        [TestCase("[0,0]:ka", "[0,0]:ka")] // ignore at same index
-        [TestCase("[-1,1]:ka", "[-1,1]:ka")] // ignore negative index
-        [TestCase("[3,1]:ka", "[1,3]:ka")]
-        [TestCase("[3,-1]:ka", "[-1,3]:ka")] // fix but ignore negative index.
-        public void TestFixTimeTagPosition(string textTag, string actualTag)
+        [TestCase("[0,1]:ka", "karaoke", "[0,1]:ka")]
+        [TestCase("[0,1]:", "karaoke", "[0,1]:")]
+        [TestCase("[0,0]:ka", "karaoke", "[0,0]:ka")] // ignore at same index
+        [TestCase("[-1,1]:ka", "karaoke", "[0,1]:ka")]
+        [TestCase("[3,1]:ka", "karaoke", "[1,3]:ka")]
+        [TestCase("[3,-1]:ka", "karaoke", "[0,3]:ka")]
+        public void TestGetFixedIndex(string textTag, string lyric, string actualTag)
         {
             // test ruby tag.
             var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
-            TextTagAssert.ArePropertyEqual(TextTagUtils.FixTimeTagPosition(rubyTag), actualRubyTag);
+            TextTagAssert.ArePropertyEqual(generateFixedTag(rubyTag, lyric), actualRubyTag);
 
             // test romaji tag.
             var romajiTag = TestCaseTagHelper.ParseRubyTag(textTag);
             var actualRomaji = TestCaseTagHelper.ParseRubyTag(actualTag);
-            TextTagAssert.ArePropertyEqual(TextTagUtils.FixTimeTagPosition(romajiTag), actualRomaji);
+            TextTagAssert.ArePropertyEqual(generateFixedTag(romajiTag, lyric), actualRomaji);
+
+            static T generateFixedTag<T>(T textTag, string lyric) where T : ITextTag, new()
+            {
+                (int startIndex, int endIndex) = TextTagUtils.GetFixedIndex(textTag, lyric);
+                return new T
+                {
+                    Text = textTag.Text,
+                    StartIndex = startIndex,
+                    EndIndex = endIndex
+                };
+            }
         }
 
         [TestCase("[0,1]:ka", "karaoke", 1, "[1,2]:ka")]

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         void SetIndex(TTextTag textTag, int? startIndex, int? endIndex);
 
+        void OffsetIndex(IEnumerable<TTextTag> textTags, int offset);
+
         void SetText(TTextTag textTag, string text);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextTagsChangeHandler.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         void SetIndex(TTextTag textTag, int? startIndex, int? endIndex);
 
-        void OffsetIndex(IEnumerable<TTextTag> textTags, int offset);
+        void ShiftingIndex(IEnumerable<TTextTag> textTags, int offset);
 
         void SetText(TTextTag textTag, string text);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
-        public void OffsetIndex(IEnumerable<TTextTag> textTags, int offset)
+        public void ShiftingIndex(IEnumerable<TTextTag> textTags, int offset)
         {
             // note: it's ok not sort the text tag by index.
             PerformOnSelection(lyric =>

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -6,10 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public abstract class LyricTextTagsChangeHandler<TTextTag> : HitObjectChangeHandler<Lyric>, ILyricTextTagsChangeHandler<TTextTag> where TTextTag : ITextTag
+    public abstract class LyricTextTagsChangeHandler<TTextTag> : HitObjectChangeHandler<Lyric>, ILyricTextTagsChangeHandler<TTextTag> where TTextTag : class, ITextTag, new()
     {
         public void Add(TTextTag textTag)
         {
@@ -53,6 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void SetIndex(TTextTag textTag, int? startIndex, int? endIndex)
         {
+            // note: it's ok not sort the text tag by index.
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = ContainsInLyric(lyric, textTag);
@@ -64,6 +66,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
                 if (endIndex != null)
                     textTag.EndIndex = endIndex.Value;
+            });
+        }
+
+        public void OffsetIndex(IEnumerable<TTextTag> textTags, int offset)
+        {
+            // note: it's ok not sort the text tag by index.
+            PerformOnSelection(lyric =>
+            {
+                foreach (var textTag in textTags)
+                {
+                    bool containsInLyric = ContainsInLyric(lyric, textTag);
+                    if (containsInLyric == false)
+                        throw new InvalidOperationException($"{nameof(textTag)} is not in the lyric");
+
+                    (int startIndex, int endIndex) = TextTagUtils.GetShiftingIndex(textTag, lyric.Text, offset);
+                    textTag.StartIndex = startIndex;
+                    textTag.EndIndex = endIndex;
+                }
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -16,9 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 {
     public class RomajiBlueprintContainer : TextTagBlueprintContainer<RomajiTag>
     {
-        [Resolved]
-        private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
-
         [UsedImplicitly]
         private readonly BindableList<RomajiTag> romajiTags;
 
@@ -41,9 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
         protected override SelectionBlueprint<RomajiTag> CreateBlueprintFor(RomajiTag item)
             => new RomajiTagSelectionBlueprint(item);
-
-        protected override void SetTextTagPosition(RomajiTag textTag, int startPosition, int endPosition)
-            => romajiTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
 
         protected class RomajiTagSelectionHandler : TextTagSelectionHandler
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RomajiBlueprintContainer.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             protected override void DeleteItems(IEnumerable<RomajiTag> items)
                 => romajiTagsChangeHandler.RemoveAll(items);
 
+            protected override void SetTextTagShifting(IEnumerable<RomajiTag> textTags, int offset)
+                => romajiTagsChangeHandler.ShiftingIndex(textTags, offset);
+
             protected override void SetTextTagIndex(RomajiTag textTag, int? startPosition, int? endPosition)
                 => romajiTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             protected override void DeleteItems(IEnumerable<RubyTag> items)
                 => rubyTagsChangeHandler.RemoveAll(items);
 
+            protected override void SetTextTagShifting(IEnumerable<RubyTag> textTags, int offset)
+                => rubyTagsChangeHandler.ShiftingIndex(textTags, offset);
+
             protected override void SetTextTagIndex(RubyTag textTag, int? startPosition, int? endPosition)
                 => rubyTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/RubyBlueprintContainer.cs
@@ -16,9 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 {
     public class RubyBlueprintContainer : TextTagBlueprintContainer<RubyTag>
     {
-        [Resolved]
-        private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
-
         [UsedImplicitly]
         private readonly BindableList<RubyTag> rubyTags;
 
@@ -41,9 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
         protected override SelectionBlueprint<RubyTag> CreateBlueprintFor(RubyTag item)
             => new RubyTagSelectionBlueprint(item);
-
-        protected override void SetTextTagPosition(RubyTag textTag, int startPosition, int endPosition)
-            => rubyTagsChangeHandler.SetIndex(textTag, startPosition, endPosition);
 
         protected class RubyTagSelectionHandler : TextTagSelectionHandler
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Framework.Logging;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
@@ -43,55 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             [Resolved]
             private EditorLyricPiece editorLyricPiece { get; set; }
 
-            // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
-            public override bool HandleMovement(MoveSelectionEvent<T> moveEvent) => true;
-
-            private float deltaPosition;
-
-            protected override void OnOperationBegan()
-            {
-                base.OnOperationBegan();
-                deltaPosition = 0;
-            }
-
-            public override bool HandleScale(Vector2 scale, Anchor anchor)
-            {
-                deltaPosition += scale.X;
-
-                // this feature only works if only select one ruby / romaji tag.
-                var selectedTextTag = SelectedItems.FirstOrDefault();
-                if (selectedTextTag == null)
-                    return false;
-
-                // get real left-side and right-side position
-                var rect = editorLyricPiece.GetTextTagPosition(selectedTextTag);
-
-                switch (anchor)
-                {
-                    case Anchor.CentreLeft:
-                        float leftPosition = rect.Left + deltaPosition;
-                        int startIndex = TextIndexUtils.ToStringIndex(editorLyricPiece.GetHoverIndex(leftPosition));
-                        if (startIndex >= selectedTextTag.EndIndex)
-                            return false;
-
-                        SetTextTagIndex(selectedTextTag, startIndex, null);
-                        return true;
-
-                    case Anchor.CentreRight:
-                        float rightPosition = rect.Right + deltaPosition;
-                        int endIndex = TextIndexUtils.ToStringIndex(editorLyricPiece.GetHoverIndex(rightPosition));
-                        if (endIndex <= selectedTextTag.StartIndex)
-                            return false;
-
-                        SetTextTagIndex(selectedTextTag, null, endIndex);
-                        return true;
-
-                    default:
-                        return false;
-                }
-            }
-
-            protected abstract void SetTextTagIndex(T textTag, int? startPosition, int? endPosition);
+            private float deltaScaleSize;
 
             protected override void OnSelectionChanged()
             {
@@ -99,7 +53,105 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
                 // only select one ruby / romaji tag can let user drag to change start and end index.
                 SelectionBox.CanScaleX = SelectedItems.Count == 1;
+
+                // should clear delta size before change start/end index.
+                deltaScaleSize = 0;
             }
+
+            #region User Input Handling
+
+            // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
+            public override bool HandleMovement(MoveSelectionEvent<T> moveEvent)
+            {
+                var selectedTextTags = SelectedItems;
+                if (!selectedTextTags.Any())
+                    throw new InvalidOperationException("Should have at least one selected item.");
+
+                float deltaXPosition = moveEvent.ScreenSpaceDelta.X;
+                Logger.LogPrint($"position: {deltaXPosition}", LoggingTarget.Information);
+
+                if (deltaXPosition < 0)
+                {
+                    var firstTimeTag = selectedTextTags.OrderBy(x => x.StartIndex).FirstOrDefault();
+                    int newStartIndex = calculateNewIndex(firstTimeTag, deltaXPosition, Anchor.CentreLeft);
+                    int shifting = newStartIndex - firstTimeTag!.StartIndex;
+                    if (shifting == 0)
+                        return false;
+
+                    SetTextTagShifting(selectedTextTags, -1);
+                }
+                else
+                {
+                    var lastTimeTag = selectedTextTags.OrderBy(x => x.EndIndex).LastOrDefault();
+                    int newEndIndex = calculateNewIndex(lastTimeTag, deltaXPosition, Anchor.CentreRight);
+                    int shifting = newEndIndex - lastTimeTag!.EndIndex;
+                    if (shifting == 0)
+                        return false;
+
+                    SetTextTagShifting(selectedTextTags, 1);
+                }
+
+                return true;
+            }
+
+            public override bool HandleScale(Vector2 scale, Anchor anchor)
+            {
+                deltaScaleSize += scale.X;
+
+                // this feature only works if only select one ruby / romaji tag.
+                var selectedTextTag = SelectedItems.FirstOrDefault();
+                if (selectedTextTag == null)
+                    return false;
+
+                switch (anchor)
+                {
+                    case Anchor.CentreLeft:
+                        int newStartIndex = calculateNewIndex(selectedTextTag, deltaScaleSize, anchor);
+                        if (newStartIndex >= selectedTextTag.EndIndex)
+
+                            return false;
+
+                        SetTextTagIndex(selectedTextTag, newStartIndex, null);
+                        return true;
+
+                    case Anchor.CentreRight:
+                        int newEndIndex = calculateNewIndex(selectedTextTag, deltaScaleSize, anchor);
+                        if (newEndIndex <= selectedTextTag.StartIndex)
+                            return false;
+
+                        SetTextTagIndex(selectedTextTag, null, newEndIndex);
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+
+            private int calculateNewIndex(T textTag, float offset, Anchor anchor)
+            {
+                // get real left-side and right-side position
+                var rect = editorLyricPiece.GetTextTagPosition(textTag);
+
+                switch (anchor)
+                {
+                    case Anchor.CentreLeft:
+                        float leftPosition = rect.Left + offset;
+                        return TextIndexUtils.ToStringIndex(editorLyricPiece.GetHoverIndex(leftPosition));
+
+                    case Anchor.CentreRight:
+                        float rightPosition = rect.Right + offset;
+                        return TextIndexUtils.ToStringIndex(editorLyricPiece.GetHoverIndex(rightPosition));
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(anchor));
+                }
+            }
+
+            #endregion
+
+            protected abstract void SetTextTagShifting(IEnumerable<T> textTags, int offset);
+
+            protected abstract void SetTextTagIndex(T textTag, int? startPosition, int? endPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -20,9 +20,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
     public abstract class TextTagBlueprintContainer<T> : ExtendBlueprintContainer<T> where T : class, ITextTag
     {
         [Resolved]
-        private EditorLyricPiece editorLyricPiece { get; set; }
-
-        [Resolved]
         private ILyricCaretState lyricCaretState { get; set; }
 
         protected readonly Lyric Lyric;
@@ -37,37 +34,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
             lyricCaretState.MoveCaretToTargetPosition(Lyric);
             return base.OnMouseDown(e);
         }
-
-        protected override bool ApplySnapResult(SelectionBlueprint<T>[] blueprints, SnapResult result)
-        {
-            if (!base.ApplySnapResult(blueprints, result))
-                return false;
-
-            // handle lots of ruby / romaji drag position changed.
-            var items = blueprints.Select(x => x.Item).ToArray();
-            if (!items.Any())
-                return false;
-
-            float leftPosition = ToLocalSpace(result.ScreenSpacePosition).X;
-            int startIndex = TextIndexUtils.ToStringIndex(editorLyricPiece.GetHoverIndex(leftPosition));
-            int diff = startIndex - items.First().StartIndex;
-            if (diff == 0)
-                return false;
-
-            foreach (var item in items)
-            {
-                int newStartIndex = item.StartIndex + diff;
-                int newEndIndex = item.EndIndex + diff;
-                if (!LyricUtils.AbleToInsertTextTagAtIndex(Lyric, newStartIndex) || !LyricUtils.AbleToInsertTextTagAtIndex(Lyric, newEndIndex))
-                    continue;
-
-                SetTextTagPosition(item, newStartIndex, newEndIndex);
-            }
-
-            return true;
-        }
-
-        protected abstract void SetTextTagPosition(T textTag, int startPosition, int endPosition);
 
         protected override IEnumerable<SelectionBlueprint<T>> SortForMovement(IReadOnlyList<SelectionBlueprint<T>> blueprints)
             => blueprints.OrderBy(b => b.Item.StartIndex);

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -24,8 +24,15 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             if (string.IsNullOrEmpty(lyric))
                 return true;
 
-            var fixedTextTag = FixTimeTagPosition(textTag);
-            return fixedTextTag.StartIndex < 0 || fixedTextTag.EndIndex > lyric.Length;
+            return outOfRange(lyric, textTag.StartIndex) || outOfRange(lyric, textTag.EndIndex);
+
+            static bool outOfRange(string lyric, int index)
+            {
+                const int min_index = 0;
+                int maxIndex = lyric.Length;
+
+                return index < min_index || index > maxIndex;
+            }
         }
 
         public static bool EmptyText<T>(T textTag) where T : ITextTag
@@ -45,9 +52,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <returns></returns>
         public static string PositionFormattedString<T>(T textTag) where T : ITextTag
         {
-            var fixedTag = FixTimeTagPosition(textTag);
-            string text = string.IsNullOrWhiteSpace(fixedTag.Text) ? "empty" : fixedTag.Text;
-            return $"{text}({fixedTag.StartIndex} ~ {fixedTag.EndIndex})";
+            string text = string.IsNullOrWhiteSpace(textTag.Text) ? "empty" : textTag.Text;
+            return $"{text}({textTag.StartIndex} ~ {textTag.EndIndex})";
         }
 
         public static string GetTextFromLyric<T>(T textTag, string lyric) where T : ITextTag
@@ -55,9 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             if (textTag == null || lyric == null)
                 return null;
 
-            var fixedTextTag = FixTimeTagPosition(textTag);
-            int startIndex = Math.Max(0, fixedTextTag.StartIndex);
-            int endIndex = Math.Min(lyric.Length, fixedTextTag.EndIndex);
+            (int startIndex, int endIndex) = GetFixedIndex(textTag, lyric);
             return lyric.Substring(startIndex, endIndex - startIndex);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -18,13 +18,13 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             return textTag;
         }
 
-        public static T Shifting<T>(T textTag, int shifting) where T : ITextTag, new() =>
-            new()
-            {
-                StartIndex = textTag.StartIndex + shifting,
-                EndIndex = textTag.EndIndex + shifting,
-                Text = textTag.Text
-            };
+        public static Tuple<int, int> GetShiftingIndex<T>(T textTag, string lyric, int shifting) where T : ITextTag
+        {
+            int lyricLength = lyric?.Length ?? 0;
+            int newStartIndex = Math.Clamp(textTag.StartIndex + shifting, 0, lyricLength);
+            int newEndIndex = Math.Clamp(textTag.EndIndex + shifting, 0, lyricLength);
+            return new Tuple<int, int>(newStartIndex, newEndIndex);
+        }
 
         public static bool OutOfRange<T>(T textTag, string lyric) where T : ITextTag
         {

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             int lyricLength = lyric?.Length ?? 0;
             int newStartIndex = Math.Clamp(textTag.StartIndex + shifting, 0, lyricLength);
             int newEndIndex = Math.Clamp(textTag.EndIndex + shifting, 0, lyricLength);
-            return new Tuple<int, int>(newStartIndex, newEndIndex);
+            return new Tuple<int, int>(Math.Min(newStartIndex, newEndIndex), Math.Max(newStartIndex, newEndIndex));
         }
 
         public static bool OutOfRange<T>(T textTag, string lyric) where T : ITextTag

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -8,15 +8,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 {
     public static class TextTagUtils
     {
-        public static T FixTimeTagPosition<T>(T textTag) where T : ITextTag
-        {
-            int startIndex = Math.Min(textTag.StartIndex, textTag.EndIndex);
-            int endIndex = Math.Max(textTag.StartIndex, textTag.EndIndex);
-
-            textTag.StartIndex = startIndex;
-            textTag.EndIndex = endIndex;
-            return textTag;
-        }
+        public static Tuple<int, int> GetFixedIndex<T>(T textTag, string lyric) where T : ITextTag
+            => GetShiftingIndex(textTag, lyric, 0);
 
         public static Tuple<int, int> GetShiftingIndex<T>(T textTag, string lyric, int shifting) where T : ITextTag
         {


### PR DESCRIPTION
Closes issue #1024 

What's added in this PR:
- adjust some utils because they are not suitable for change handler.
- implement the shifting text tag method in the change handler.
- clean some unused methods in the blueprint container(because all events should get from the change handler).
- refactor the code in the selection handler and deal with the drag event.