### PR TITLE
Remove continuous property in lyric layout.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/NicoKaraDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/NicoKaraDecoderTest.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                 Assert.AreEqual(firstLayout.Alignment, Anchor.BottomRight);
                 Assert.AreEqual(firstLayout.HorizontalMargin, 30);
                 Assert.AreEqual(firstLayout.VerticalMargin, 45);
-                Assert.AreEqual(firstLayout.Continuous, false);
 
                 // Testing style
                 var firstFont = skin.LyricStyles.FirstOrDefault();

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/KaraokeSkinElementConvertorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/KaraokeSkinElementConvertorTest.cs
@@ -41,16 +41,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
                 Alignment = Anchor.TopLeft,
                 HorizontalMargin = 10,
                 VerticalMargin = 20,
-                Continuous = true,
             };
             string result = JsonConvert.SerializeObject(lyricLayout, CreateSettings());
-            Assert.AreEqual(result, "{\"$type\":1,\"id\":1,\"name\":\"Testing layout\",\"alignment\":9,\"horizontal_margin\":10,\"vertical_margin\":20,\"continuous\":true}");
+            Assert.AreEqual(result, "{\"$type\":1,\"id\":1,\"name\":\"Testing layout\",\"alignment\":9,\"horizontal_margin\":10,\"vertical_margin\":20}");
         }
 
         [Test]
         public void TestLyricLayoutDeserialize()
         {
-            const string json = "{\"$type\":1,\"id\":1,\"name\":\"Testing layout\",\"alignment\":9,\"horizontal_margin\":10,\"vertical_margin\":20,\"continuous\":true}";
+            const string json = "{\"$type\":1,\"id\":1,\"name\":\"Testing layout\",\"alignment\":9,\"horizontal_margin\":10,\"vertical_margin\":20}";
             var result = JsonConvert.DeserializeObject<IKaraokeSkinElement>(json, CreateSettings()) as LyricLayout;
             var actual = new LyricLayout
             {
@@ -59,7 +58,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
                 Alignment = Anchor.TopLeft,
                 HorizontalMargin = 10,
                 VerticalMargin = 20,
-                Continuous = true,
             };
 
             Assert.NotNull(result);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/NicoKaraDecoder.cs
@@ -51,7 +51,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                     Alignment = convertAnchor(karaokeLayout.HorizontalAlignment, karaokeLayout.VerticalAlignment),
                     HorizontalMargin = karaokeLayout.HorizontalMargin,
                     VerticalMargin = karaokeLayout.VerticalMargin,
-                    Continuous = karaokeLayout.Continuous,
                 });
             }
 

--- a/osu.Game.Rulesets.Karaoke/Skinning/Elements/LyricLayout.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Elements/LyricLayout.cs
@@ -33,11 +33,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Elements
         /// </summary>
         public int VerticalMargin { get; set; }
 
-        /// <summary>
-        /// ???
-        /// </summary>
-        public bool Continuous { get; set; }
-
         public void ApplyTo(Drawable d)
         {
             if (d is not DrawableLyric drawableLyric)
@@ -53,12 +48,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Elements
                 Top = Alignment.HasFlagFast(Anchor.y0) ? VerticalMargin : 0,
                 Bottom = Alignment.HasFlagFast(Anchor.y2) ? VerticalMargin : 0
             };
-
-            drawableLyric.ApplyToLyricPieces(l =>
-            {
-                // Layout to text
-                l.Continuous = Continuous;
-            });
         }
     }
 }


### PR DESCRIPTION
remove this property because it's meaningless.
also, it can be replaced by customized skin elements (e.g: LyricAutoChangeNewLine).