### PR TITLE
Should wrap change handler in note popover.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Blueprints/Notes/NoteSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Blueprints/Notes/NoteSelectionBlueprint.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Karaoke.UI;
 using osu.Game.Rulesets.Karaoke.UI.Position;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes
 {
@@ -32,6 +33,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes
 
         [Resolved]
         private INotePositionInfo notePositionInfo { get; set; }
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
 
         protected ScrollingHitObjectContainer HitObjectContainer => ((KaraokePlayfield)playfield).NotePlayfield.HitObjectContainer;
 
@@ -68,6 +72,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes
 
         protected override bool OnClick(ClickEvent e)
         {
+            // should only select current note before open the popover because note change handler will change property in all selected notes.
+            beatmap.SelectedHitObjects.Clear();
+            beatmap.SelectedHitObjects.Add(HitObject);
+
             this.ShowPopover();
             return base.OnClick(e);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotePropertyChangeHandler.cs
@@ -1,0 +1,14 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
+{
+    public interface INotePropertyChangeHandler
+    {
+        void ChangeText(string text);
+
+        void ChangeRubyText(string ruby);
+
+        void ChangeDisplayState(bool display);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
@@ -1,0 +1,34 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
+{
+    public class NotePropertyChangeHandler : HitObjectChangeHandler<Note>, INotePropertyChangeHandler
+    {
+        public void ChangeText(string text)
+        {
+            PerformOnSelection(note =>
+            {
+                note.Text = text;
+            });
+        }
+
+        public void ChangeRubyText(string ruby)
+        {
+            PerformOnSelection(note =>
+            {
+                note.RubyText = ruby;
+            });
+        }
+
+        public void ChangeDisplayState(bool display)
+        {
+            PerformOnSelection(note =>
+            {
+                note.Display = display;
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -1,17 +1,27 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
 {
     public class NoteEditPopover : OsuPopover
     {
+        [Resolved(canBeNull: true)]
+        private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
+
         public NoteEditPopover(Note note)
         {
+            LabelledTextBox text;
+            LabelledTextBox rubyText;
+            LabelledSwitchButton display;
+
             Children = new Drawable[]
             {
                 new FillFlowContainer
@@ -21,27 +31,55 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        new LabelledTextBox
+                        text = new LabelledTextBox
                         {
                             Label = "Text",
                             Description = "The text display on the note.",
                             Current = note.TextBindable
                         },
-                        new LabelledTextBox
+                        rubyText = new LabelledTextBox
                         {
                             Label = "Ruby text",
-                            Description = "Should placing something like ruby, 拼音 or ふりがな.",
+                            Description = "Should place something like ruby, 拼音 or ふりがな.",
                             Current = note.RubyTextBindable
                         },
-                        new LabelledSwitchButton
+                        display = new LabelledSwitchButton
                         {
                             Label = "Display",
                             Description = "This note will be hidden and not scorable if not display.",
-                            Current = note.DisplayBindable,
+                            Current = note.DisplayBindable
                         }
                     }
                 }
             };
+
+            text.OnCommit += (sender, newText) =>
+            {
+                string text = sender.Text.Trim();
+                notePropertyChangeHandler?.ChangeText(text);
+            };
+
+            rubyText.OnCommit += (sender, newText) =>
+            {
+                string text = sender.Text.Trim();
+                notePropertyChangeHandler?.ChangeRubyText(text);
+            };
+
+            display.Current.BindValueChanged(v =>
+            {
+                notePropertyChangeHandler?.ChangeDisplayState(v.NewValue);
+            });
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(HitObjectComposer composer)
+        {
+            if (notePropertyChangeHandler != null || composer == null)
+                return;
+
+            // todo: not a good way to get change handler, might remove or found another way eventually.
+            // cannot get change handler directly in editor screen, so should trying to get from karaoke hit object composer.
+            notePropertyChangeHandler = composer.Dependencies.Get<INotePropertyChangeHandler>();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached(typeof(INotesChangeHandler))]
         private readonly NotesChangeHandler notesChangeHandler;
 
+        [Cached(typeof(INotePropertyChangeHandler))]
+        private readonly NotePropertyChangeHandler notePropertyChangeHandler;
+
         [Cached(typeof(ILyricSingerChangeHandler))]
         private readonly LyricSingerChangeHandler lyricSingerChangeHandler;
 
@@ -78,6 +81,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());
             AddInternal(notesChangeHandler = new NotesChangeHandler());
+            AddInternal(notePropertyChangeHandler = new NotePropertyChangeHandler());
             AddInternal(lyricSingerChangeHandler = new LyricSingerChangeHandler());
             AddInternal(lyricLayoutChangeHandler = new LyricLayoutChangeHandler());
             AddInternal(singersChangeHandler = new SingersChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             {
                 new LabelledEnumDropdown<NoteEditPropertyMode>
                 {
-                    Label = "Record tag mode",
-                    Description = "Only record time with start/end time-tag while recording.",
+                    Label = "Edit property",
+                    Description = "Batch edit text, ruby(alternative) text or display from notes",
                     Current = bindableNoteEditPropertyMode,
                 },
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
-                blueprintSelectionState.SelectedNotes.BindTo(SelectedItems);
+                SelectedItems.BindTo(blueprintSelectionState.SelectedNotes);
             }
         }
 
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
-                blueprintSelectionState.SelectedNotes.BindTo(SelectedItems);
+                SelectedItems.BindTo(blueprintSelectionState.SelectedNotes);
             }
         }
 
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
-                blueprintSelectionState.SelectedNotes.BindTo(SelectedItems);
+                SelectedItems.BindTo(blueprintSelectionState.SelectedNotes);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
@@ -80,6 +81,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private class LabelledNoteTextTextBox : LabelledObjectFieldTextBox<Note>
         {
+            [Resolved]
+            private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
+
             public LabelledNoteTextTextBox(Note item)
                 : base(item)
             {
@@ -89,7 +93,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 => note.Text;
 
             protected override void ApplyValue(Note note, string value)
-                => note.Text = value;
+                => notePropertyChangeHandler.ChangeText(value);
 
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
@@ -100,6 +104,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private class LabelledNoteRubyTextTextBox : LabelledObjectFieldTextBox<Note>
         {
+            [Resolved]
+            private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
+
             public LabelledNoteRubyTextTextBox(Note item)
                 : base(item)
             {
@@ -109,7 +116,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 => note.RubyText;
 
             protected override void ApplyValue(Note note, string value)
-                => note.RubyText = value;
+                => notePropertyChangeHandler.ChangeRubyText(value);
 
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
@@ -120,6 +127,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private class LabelledNoteDisplaySwitchButton : LabelledObjectFieldSwitchButton<Note>
         {
+            [Resolved]
+            private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
+
             public LabelledNoteDisplaySwitchButton(Note item)
                 : base(item)
             {
@@ -129,7 +139,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 => note.Display;
 
             protected override void ApplyValue(Note note, bool value)
-                => note.Display = value;
+                => notePropertyChangeHandler.ChangeDisplayState(value);
 
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
-                blueprintSelectionState.SelectedRomajiTags.BindTo(SelectedItems);
+                SelectedItems.BindTo(blueprintSelectionState.SelectedRomajiTags);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             [BackgroundDependencyLoader]
             private void load(IBlueprintSelectionState blueprintSelectionState)
             {
-                blueprintSelectionState.SelectedRubyTags.BindTo(SelectedItems);
+                SelectedItems.BindTo(blueprintSelectionState.SelectedRubyTags);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(INotesChangeHandler))]
         private readonly NotesChangeHandler notesChangeHandler;
 
+        [Cached(typeof(INotePropertyChangeHandler))]
+        private readonly NotePropertyChangeHandler notePropertyChangeHandler;
+
         [Cached(typeof(ILyricLayoutChangeHandler))]
         private readonly LyricLayoutChangeHandler lyricLayoutChangeHandler;
 
@@ -67,6 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             AddInternal(lyricTimeTagsChangeHandler = new LyricTimeTagsChangeHandler());
             AddInternal(notePositionInfo = new NotePositionInfo());
             AddInternal(notesChangeHandler = new NotesChangeHandler());
+            AddInternal(notePropertyChangeHandler = new NotePropertyChangeHandler());
             AddInternal(lyricLayoutChangeHandler = new LyricLayoutChangeHandler());
             AddInternal(lyricSingerChangeHandler = new LyricSingerChangeHandler());
             AddInternal(singersChangeHandler = new SingersChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Notes/NoteEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Notes/NoteEditorHitObjectBlueprint.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Blueprints.Notes.Components;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.UI.Position;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -41,6 +42,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Notes
 
         [Resolved]
         private INotePositionInfo notePositionInfo { get; set; }
+
+        [Resolved]
+        private IBlueprintSelectionState blueprintSelectionState { get; set; }
 
         private readonly Lyric lyric;
 
@@ -105,6 +109,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Notes
 
         protected override bool OnClick(ClickEvent e)
         {
+            // should only select current note before open the popover because note change handler will change property in all selected notes.
+            blueprintSelectionState.SelectedNotes.Clear();
+            blueprintSelectionState.SelectedNotes.Add(Item);
+
             this.ShowPopover();
             return base.OnClick(e);
         }


### PR DESCRIPTION
Close issue #1053

What's done in this PR:
- Implemented note change handler.
- apply a change handler in the note edit popover.
- adjust wording(fix part of issue #1052).
- adjust some binding events.
- should only select the current note before opening the popover because the note change handler will change property in all selected notes.