### PR TITLE
Make the ruleset able to read customized beatmap

### DIFF
--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -295,6 +295,9 @@ namespace osu.Game.Rulesets.Karaoke
         {
             // It's a tricky way to let lazer to read karaoke testing beatmap
             KaraokeLegacyBeatmapDecoder.Register();
+
+            // it's a tricky way for loading customized karaoke beatmap.
+            RulesetInfo.OnlineID = 111;
         }
     }
 }


### PR DESCRIPTION
add this shit back.
.
If still not show the beatmap, please try to remove the ruleset dll and re-add it.
Or re-import the beatmap.
.
https://docs.mongodb.com/realm-legacy/products/realm-studio.html#download-studio
![image](https://user-images.githubusercontent.com/9100368/152551075-232a93fc-3ee0-431b-8830-5c6205c76117.png)
Or use this way to change the online id from -1 to 111 in the `clicnt.realm` if still not working.
