### PR TITLE
Make sure only select one lyric in some cases in the change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -18,6 +18,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
 
         protected IEnumerable<THitObject> HitObjects => beatmap.HitObjects.OfType<THitObject>();
 
+        protected void CheckExactlySelectedOneHitObject()
+        {
+            if (beatmap.SelectedHitObjects.OfType<THitObject>().Count() != 1)
+                throw new InvalidOperationException($"Should be exactly one {nameof(THitObject)} being selected.");
+        }
+
         protected void PerformOnSelection(Action<THitObject> action) => beatmap.PerformOnSelection(h =>
         {
             if (h is THitObject tHitObject)

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextChangeHandler.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
     {
         public void InsertText(int index, string text)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 LyricUtils.AddText(lyric, index, text);
@@ -19,6 +21,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void DeleteLyricText(int index)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 LyricUtils.RemoveText(lyric, index - 1);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
     {
         public void Add(TTextTag textTag)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = ContainsInLyric(lyric, textTag);
@@ -26,6 +28,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void Remove(TTextTag textTag)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = ContainsInLyric(lyric, textTag);
@@ -38,6 +42,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void RemoveAll(IEnumerable<TTextTag> textTags)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 // should convert to array because enumerable might change while deleting.
@@ -54,6 +60,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void SetIndex(TTextTag textTag, int? startIndex, int? endIndex)
         {
+            CheckExactlySelectedOneHitObject();
+
             // note: it's ok not sort the text tag by index.
             PerformOnSelection(lyric =>
             {
@@ -71,6 +79,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void ShiftingIndex(IEnumerable<TTextTag> textTags, int offset)
         {
+            CheckExactlySelectedOneHitObject();
+
             // note: it's ok not sort the text tag by index.
             PerformOnSelection(lyric =>
             {
@@ -89,6 +99,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void SetText(TTextTag textTag, string text)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = ContainsInLyric(lyric, textTag);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void SetTimeTagTime(TimeTag timeTag, double time)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = lyric.TimeTags?.Contains(timeTag) ?? false;
@@ -44,6 +46,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void ClearTimeTagTime(TimeTag timeTag)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = lyric.TimeTags?.Contains(timeTag) ?? false;
@@ -56,6 +60,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void Add(TimeTag timeTag)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 bool containsInLyric = lyric.TimeTags.Contains(timeTag);
@@ -68,6 +74,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void Remove(TimeTag timeTag)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 // delete time tag from list
@@ -77,6 +85,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void AddByPosition(TextIndex index)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 lyric.TimeTags.Add(new TimeTag(index));
@@ -85,6 +95,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void RemoveByPosition(TextIndex index)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 var matchedTimeTags = lyric.TimeTags.Where(x => x.Index == index).ToList();

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTranslateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTranslateChangeHandler.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
     {
         public void UpdateTranslate(CultureInfo cultureInfo, string translate)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 // should not save translate if is null or empty or whitespace

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricsChangeHandler.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
     {
         public void Split(int index)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 // Shifting order that order is larger than current lyric.
@@ -35,6 +37,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void Combine()
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 var previousLyric = HitObjects.GetPrevious(lyric);
@@ -57,6 +61,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         public void CreateAtPosition()
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(lyric =>
             {
                 int order = lyric.Order;

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
 
         public void Split(float percentage = 0.5f)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(note =>
             {
                 var (firstNote, secondNote) = NotesUtils.SplitNote(note);
@@ -70,6 +72,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
 
         public void ChangeText(string text)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(note =>
             {
                 note.Text = text;
@@ -78,6 +82,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
 
         public void ChangeRubyText(string ruby)
         {
+            CheckExactlySelectedOneHitObject();
+
             PerformOnSelection(note =>
             {
                 note.RubyText = ruby;


### PR DESCRIPTION
closes issue #1118
should check the selection amount if change value to exactly one hit object.
for preventing unexpected behavior, e.g:
- change text to multiple notes at one time.
- add same class instance to different lyrics).