### PR TITLE
Implement update singer change in lyric editor extend area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
             Assert.IsTrue(translates != null);
 
             // Check translate count
-            Assert.AreEqual(translates.Length, 2);
+            Assert.AreEqual(translates.Count, 2);
 
             // All lyric should have two translates
             Assert.AreEqual(lyrics[0].Translates.Count, 2);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckTranslateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckTranslateTest.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
         public void TestNoLyricButHaveLanguage()
         {
             // test no lyric and have language. (should not show alert)
-            var translateLanguages = new[] { new CultureInfo("Ja-jp") };
+            var translateLanguages = new List<CultureInfo> { new("Ja-jp") };
             var beatmap = createTestingBeatmap(translateLanguages, null);
             var result = check.Run(getContext(beatmap));
             Assert.AreEqual(result.Count(), 0);
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
         public void TestHaveLyricAndLanguage()
         {
             // no lyric with translate string. (should have issue)
-            var translateLanguages = new[] { new CultureInfo("Ja-jp") };
+            var translateLanguages = new List<CultureInfo> { new("Ja-jp") };
             var beatmap = createTestingBeatmap(translateLanguages, new[]
             {
                 createLyric(),
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
             }
         }
 
-        private static IBeatmap createTestingBeatmap(CultureInfo[] translateLanguage, IEnumerable<Lyric> lyrics)
+        private static IBeatmap createTestingBeatmap(List<CultureInfo> translateLanguage, IEnumerable<Lyric> lyrics)
         {
             var karaokeBeatmap = new KaraokeBeatmap
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -26,9 +27,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             var karaokeBeatmap = base.CreateBeatmap();
 
             // todo : insert singers
-            karaokeBeatmap.Singers = new[]
+            karaokeBeatmap.Singers = new List<Singer>
             {
-                new Singer(1)
+                new(1)
                 {
                     Order = 1,
                     Name = "初音ミク",
@@ -37,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     Description = "International superstar vocaloid Hatsune Miku.",
                     Color = Colour4.AliceBlue
                 },
-                new Singer(2)
+                new(2)
                 {
                     Order = 2,
                     Name = "ハク",
@@ -46,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     Description = "Creator of this ruleset.",
                     Color = Colour4.Yellow
                 },
-                new Singer(3)
+                new(3)
                 {
                     Order = 3,
                     Name = "ゴミパソコン",

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneTranslateScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneTranslateScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -24,11 +25,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         {
             var karaokeBeatmap = base.CreateBeatmap();
 
-            karaokeBeatmap.AvailableTranslates = new[]
+            karaokeBeatmap.AvailableTranslates = new List<CultureInfo>
             {
-                new CultureInfo("zh-TW"),
-                new CultureInfo("en-US"),
-                new CultureInfo("ja-JP")
+                new("zh-TW"),
+                new("en-US"),
+                new("ja-JP")
             };
 
             return karaokeBeatmap;

--- a/osu.Game.Rulesets.Karaoke.Tests/Ranking/TestSceneBeatmapMetadataGraph.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Ranking/TestSceneBeatmapMetadataGraph.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -50,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Ranking
             };
         });
 
-        private static Singer[] createDefaultSinger()
+        private static List<Singer> createDefaultSinger()
         {
             var metadata = new List<Singer>();
 
@@ -64,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Ranking
                 });
             }
 
-            return metadata.ToArray();
+            return metadata.ToList();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
             var dictionary = new LegacyProperties
             {
-                AvailableTranslates = availableTranslates.ToArray()
+                AvailableTranslates = availableTranslates
             };
 
             beatmap.HitObjects.Add(dictionary);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -14,15 +13,15 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 {
     public class KaraokeBeatmap : Beatmap<KaraokeHitObject>
     {
-        public CultureInfo[] AvailableTranslates { get; set; } = Array.Empty<CultureInfo>();
+        public List<CultureInfo> AvailableTranslates { get; set; } = new ();
 
-        public Singer[] Singers { get; set; } = Array.Empty<Singer>();
+        public List<Singer> Singers { get; set; } = new();
 
         public int TotalColumns { get; set; } = 9;
 
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
-            int singers = Singers.Length;
+            int singers = Singers.Count;
             int lyrics = HitObjects.Count(s => s is Lyric);
 
             var defaultStatistic = new List<BeatmapStatistic>

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
     {
         public static bool IsScorable(this IBeatmap beatmap) => beatmap?.HitObjects.OfType<Note>().Any(x => x.Display) ?? false;
 
-        public static CultureInfo[] AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates ?? Array.Empty<CultureInfo>();
+        public static List<CultureInfo> AvailableTranslates(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.AvailableTranslates ?? new List<CultureInfo>();
 
         public static bool AnyTranslate(this IBeatmap beatmap) => beatmap?.AvailableTranslates()?.Any() ?? false;
 
@@ -23,6 +23,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
             return pitch / 20 - 7;
         }
 
-        public static Singer[] GetSingers(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.Singers;
+        public static List<Singer> GetSingers(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.Singers;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapChangeHandler.cs
@@ -2,9 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
@@ -14,20 +18,73 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
-        protected KaraokeBeatmap Beatmap => beatmap.PlayableBeatmap as KaraokeBeatmap;
+        private KaraokeBeatmap karaokeBeatmap => beatmap.PlayableBeatmap as KaraokeBeatmap;
 
-        [Resolved(CanBeNull = true)]
-        private IEditorChangeHandler changeHandler { get; set; }
+        protected IEnumerable<Lyric> Lyrics => karaokeBeatmap.HitObjects.OfType<Lyric>();
+
+        // todo: should be interface.
+        protected BindableList<TItem> Items = new();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Items.AddRange(GetItemsFromBeatmap(karaokeBeatmap));
+
+            // todo: find a better way to handle only beatmap property changed.
+            beatmap.TransactionEnded += syncItemsFromBeatmap;
+
+            syncItemsFromBeatmap();
+
+            void syncItemsFromBeatmap()
+            {
+                var items = GetItemsFromBeatmap(karaokeBeatmap);
+
+                if (Items.SequenceEqual(items))
+                    return;
+
+                Items.AddRange(items.Except(Items));
+                Items.RemoveAll(x => !items.Contains(x));
+            }
+        }
 
         protected void PerformObjectChanged(TItem item, Action<TItem> action)
         {
-            changeHandler?.BeginChange();
+            // should call change from editor beatmap because there's only way to trigger transaction ended.
+            beatmap?.BeginChange();
             action?.Invoke(item);
-            changeHandler?.EndChange();
+            beatmap?.EndChange();
         }
 
-        public abstract void Add(TItem item);
+        public abstract List<TItem> GetItemsFromBeatmap(KaraokeBeatmap beatmap);
 
-        public abstract void Remove(TItem item);
+        public void Add(TItem item)
+        {
+            var items = GetItemsFromBeatmap(karaokeBeatmap);
+            if (items.Contains(item))
+                throw new InvalidOperationException(nameof(item));
+
+            PerformObjectChanged(item, i =>
+            {
+                items.Add(i);
+                OnItemAdded(i);
+            });
+        }
+
+        public void Remove(TItem item)
+        {
+            var items = GetItemsFromBeatmap(karaokeBeatmap);
+            if (!items.Contains(item))
+                throw new InvalidOperationException($"{nameof(item)} is not in the list");
+
+            PerformObjectChanged(item, i =>
+            {
+                items.Remove(i);
+                OnItemRemoved(i);
+            });
+        }
+
+        protected abstract void OnItemAdded(TItem item);
+
+        protected abstract void OnItemRemoved(TItem item);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/ILanguagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/ILanguagesChangeHandler.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages
 {
     public interface ILanguagesChangeHandler
     {
-        BindableList<CultureInfo> Languages { get; }
+        IBindableList<CultureInfo> Languages { get; }
 
         void Add(CultureInfo culture);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
@@ -1,61 +1,36 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages
 {
     public class LanguagesChangeHandler : BeatmapChangeHandler<CultureInfo>, ILanguagesChangeHandler
     {
-        private readonly BindableList<CultureInfo> bindableLanguages = new();
+        public IBindableList<CultureInfo> Languages => Items;
 
-        public IBindableList<CultureInfo> Languages => bindableLanguages;
+        public override List<CultureInfo> GetItemsFromBeatmap(KaraokeBeatmap beatmap)
+            => beatmap.AvailableTranslates;
 
-        private IEnumerable<Lyric> lyrics => Beatmap.HitObjects.OfType<Lyric>();
-
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void OnItemAdded(CultureInfo item)
         {
-            bindableLanguages.AddRange(Beatmap.AvailableTranslates);
-            bindableLanguages.BindCollectionChanged((_, _) => { Beatmap.AvailableTranslates = Languages.ToList(); });
+            // there's no need to do anything.
         }
 
-        public override void Add(CultureInfo item)
+        protected override void OnItemRemoved(CultureInfo item)
         {
-            if (bindableLanguages.Contains(item))
-                return;
-
-            PerformObjectChanged(item, cultureInfo =>
+            // Delete from lyric also.
+            foreach (var lyric in Lyrics.Where(lyric => lyric.Translates.ContainsKey(item)))
             {
-                bindableLanguages.Add(cultureInfo);
-            });
-        }
-
-        public override void Remove(CultureInfo item)
-        {
-            if (!bindableLanguages.Contains(item))
-                throw new InvalidOperationException($"{nameof(item)} is not in the list");
-
-            PerformObjectChanged(item, cultureInfo =>
-            {
-                // Delete from list.
-                bindableLanguages.Remove(cultureInfo);
-
-                // Delete from lyric also.
-                foreach (var lyric in lyrics.Where(lyric => lyric.Translates.ContainsKey(cultureInfo)))
-                {
-                    lyric.Translates.Remove(cultureInfo);
-                }
-            });
+                lyric.Translates.Remove(item);
+            }
         }
 
         public bool IsLanguageContainsTranslate(CultureInfo cultureInfo)
-            => lyrics.Any(x => x.Translates.ContainsKey(cultureInfo));
+            => Lyrics.Any(x => x.Translates.ContainsKey(cultureInfo));
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
@@ -13,37 +13,39 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages
 {
     public class LanguagesChangeHandler : BeatmapChangeHandler<CultureInfo>, ILanguagesChangeHandler
     {
-        public BindableList<CultureInfo> Languages { get; } = new();
+        private readonly BindableList<CultureInfo> bindableLanguages = new();
+
+        public IBindableList<CultureInfo> Languages => bindableLanguages;
 
         private IEnumerable<Lyric> lyrics => Beatmap.HitObjects.OfType<Lyric>();
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Languages.AddRange(Beatmap.AvailableTranslates);
-            Languages.BindCollectionChanged((_, _) => { Beatmap.AvailableTranslates = Languages.ToList(); });
+            bindableLanguages.AddRange(Beatmap.AvailableTranslates);
+            bindableLanguages.BindCollectionChanged((_, _) => { Beatmap.AvailableTranslates = Languages.ToList(); });
         }
 
         public override void Add(CultureInfo item)
         {
-            if (Languages.Contains(item))
+            if (bindableLanguages.Contains(item))
                 return;
 
             PerformObjectChanged(item, cultureInfo =>
             {
-                Languages.Add(cultureInfo);
+                bindableLanguages.Add(cultureInfo);
             });
         }
 
         public override void Remove(CultureInfo item)
         {
-            if (!Languages.Contains(item))
+            if (!bindableLanguages.Contains(item))
                 throw new InvalidOperationException($"{nameof(item)} is not in the list");
 
             PerformObjectChanged(item, cultureInfo =>
             {
                 // Delete from list.
-                Languages.Remove(cultureInfo);
+                bindableLanguages.Remove(cultureInfo);
 
                 // Delete from lyric also.
                 foreach (var lyric in lyrics.Where(lyric => lyric.Translates.ContainsKey(cultureInfo)))

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages
         private void load()
         {
             Languages.AddRange(Beatmap.AvailableTranslates);
-            Languages.BindCollectionChanged((_, _) => { Beatmap.AvailableTranslates = Languages.ToArray(); });
+            Languages.BindCollectionChanged((_, _) => { Beatmap.AvailableTranslates = Languages.ToList(); });
         }
 
         public override void Add(CultureInfo item)

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/ISingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/ISingersChangeHandler.cs
@@ -8,6 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
 {
     public interface ISingersChangeHandler
     {
+        // todo: should use IBindableList eventually, but cannot do that because it's bind to selection item.
         BindableList<Singer> Singers { get; }
 
         void ChangeOrder(Singer singer, int newIndex);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
             // should write-back if singer changed.
             Singers.BindCollectionChanged((_, _) =>
             {
-                Beatmap.Singers = Singers.ToArray();
+                Beatmap.Singers = Singers.ToList();
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
@@ -1,31 +1,22 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
 {
     public class SingersChangeHandler : BeatmapChangeHandler<Singer>, ISingersChangeHandler
     {
-        public BindableList<Singer> Singers { get; } = new();
+        public BindableList<Singer> Singers => Items;
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            Singers.AddRange(Beatmap.Singers);
-
-            // should write-back if singer changed.
-            Singers.BindCollectionChanged((_, _) =>
-            {
-                Beatmap.Singers = Singers.ToList();
-            });
-        }
+        public override List<Singer> GetItemsFromBeatmap(KaraokeBeatmap beatmap)
+            => beatmap.Singers;
 
         public void ChangeOrder(Singer singer, int newIndex)
         {
@@ -40,29 +31,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
             });
         }
 
-        public override void Add(Singer item)
+        protected override void OnItemAdded(Singer item)
         {
-            PerformObjectChanged(item, singer =>
-            {
-                singer.Order = OrderUtils.GetMaxOrderNumber(Singers.ToArray()) + 1;
-                Singers.Add(singer);
-            });
+            // should give it a id.
+            item.Order = OrderUtils.GetMaxOrderNumber(Singers.ToArray()) + 1;
         }
 
-        public override void Remove(Singer item)
+        protected override void OnItemRemoved(Singer item)
         {
-            PerformObjectChanged(item, singer =>
+            // should clear removed singer ids in singer editor.
+            Lyrics.ForEach(x =>
             {
-                // Shifting order that order is larger than current singer
-                OrderUtils.ShiftingOrder(Singers.Where(x => x.Order > singer.Order), -1);
-                Singers.Remove(singer);
-
-                // should clear removed singer ids in singer editor.
-                var lyrics = Beatmap.HitObjects.OfType<Lyric>();
-                lyrics.ForEach(x =>
-                {
-                    LyricUtils.RemoveSinger(x, singer);
-                });
+                LyricUtils.RemoveSinger(x, item);
             });
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckTranslate.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckTranslate.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -27,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            var languages = availableTranslateInBeatmap(context.Beatmap) ?? Array.Empty<CultureInfo>();
+            var languages = availableTranslateInBeatmap(context.Beatmap) ?? new List<CultureInfo>();
 
             var lyrics = context.Beatmap.HitObjects.OfType<Lyric>().ToList();
             if (lyrics.Count == 0)
@@ -61,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
             }
         }
 
-        private CultureInfo[] availableTranslateInBeatmap(IBeatmap beatmap)
+        private List<CultureInfo> availableTranslateInBeatmap(IBeatmap beatmap)
         {
             if (beatmap is not EditorBeatmap editorBeatmap)
                 return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -76,11 +76,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(languageSelectionDialog = new LanguageSelectionDialog());
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load()
-        {
-        }
-
         protected override GenericEditorScreen<KaraokeEditorScreenMode> GenerateScreen(KaraokeEditorScreenMode screenMode) =>
             screenMode switch
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
 using osu.Game.Rulesets.Karaoke.UI.Position;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
@@ -46,6 +47,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(ILyricSingerChangeHandler))]
         private readonly LyricSingerChangeHandler lyricSingerChangeHandler;
 
+        [Cached(typeof(ISingersChangeHandler))]
+        private readonly SingersChangeHandler singersChangeHandler;
+
         [Cached(typeof(ILockChangeHandler))]
         private readonly LockChangeHandler lockChangeHandler;
 
@@ -62,6 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             AddInternal(notesChangeHandler = new NotesChangeHandler());
             AddInternal(lyricLayoutChangeHandler = new LyricLayoutChangeHandler());
             AddInternal(lyricSingerChangeHandler = new LyricSingerChangeHandler());
+            AddInternal(singersChangeHandler = new SingersChangeHandler());
             AddInternal(lockChangeHandler = new LockChangeHandler());
 
             LyricEditor lyricEditor;

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
             {
                 alreadyAsked = true;
 
-                if (languagesChangeHandler.Languages.Count == 0 && !alreadyAsked)
+                if (!languagesChangeHandler.Languages.Any() && !alreadyAsked)
                 {
                     dialogOverlay.Push(new CreateNewLanguagePopupDialog(isOk =>
                     {

--- a/osu.Game.Rulesets.Karaoke/Objects/LegacyProperties.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/LegacyProperties.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
     // todo: this function is used for legacy karaoke beatmap, will be removed eventually.
     public class LegacyProperties : KaraokeHitObject
     {
-        public CultureInfo[] AvailableTranslates { get; set; }
+        public List<CultureInfo> AvailableTranslates { get; set; }
 
         public IDictionary<int, Singer> Singers { get; set; } = new Dictionary<int, Singer>();
     }


### PR DESCRIPTION
Implement part of #1036

What's changed in this PR:
- clean-up the code.
- change some properties from array to list in karaoke beatmap.
- refactor karaoke beatmap change handler and derived handler. for now, those change handler is focused on the list of items add/remove/changed in the karaoke beatmap.
- update singer list in the extend area if singer list changed.