### PR TITLE
Fix the issue that cannot enter the editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/DrawableKaraokeEditorRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/DrawableKaraokeEditorRuleset.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             bindableDisplayTranslateToggle.BindValueChanged(x => { Session.SetValue(KaraokeRulesetSession.UseTranslate, x.NewValue); });
         }
 
-        public override DrawableHitObject<KaraokeHitObject> CreateDrawableRepresentation(KaraokeHitObject h) => null;
-
         protected override Playfield CreatePlayfield() => new KaraokeEditorPlayfield();
 
         [BackgroundDependencyLoader]
@@ -44,5 +42,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             editConfigManager.BindWith(KaraokeRulesetEditSetting.DisplayRomaji, bindableDisplayRomajiToggle);
             editConfigManager.BindWith(KaraokeRulesetEditSetting.DisplayTranslate, bindableDisplayTranslateToggle);
         }
+
+        // todo: use default adjustment container because DrawableEditorRulesetWrapper will create it but contains no KaraokeRulesetConfigManager
+        public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new();
     }
 }


### PR DESCRIPTION
resolved issue #1102
the root cause if cannot enter editor is caused by `KaraokePlayfieldAdjustmentContainer` need the DI, but not provided because it's been created in another place.

the better solution might be to create a default playfield adjustment container.