### PR TITLE
Remove layout index from lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLayoutToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLayoutToolTip.cs
@@ -43,7 +43,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
 
             foreach ((int key, string value) in layouts)
             {
-                setTooltip($"Test lyric with layout {value}", lyric => { lyric.LayoutIndex = key; });
+                setTooltip($"Test lyric with layout {value}", lyric =>
+                {
+                    // todo: should change mapping group id from the lyric.
+                });
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
@@ -139,24 +139,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         }
 
         [TestCase(1, 1, 1)]
-        [TestCase(2, 2, 2)]
-        [TestCase(-5, -5, -5)] // copy layout index even it's wrong.
-        public void TestSeparateLyricLayoutIndex(int actualLayout, int firstLayout, int secondLayout)
-        {
-            const int split_index = 2;
-            var lyric = new Lyric
-            {
-                Text = "karaoke!",
-                LayoutIndex = actualLayout
-            };
-
-            var (firstLyric, secondLyric) = LyricsUtils.SplitLyric(lyric, split_index);
-
-            Assert.AreEqual(firstLyric.LayoutIndex, firstLayout);
-            Assert.AreEqual(secondLyric.LayoutIndex, secondLayout);
-        }
-
-        [TestCase(1, 1, 1)]
         [TestCase(54, 54, 54)]
         [TestCase(null, null, null)]
         public void TestSeparateLyricLanguage(int? lcid, int? firstLcid, int? secondLcid)
@@ -307,21 +289,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 
             var combineLyric = LyricsUtils.CombineLyric(lyric1, lyric2);
             Assert.AreEqual(combineLyric.Singers, actualSingerIndexes);
-        }
-
-        [TestCase(1, 2, 1)]
-        [TestCase(1, 3, 1)]
-        [TestCase(1, -1, 1)]
-        [TestCase(-1, 1, -1)]
-        [TestCase(-5, 1, -5)] // Wrong layout index
-        public void TestCombineLayoutIndex(int firstLayout, int secondLayout, int actualLayout)
-        {
-            var lyric1 = new Lyric { LayoutIndex = firstLayout };
-            var lyric2 = new Lyric { LayoutIndex = secondLayout };
-
-            // just use first lyric's layout id.
-            var combineLyric = LyricsUtils.CombineLyric(lyric1, lyric2);
-            Assert.AreEqual(combineLyric.LayoutIndex, actualLayout);
         }
 
         [TestCase(1, 1, 1)]

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
@@ -13,8 +13,6 @@ using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Components.ContextMenu;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Skinning;
-using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Karaoke.UI.Components;
 using osu.Game.Rulesets.Karaoke.UI.Position;
 using osu.Game.Rulesets.Karaoke.UI.Scrolling;
@@ -54,7 +52,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             {
                 return new[]
                 {
-                    createLayoutMenuItem(),
                     createSingerMenuItem()
                 };
             }
@@ -96,29 +93,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             {
                 notesChangeHandler.Combine();
             });
-        }
-
-        private MenuItem createLayoutMenuItem()
-        {
-            var lyrics = EditorBeatmap.SelectedHitObjects.Cast<Lyric>();
-            var layoutDictionary = source.GetConfig<KaraokeIndexLookup, IDictionary<int, string>>(KaraokeIndexLookup.Layout)?.Value;
-            var selectedLayoutIndexes = lyrics.Select(x => x.LayoutIndex).Distinct().ToList();
-            int selectedLayoutIndex = selectedLayoutIndexes.Count == 1 ? selectedLayoutIndexes.FirstOrDefault() : -1;
-
-            return new OsuMenuItem("Layout")
-            {
-                Items = layoutDictionary?.Select(x => new TernaryStateToggleMenuItem(x.Value, selectedLayoutIndex == x.Key ? MenuItemType.Highlighted : MenuItemType.Standard, state =>
-                {
-                    if (state != TernaryState.True)
-                        return;
-
-                    int layoutIndex = x.Key;
-                    var layout = source.GetConfig<KaraokeSkinLookup, LyricLayout>(new KaraokeSkinLookup(ElementType.LyricLayout, layoutIndex)).Value;
-
-                    // todo: should use another way to change the layout.
-                    // lyricLayoutChangeHandler.ChangeLayout(layout);
-                })).ToArray()
-            };
         }
 
         private MenuItem createSingerMenuItem()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
     public class EditLyricRow : LyricEditorRow
     {
         private const int min_height = 75;
-        private const int continuous_spacing = 20;
 
         public EditLyricRow(Lyric lyric)
             : base(lyric)
@@ -43,16 +42,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
 
         protected override Drawable CreateLyricInfo(Lyric lyric)
         {
-            // todo : need to refactor this part.
-            bool isContinuous = lyric.LayoutIndex == -1;
-            int continuousSpacing = isContinuous ? continuous_spacing : 0;
-
             return new InfoControl(lyric)
             {
-                Margin = new MarginPadding
-                {
-                    Left = continuousSpacing,
-                },
                 // todo : cannot use relative size to both because it will cause size cannot roll-back if make lyric smaller.
                 RelativeSizeAxes = Axes.X,
                 Height = min_height,

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -133,19 +133,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         }
 
         [JsonIgnore]
-        public readonly Bindable<int> LayoutIndexBindable = new();
-
-        /// <summary>
-        /// Layout index
-        /// </summary>
-        [JsonIgnore]
-        public int LayoutIndex
-        {
-            get => LayoutIndexBindable.Value;
-            set => LayoutIndexBindable.Value = value;
-        }
-
-        [JsonIgnore]
         public readonly BindableDictionary<CultureInfo, string> TranslateTextBindable = new();
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutPreview.cs
@@ -85,7 +85,9 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Layout
                 manager.EditLayout.BindValueChanged(v =>
                 {
                     if (Child is PreviewDrawableLyric lyric)
-                        lyric.HitObject.LayoutIndex = v.NewValue.ID;
+                    {
+                        // todo: should trigger the skin change instead.
+                    }
                 }, true);
             }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutSelection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/LayoutSelection.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Layout
         {
             private const float selection_size = (240 - layout_setting_horizontal_padding * 2 - SECTION_SPACING) / 2;
 
+            // todo: should changed into selected layout index
             private readonly Bindable<int> selectedLayoutIndex = new();
 
             private readonly DrawableLayoutPreview drawableLayoutPreview;
@@ -131,20 +132,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Layout
                     if (drawableLayoutPreview.Lyric == value)
                         return;
 
-                    // unbind previous event
-                    if (Lyric != null)
-                    {
-                        selectedLayoutIndex.UnbindFrom(Lyric.LayoutIndexBindable);
-                    }
-
                     // update lyric
                     drawableLayoutPreview.Lyric = value;
-
-                    // bind layout index.
-                    if (Lyric != null)
-                    {
-                        selectedLayoutIndex.BindTo(Lyric.LayoutIndexBindable);
-                    }
                 }
             }
 

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
@@ -65,7 +65,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 RomajiTags = lyric.RomajiTags?.Where(x => x.StartIndex < splitIndex && x.EndIndex <= splitIndex).ToArray(),
                 // todo : should implement time and duration
                 Singers = lyric.Singers,
-                LayoutIndex = lyric.LayoutIndex,
                 Language = lyric.Language,
             };
 
@@ -78,7 +77,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 RomajiTags = shiftingTextTag(lyric.RomajiTags?.Where(x => x.StartIndex >= splitIndex && x.EndIndex > splitIndex).ToArray(), secondLyricText, -splitIndex),
                 // todo : should implement time and duration
                 Singers = lyric.Singers,
-                LayoutIndex = lyric.LayoutIndex,
                 Language = lyric.Language,
             };
 
@@ -127,7 +125,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 StartTime = startTime,
                 Duration = endTime - startTime,
                 Singers = singers.Distinct().ToArray(),
-                LayoutIndex = firstLyric.LayoutIndex,
                 Language = language,
             };
         }


### PR DESCRIPTION
It's the last step of #1079
What's done in this PR:
- remove copy layout Id logic in lyric utils.
- should not able to assign layout index directly in the editor.
- should trigger the skin change instead if re-assign the layout id. -> it's a todo issue
- remove broken test case.
- should fix the preview layout in the lyric -> it's a todo issue
- finally can remove this property.