### PR TITLE
Apply new skin roles in the karaoke beatmap.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Cursor/LayoutToolTip.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Cursor
 
             // Get layout
             int layoutIndex = lyric.LayoutIndex;
-            var layout = skinSource?.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(ElementType.LyricLayout, layoutIndex)).Value;
+            var layout = skinSource?.GetConfig<Lyric, LyricLayout>(lyric).Value;
 
             // Display in content\
             preview.Layout = layout;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
@@ -131,8 +131,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
         [BackgroundDependencyLoader(true)]
         private void load(ISkinSource skin, ShaderManager shaderManager)
         {
-            // this is a temp way to apply style.
-            skin.GetConfig<KaraokeSkinLookup, LyricStyle>(new KaraokeSkinLookup(ElementType.LyricStyle, HitObject.Singers))?.BindValueChanged(lyricStyle =>
+            skin.GetConfig<Lyric, LyricStyle>(HitObject)?.BindValueChanged(lyricStyle =>
             {
                 var newStyle = lyricStyle.NewValue;
                 if (newStyle == null)
@@ -142,7 +141,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 RightLyricTextShaders = SkinConvertorTool.ConvertRightSideShader(shaderManager, newStyle);
             }, true);
 
-            skin.GetConfig<KaraokeSkinLookup, LyricConfig>(new KaraokeSkinLookup(ElementType.LyricConfig, HitObject.Singers))?.BindValueChanged(lyricConfig =>
+            skin.GetConfig<Lyric, LyricConfig>(HitObject)?.BindValueChanged(lyricConfig =>
             {
                 var newConfig = lyricConfig.NewValue;
                 if (newConfig == null)

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var lyricFont = CurrentSkin.GetConfig<KaraokeSkinLookup, LyricStyle>(new KaraokeSkinLookup(ElementType.LyricStyle, HitObject.Singers))?.Value;
+            var lyricFont = CurrentSkin.GetConfig<Lyric, LyricStyle>(HitObject)?.Value;
             if (lyricFont == null)
                 return;
 
@@ -191,7 +191,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var lyricConfig = CurrentSkin.GetConfig<KaraokeSkinLookup, LyricConfig>(new KaraokeSkinLookup(ElementType.LyricConfig, HitObject.Singers))?.Value;
+            var lyricConfig = CurrentSkin.GetConfig<Lyric, LyricConfig>(HitObject)?.Value;
 
             foreach (var lyricPiece in lyricPieces)
             {
@@ -268,7 +268,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var layout = CurrentSkin.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(ElementType.LyricLayout, HitObject.LayoutIndex))?.Value;
+            var layout = CurrentSkin.GetConfig<Lyric, LyricLayout>(HitObject)?.Value;
             if (layout == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             if (HitObject == null)
                 return;
 
-            var noteSkin = skin.GetConfig<KaraokeSkinLookup, NoteStyle>(new KaraokeSkinLookup(ElementType.NoteStyle, HitObject.ParentLyric?.Singers))?.Value;
+            var noteSkin = skin.GetConfig<Note, NoteStyle>(HitObject)?.Value;
             if (noteSkin == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultBodyPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultBodyPiece.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -41,8 +42,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Default
             AddLayout(subtractionCache);
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] DrawableHitObject drawableObject, ISkinSource skin)
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableObject, ISkinSource skin)
         {
             InternalChildren = new[]
             {
@@ -56,25 +57,22 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Default
                 }
             };
 
-            if (drawableObject != null)
-            {
-                var holdNote = (DrawableNote)drawableObject;
+            var note = (DrawableNote)drawableObject;
 
-                isHitting.BindTo(holdNote.IsHitting);
-                display.BindTo(holdNote.DisplayBindable);
-                singer.BindTo(holdNote.SingersBindable);
-            }
+            isHitting.BindTo(note.IsHitting);
+            display.BindTo(note.DisplayBindable);
+            singer.BindTo(note.SingersBindable);
 
             AccentColour.BindValueChanged(onAccentChanged);
             HitColour.BindValueChanged(onAccentChanged);
             isHitting.BindValueChanged(_ => onAccentChanged(), true);
             display.BindValueChanged(_ => onAccentChanged(), true);
-            singer.BindCollectionChanged((_, _) => applySingerStyle(skin, singer), true);
+            singer.BindCollectionChanged((_, _) => applySingerStyle(skin, note.HitObject), true);
         }
 
-        private void applySingerStyle(ISkinSource skin, IEnumerable<int> singers)
+        private void applySingerStyle(ISkinSource skin, Note note)
         {
-            var noteSkin = skin?.GetConfig<KaraokeSkinLookup, NoteStyle>(new KaraokeSkinLookup(ElementType.NoteStyle, singers))?.Value;
+            var noteSkin = skin?.GetConfig<Note, NoteStyle>(note)?.Value;
             if (noteSkin == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Skinning/Groups/BaseGroup.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Groups/BaseGroup.cs
@@ -1,9 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
-using osu.Game.Beatmaps;
+using System.ComponentModel;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 
@@ -15,33 +13,29 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Groups
 
         public string Name { get; set; }
 
-        public IEnumerable<KaraokeHitObject> GetGroupHitObjects(IBeatmap beatmap, IKaraokeSkinElement element)
+        public bool InTheGroup(KaraokeHitObject hitObject, ElementType elementType)
         {
-            // get processable hit objects type first.
-            var acceptedHitObjects = filterAcceptedHitObjects(beatmap, element).OfType<THitObject>();
-
-            // then get the objects by customized group.
-            return acceptedHitObjects.Where(InTheGroup);
+            bool accepted = isTypeAccepted(hitObject, elementType);
+            return accepted && InTheGroup(hitObject as THitObject);
         }
 
         protected abstract bool InTheGroup(THitObject hitObject);
 
-        private IEnumerable<KaraokeHitObject> filterAcceptedHitObjects(IBeatmap beatmap, IKaraokeSkinElement element)
+        private static bool isTypeAccepted(KaraokeHitObject hitObject, ElementType elementType)
         {
-            var karaokeHitObjects = beatmap.HitObjects.OfType<KaraokeHitObject>();
-
-            switch (element)
+            switch (elementType)
             {
-                case LyricConfig:
-                case LyricLayout:
-                case LyricStyle:
-                    return karaokeHitObjects.OfType<Lyric>();
+                case ElementType.LyricConfig:
+                case ElementType.LyricLayout:
+                case ElementType.LyricStyle:
+                    return hitObject is Lyric;
 
-                case NoteStyle:
-                    return karaokeHitObjects.OfType<Note>();
+                case ElementType.NoteStyle:
+                    return hitObject is Note;
+
+                default:
+                    throw new InvalidEnumArgumentException(nameof(elementType));
             }
-
-            return karaokeHitObjects;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Groups/IGroup.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Groups/IGroup.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 
@@ -14,6 +12,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Groups
 
         public string Name { get; set; }
 
-        IEnumerable<KaraokeHitObject> GetGroupHitObjects(IBeatmap beatmap, IKaraokeSkinElement element);
+        bool InTheGroup(KaraokeHitObject hitObject, ElementType elementType);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeBeatmapSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeBeatmapSkin.cs
@@ -47,7 +47,16 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
         {
             switch (lookup)
             {
-                // Lookup skin by type and index
+                // get the target element by hit object.
+                case KaraokeHitObject hitObject:
+                {
+                    var type = typeof(TValue);
+                    var element = GetElementByHitObjectAndElementType(hitObject, type);
+                    return SkinUtils.As<TValue>(new Bindable<TValue>((TValue)element));
+                }
+
+                // in some cases, we still need to get target of element by type and id.
+                // e.d: get list of layout in the skin manager.
                 case KaraokeSkinLookup skinLookup:
                 {
                     var type = skinLookup.Type;

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeBeatmapSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeBeatmapSkin.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.IO;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Karaoke.Skinning.Groups;
 using osu.Game.Rulesets.Karaoke.Skinning.MappingRoles;
@@ -70,6 +71,33 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
             }
 
             return null;
+        }
+
+        protected override IKaraokeSkinElement GetElementByHitObjectAndElementType(KaraokeHitObject hitObject, Type elementType)
+        {
+            var type = GetElementType(elementType);
+            var firstMatchedRole = DefaultMappingRoles.FirstOrDefault(x => x.CanApply(this, hitObject, type));
+
+            if (firstMatchedRole == null)
+                return base.GetElementByHitObjectAndElementType(hitObject, elementType);
+
+            int elementId = firstMatchedRole.ElementId;
+            var element = ToElement(type, elementId);
+            return element;
+        }
+
+        protected IKaraokeSkinElement ToElement(ElementType type, int id)
+        {
+            var elements = Elements[type];
+            if (elements == null)
+                throw new ArgumentNullException(nameof(elements));
+
+            var element = elements.FirstOrDefault(x => x.ID == id);
+            if (element == null)
+                throw new ArgumentNullException(nameof(element));
+
+            // should make sure that must be able to found element from the skin.
+            return element;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
@@ -70,7 +70,16 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
         {
             switch (lookup)
             {
-                // Lookup skin by type and index
+                // get the target element by hit object.
+                case KaraokeHitObject hitObject:
+                {
+                    var type = typeof(TValue);
+                    var element = GetElementByHitObjectAndElementType(hitObject, type);
+                    return SkinUtils.As<TValue>(new Bindable<TValue>((TValue)element));
+                }
+
+                // in some cases, we still need to get target of element by type and id.
+                // e.d: get list of layout in the skin manager.
                 case KaraokeSkinLookup skinLookup:
                 {
                     var type = skinLookup.Type;

--- a/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/KaraokeSkin.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.IO;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Karaoke.UI.Components;
 using osu.Game.Rulesets.Karaoke.UI.Scrolling;
@@ -99,5 +100,31 @@ namespace osu.Game.Rulesets.Karaoke.Skinning
 
             return null;
         }
+
+        protected virtual IKaraokeSkinElement GetElementByHitObjectAndElementType(KaraokeHitObject hitObject, Type elementType)
+        {
+            var type = GetElementType(elementType);
+            return ToElement(type);
+        }
+
+        protected static ElementType GetElementType(Type elementType)
+        {
+            return elementType switch
+            {
+                var type when type == typeof(LyricConfig) => ElementType.LyricConfig,
+                var type when type == typeof(LyricLayout) => ElementType.LyricLayout,
+                var type when type == typeof(LyricStyle) => ElementType.LyricStyle,
+                var type when type == typeof(NoteStyle) => ElementType.NoteStyle,
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        protected IKaraokeSkinElement ToElement(ElementType type)
+            => type switch
+            {
+                ElementType.LyricStyle or ElementType.LyricConfig or ElementType.NoteStyle => DefaultElement[type],
+                ElementType.LyricLayout => null,
+                _ => throw new InvalidEnumArgumentException(nameof(type))
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Legacy/LegacyNotePiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Legacy/LegacyNotePiece.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Layout;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -57,23 +58,19 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
                 border = createLayer("Border layer", skin, LegacyKaraokeSkinNoteLayer.Border)
             };
 
+            var note = (DrawableNote)drawableObject;
+
             direction.BindTo(scrollingInfo.Direction);
             direction.BindValueChanged(OnDirectionChanged, true);
-
-            if (drawableObject != null)
-            {
-                var holdNote = (DrawableNote)drawableObject;
-
-                isHitting.BindTo(holdNote.IsHitting);
-                display.BindTo(holdNote.DisplayBindable);
-                singer.BindTo(holdNote.SingersBindable);
-            }
+            isHitting.BindTo(note.IsHitting);
+            display.BindTo(note.DisplayBindable);
+            singer.BindTo(note.SingersBindable);
 
             AccentColour.BindValueChanged(onAccentChanged);
             HitColour.BindValueChanged(onAccentChanged);
             isHitting.BindValueChanged(onIsHittingChanged, true);
             display.BindValueChanged(_ => onAccentChanged(), true);
-            singer.BindCollectionChanged((_, _) => applySingerStyle(skin, singer), true);
+            singer.BindCollectionChanged((_, _) => applySingerStyle(skin, note.HitObject), true);
         }
 
         private void onIsHittingChanged(ValueChangedEvent<bool> isHitting)
@@ -102,9 +99,9 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
                 foreground.FadeColour(AccentColour.Value.Lighten(0.7f), animation_length).Then().FadeColour(foreground.Colour, animation_length).Loop();
         }
 
-        private void applySingerStyle(ISkinSource skin, IEnumerable<int> singers)
+        private void applySingerStyle(ISkinSource skin, Note note)
         {
-            var noteSkin = skin?.GetConfig<KaraokeSkinLookup, NoteStyle>(new KaraokeSkinLookup(ElementType.NoteStyle, singers))?.Value;
+            var noteSkin = skin?.GetConfig<Note, NoteStyle>(note)?.Value;
             if (noteSkin == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/DefaultMappingRole.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/DefaultMappingRole.cs
@@ -1,10 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Karaoke.Skinning.Groups;
@@ -13,22 +10,17 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.MappingRoles
 {
     public class DefaultMappingRole : MappingRole
     {
-        public ElementType ElementType { get; set; }
-
-        public int ElementId { get; set; }
-
         public int GroupId { get; set; }
 
-        public override IEnumerable<KaraokeHitObject> GetApplicableHitObjects(KaraokeBeatmapSkin beatmapSkin, IBeatmap beatmap)
+        public override bool CanApply(KaraokeBeatmapSkin beatmapSkin, KaraokeHitObject hitObject, ElementType elementType)
         {
-            var element = getElementByTypeAndId(beatmapSkin, ElementType, ElementId);
+            if (ElementType != elementType)
+                return false;
+
             var group = getGroupById(beatmapSkin, GroupId);
-
-            return group.GetGroupHitObjects(beatmap, element);
+            bool inTheGroup = group.InTheGroup(hitObject, elementType);
+            return inTheGroup;
         }
-
-        private static IKaraokeSkinElement getElementByTypeAndId(KaraokeBeatmapSkin beatmapSkin, ElementType elementType, int elementId)
-            => beatmapSkin.Elements[elementType].FirstOrDefault(x => x.ID == elementId);
 
         private static IGroup getGroupById(KaraokeBeatmapSkin beatmapSkin, int groupId)
             => beatmapSkin.Groups.FirstOrDefault(x => x.ID == groupId);

--- a/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/IMappingRole.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/IMappingRole.cs
@@ -1,9 +1,8 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.MappingRoles
 {
@@ -11,6 +10,10 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.MappingRoles
     {
         string Name { get; set; }
 
-        IEnumerable<KaraokeHitObject> GetApplicableHitObjects(KaraokeBeatmapSkin beatmapSkin, IBeatmap beatmap);
+        ElementType ElementType { get; set; }
+
+        int ElementId { get; set; }
+
+        bool CanApply(KaraokeBeatmapSkin beatmapSkin, KaraokeHitObject hitObject, ElementType elementType);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/MappingRole.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/MappingRoles/MappingRole.cs
@@ -1,9 +1,8 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.MappingRoles
 {
@@ -11,6 +10,10 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.MappingRoles
     {
         public string Name { get; set; }
 
-        public abstract IEnumerable<KaraokeHitObject> GetApplicableHitObjects(KaraokeBeatmapSkin beatmapSkin, IBeatmap beatmap);
+        public ElementType ElementType { get; set; }
+
+        public int ElementId { get; set; }
+
+        public abstract bool CanApply(KaraokeBeatmapSkin beatmapSkin, KaraokeHitObject hitObject, ElementType elementType);
     }
 }


### PR DESCRIPTION
What's done in this PR:
- adjust the logic in the mapping or group class.
- apply the logic into karaoke skin.
- should get the skin element by the hit object, not by lookup.