### PR TITLE
Implement singer selection in lyric editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Metadatas;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -310,64 +309,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         #endregion
 
         #region Singer
-
-        [TestCase(new string[] { }, "[1]name:Singer1", true, new[] { 1 })]
-        [TestCase(new[] { "[1]name:Singer1" }, "[1]name:Singer1", false, new[] { 1 })]
-        [TestCase(new[] { "[1]name:Singer1" }, "[2]name:Singer2", true, new[] { 1, 2 })]
-        public void TestAddSinger(string[] existSingers, string addSinger, bool isAdded, int[] actualSingers)
-        {
-            var singer = TestCaseTagHelper.ParseSinger(addSinger);
-            var lyric = new Lyric
-            {
-                Singers = TestCaseTagHelper.ParseSingers(existSingers)?.Select(x => x.ID).ToArray()
-            };
-
-            try
-            {
-                Assert.AreEqual(LyricUtils.AddSinger(lyric, singer), isAdded);
-                Assert.AreEqual(lyric.Singers, actualSingers);
-            }
-            catch
-            {
-                Assert.IsNull(actualSingers);
-            }
-        }
-
-        [TestCase(new[] { "[1]name:Singer1" }, "[1]name:Singer1", true, new int[] { })]
-        [TestCase(new[] { "[1]name:Singer1" }, "[2]name:Singer2", false, new[] { 1 })]
-        [TestCase(new string[] { }, "[1]name:Singer1", false, new int[] { })]
-        [TestCase(new[] { "[1]name:Singer1" }, "[0]name:Singer0", false, null)] // should not remove invalid singer.
-        public void TestRemoveSinger(string[] existSingers, string removeSinger, bool isAdded, int[] actualSingers)
-        {
-            var singer = TestCaseTagHelper.ParseSinger(removeSinger);
-            var lyric = new Lyric
-            {
-                Singers = TestCaseTagHelper.ParseSingers(existSingers)?.Select(x => x.ID).ToArray()
-            };
-
-            try
-            {
-                Assert.AreEqual(LyricUtils.RemoveSinger(lyric, singer), isAdded);
-                Assert.AreEqual(lyric.Singers, actualSingers);
-            }
-            catch
-            {
-                Assert.IsNull(actualSingers);
-            }
-        }
-
-        [TestCase(new[] { "[1]name:Singer1" }, false)]
-        [TestCase(new string[] { }, false)]
-        public void ClearSinger(string[] existSingers, bool stillContainsSinger)
-        {
-            var lyric = new Lyric
-            {
-                Singers = TestCaseTagHelper.ParseSingers(existSingers)?.Select(x => x.ID).ToArray()
-            };
-            LyricUtils.ClearSinger(lyric);
-
-            Assert.AreEqual(lyric.Singers!.Any(), stillContainsSinger);
-        }
 
         [TestCase(new[] { "[1]name:Singer1" }, "[1]name:Singer1", true)]
         [TestCase(new[] { "[1]name:Singer1" }, "[2]name:Singer2", false)]

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
@@ -3,7 +3,6 @@
 
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
@@ -13,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                LyricUtils.AddSinger(lyric, singer);
+                lyric.Singers.Add(singer.ID);
             });
         }
 
@@ -21,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                LyricUtils.RemoveSinger(lyric, singer);
+                lyric.Singers.Remove(singer.ID);
             });
         }
 
@@ -29,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                LyricUtils.ClearSinger(lyric);
+                lyric.Singers.Clear();
             });
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
             // should clear removed singer ids in singer editor.
             Lyrics.ForEach(x =>
             {
-                LyricUtils.RemoveSinger(x, item);
+                x.Singers.Remove(item.ID);
             });
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
@@ -4,12 +4,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
@@ -17,6 +19,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
     public class SingerInfo : Container
     {
         private readonly SingerDisplay singerDisplay;
+
+        private readonly IBindableList<int> singerIndexesBindable = new BindableList<int>();
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
 
         private readonly Lyric lyric;
 
@@ -30,32 +37,32 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             };
-        }
 
-        [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap)
-        {
-            lyric.SingersBindable.BindCollectionChanged((_, _) =>
+            singerIndexesBindable.BindTo(lyric.SingersBindable);
+            singerIndexesBindable.BindCollectionChanged((_, _) =>
             {
-                if (beatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
-                    return;
-
-                var singers = karaokeBeatmap.Singers?.Where(x => lyric.SingersBindable?.Contains(x.ID) ?? false).ToList();
-
-                if (singers?.Any() ?? false)
+                Schedule(() =>
                 {
-                    singerDisplay.Current.Value = singers;
-                }
-                else
-                {
-                    singerDisplay.Current.Value = new List<Singer>
+                    if (beatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
+                        return;
+
+                    var singers = karaokeBeatmap.Singers?.Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
+
+                    if (singers?.Any() ?? false)
                     {
-                        new()
+                        singerDisplay.Current.Value = singers;
+                    }
+                    else
+                    {
+                        singerDisplay.Current.Value = new List<Singer>
                         {
-                            Name = "No singer"
-                        }
-                    };
-                }
+                            new()
+                            {
+                                Name = "No singer"
+                            }
+                        };
+                    }
+                });
             }, true);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -278,61 +278,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         #region Singer
 
-        public static bool AddSinger(Lyric lyric, Singer singer)
-        {
-            if (lyric == null)
-                throw new ArgumentNullException(nameof(lyric));
-
-            if (singer == null)
-                throw new ArgumentNullException(nameof(singer));
-
-            if (singer.ID <= 0)
-                throw new ArgumentOutOfRangeException(nameof(singer.ID));
-
-            // do nothing if already contains singer index.
-            if (ContainsSinger(lyric, singer))
-                return false;
-
-            var newSingerList = lyric.Singers?.ToList() ?? new List<int>();
-            newSingerList.Add(singer.ID);
-            lyric.Singers = newSingerList.ToArray();
-
-            return true;
-        }
-
-        public static bool RemoveSinger(Lyric lyric, Singer singer)
-        {
-            if (lyric == null)
-                throw new ArgumentNullException(nameof(lyric));
-
-            if (singer == null)
-                throw new ArgumentNullException(nameof(singer));
-
-            if (singer.ID <= 0)
-                throw new ArgumentOutOfRangeException(nameof(singer.ID));
-
-            // do nothing if not contains singer index.
-            if (!ContainsSinger(lyric, singer))
-                return false;
-
-            int[] newSingerIds = lyric.Singers.Where(x => x != singer.ID).ToArray();
-            lyric.Singers = newSingerIds;
-
-            return true;
-        }
-
-        public static bool ClearSinger(Lyric lyric)
-        {
-            if (lyric == null)
-                throw new ArgumentNullException(nameof(lyric));
-
-            if (lyric.Singers == null || !lyric.Singers.Any())
-                return false;
-
-            lyric.Singers = new List<int>();
-            return true;
-        }
-
         public static bool ContainsSinger(Lyric lyric, Singer singer)
         {
             if (lyric == null)


### PR DESCRIPTION
Close issue #1036

![image](https://user-images.githubusercontent.com/9100368/149654896-1d64a369-ca06-4e82-b70a-8a31e831e694.png)
What's changed in this PR:
- remove some unneeded utils because only use in the change handler.
- refactor the logic in singer info.
- implement a change singer feature in the lyric editor. lyric singer selection will update if the singer's property is changed in other places like the singer editor.