### PR TITLE
Adjust edit singer style in lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
@@ -13,6 +14,7 @@ using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osuTK;
 
@@ -93,12 +95,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
             bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
         }
 
-        public class LabelledSingerSwitchButton : LabelledSwitchButton
+        public class LabelledSingerSwitchButton : LabelledSwitchButton, IHasCustomTooltip<Singer>
         {
             private const float avatar_size = 40f;
 
             public LabelledSingerSwitchButton(Singer singer)
             {
+                TooltipContent = singer;
+
                 Label = singer.Name;
                 Description = singer.Description;
 
@@ -125,6 +129,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
                     }
                 });
             }
+
+            public ITooltip<Singer> GetCustomTooltip() => new SingerToolTip();
+
+            public Singer TooltipContent { get; }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -47,21 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
                         return;
 
                     var singers = karaokeBeatmap.Singers?.Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
-
-                    if (singers?.Any() ?? false)
-                    {
-                        singerDisplay.Current.Value = singers;
-                    }
-                    else
-                    {
-                        singerDisplay.Current.Value = new List<Singer>
-                        {
-                            new()
-                            {
-                                Name = "No singer"
-                            }
-                        };
-                    }
+                    singerDisplay.Current.Value = singers;
                 });
             }, true);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
@@ -16,19 +16,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
 {
     public class SingerInfo : Container
     {
-        private readonly SingerDisplay singerDisplay;
-
         private readonly IBindableList<int> singerIndexesBindable = new BindableList<int>();
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
-        private readonly Lyric lyric;
-
         public SingerInfo(Lyric lyric)
         {
-            this.lyric = lyric;
             AutoSizeAxes = Axes.Both;
+            SingerDisplay singerDisplay;
 
             Child = singerDisplay = new SingerDisplay
             {

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
@@ -7,13 +7,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
 {
-    public class SingerToolTip : BackgroundToolTip<Singer>
+    public class SingerToolTip : BackgroundToolTip<ISinger>
     {
         private readonly DrawableSingerAvatar avatar;
         private readonly OsuSpriteText singerName;
@@ -76,20 +77,24 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
             };
         }
 
-        private Singer lastSinger;
+        private ISinger lastSinger;
 
-        public override void SetContent(Singer singer)
+        public override void SetContent(ISinger singer)
         {
             if (singer == lastSinger)
                 return;
 
             lastSinger = singer;
 
-            avatar.Singer = singer;
-            singerName.Text = singer.Name;
-            singerEnglishName.Text = singer.EnglishName != null ? $"({singer.EnglishName})" : "";
-            singerRomajiName.Text = singer.RomajiName;
-            singerDescription.Text = singer.Description ?? "<No description>";
+            if (singer is not Singer s)
+                return;
+
+            // todo: other type of singer(e.g: sub-singer) might display different info.
+            avatar.Singer = s;
+            singerName.Text = s.Name;
+            singerEnglishName.Text = s.EnglishName != null ? $"({s.EnglishName})" : "";
+            singerRomajiName.Text = s.RomajiName;
+            singerDescription.Text = s.Description ?? "<No description>";
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/SingerDisplay.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/SingerDisplay.cs
@@ -6,10 +6,13 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
+using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osuTK;
 
@@ -38,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             }
         }
 
-        private readonly FillFlowContainer<DrawableCircleSingerAvatar> iconsContainer;
+        private readonly FillFlowContainer<DrawableSinger> iconsContainer;
 
         public SingerDisplay()
         {
@@ -52,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 Direction = FillDirection.Vertical,
                 Children = new Drawable[]
                 {
-                    iconsContainer = new ReverseChildIDFillFlowContainer<DrawableCircleSingerAvatar>
+                    iconsContainer = new ReverseChildIDFillFlowContainer<DrawableSinger>
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
@@ -68,7 +71,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
 
                 foreach (var singer in singers.NewValue)
                 {
-                    iconsContainer.Add(new DrawableCircleSingerAvatar
+                    iconsContainer.Add(new DrawableSinger
                     {
                         Singer = singer,
                         Name = "Avatar",
@@ -125,6 +128,13 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
         {
             contract();
             base.OnHoverLost(e);
+        }
+
+        private class DrawableSinger : DrawableCircleSingerAvatar, IHasCustomTooltip<ISinger>
+        {
+            public ITooltip<ISinger> GetCustomTooltip() => new SingerToolTip();
+
+            public ISinger TooltipContent => Singer;
         }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/149782204-c33c9d32-a054-454d-a04f-b16f7cfcfb1d.png)
What's changed in this PR:
- show tooltip if hover at the singer.
- show tooltip if hover at singer display component.
- remove default singer display if there's no singer in the lyric.