### PR TITLE
Should wrap change in importLyric method in KaraokeEditor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneEditorMenuBar.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                         {
                             Items = new MenuItem[]
                             {
-                                new ImportLyricMenu(null, "Import from text", _ => { }),
-                                new ImportLyricMenu(null, "Import from .lrc file", _ => { }),
+                                new ImportLyricMenu(null, "Import from text", null),
+                                new ImportLyricMenu(null, "Import from .lrc file", null),
                                 new EditorMenuItemSpacer(),
                                 new EditorMenuItem("Export to .lrc", MenuItemType.Standard, () => { }),
                                 new EditorMenuItem("Export to text", MenuItemType.Standard, () => { }),

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapChangeHandler.cs
@@ -1,0 +1,31 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
+{
+    public class BeatmapChangeHandler : Component, IBeatmapChangeHandler
+    {
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
+
+        public void Import(IBeatmap newBeatmap)
+        {
+            beatmap.BeginChange();
+
+            beatmap.Clear();
+
+            var lyrics = newBeatmap.HitObjects.OfType<Lyric>().ToArray();
+            if (lyrics.Any())
+                beatmap.AddRange(lyrics);
+
+            beatmap.EndChange();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -13,7 +13,7 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
 {
-    public abstract class BeatmapChangeHandler<TItem> : Component
+    public abstract class BeatmapPropertyChangeHandler<TItem> : Component
     {
         [Resolved]
         private EditorBeatmap beatmap { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/IBeatmapChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/IBeatmapChangeHandler.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
+{
+    public interface IBeatmapChangeHandler
+    {
+        void Import(IBeatmap newBeatmap);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Languages/LanguagesChangeHandler.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages
 {
-    public class LanguagesChangeHandler : BeatmapChangeHandler<CultureInfo>, ILanguagesChangeHandler
+    public class LanguagesChangeHandler : BeatmapPropertyChangeHandler<CultureInfo>, ILanguagesChangeHandler
     {
         public IBindableList<CultureInfo> Languages => Items;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
 {
-    public class SingersChangeHandler : BeatmapChangeHandler<Singer>, ISingersChangeHandler
+    public class SingersChangeHandler : BeatmapPropertyChangeHandler<Singer>, ISingersChangeHandler
     {
         public BindableList<Singer> Singers => Items;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/ImportLyricMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/ImportLyricMenu.cs
@@ -1,25 +1,24 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.ImportLyric;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menus
 {
     public class ImportLyricMenu : MenuItem
     {
-        public ImportLyricMenu(IScreen screen, string text, Action<IBeatmap> importResult)
-            : base(text, () => openLyricImporter(screen, importResult))
+        public ImportLyricMenu(IScreen screen, string text, IBeatmapChangeHandler beatmapChangeHandler)
+            : base(text, () => openLyricImporter(screen, beatmapChangeHandler))
         {
         }
 
-        private static void openLyricImporter(IScreen screen, Action<IBeatmap> importResult)
+        private static void openLyricImporter(IScreen screen, IBeatmapChangeHandler beatmapChangeHandler)
         {
             var importer = new LyricImporter();
-            importer.OnImportFinished += importResult;
+            importer.OnImportFinished += beatmapChangeHandler.Import;
             screen?.Push(importer);
         }
     }


### PR DESCRIPTION
Closes issue #1054

What's changed in this PR:
- Create `BeatmapChangeHandler` for any big change in the beatmap. (e.g: import or clear).
- remove `IPlacementHandler` from `KaraokeEditor` because got no idea why need this shit.