### PR TITLE
Should re-sort the order while save the time-tags to json.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RomajiTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RomajiTagsConverterTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
+{
+    public class RomajiTagsConverterTest : BaseSingleConverterTest<RomajiTagsConverter>
+    {
+        protected override JsonConverter[] CreateExtraConverts()
+            => new JsonConverter[]
+            {
+                new RomajiTagConverter(),
+            };
+
+        [Test]
+        public void TestSerialize()
+        {
+            var timeTags = new[]
+            {
+                new RomajiTag
+                {
+                    StartIndex = 2,
+                    EndIndex = 3,
+                    Text = "ji"
+                },
+                new RomajiTag
+                {
+                    StartIndex = 1,
+                    EndIndex = 2,
+                    Text = "roma"
+                },
+            };
+
+            const string expected = "[\"[1,2]:roma\",\"[2,3]:ji\"]";
+            string actual = JsonConvert.SerializeObject(timeTags, CreateSettings());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDeserialize()
+        {
+            const string json = "[\"[2,3]:ji\",\"[1,2]:roma\"]";
+
+            var expected = new[]
+            {
+                new RomajiTag
+                {
+                    StartIndex = 1,
+                    EndIndex = 2,
+                    Text = "roma"
+                },
+                new RomajiTag
+                {
+                    StartIndex = 2,
+                    EndIndex = 3,
+                    Text = "ji"
+                },
+            };
+            var actual = JsonConvert.DeserializeObject<RomajiTag[]>(json, CreateSettings());
+            TextTagAssert.ArePropertyEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagsConverterTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
+{
+    public class RubyTagsConverterTest : BaseSingleConverterTest<RubyTagsConverter>
+    {
+        protected override JsonConverter[] CreateExtraConverts()
+            => new JsonConverter[]
+            {
+                new RubyTagConverter(),
+            };
+
+        [Test]
+        public void TestSerialize()
+        {
+            var timeTags = new[]
+            {
+                new RubyTag
+                {
+                    StartIndex = 2,
+                    EndIndex = 3,
+                    Text = "ビ"
+                },
+                new RubyTag
+                {
+                    StartIndex = 1,
+                    EndIndex = 2,
+                    Text = "ル"
+                },
+            };
+
+            const string expected = "[\"[1,2]:ル\",\"[2,3]:ビ\"]";
+            string actual = JsonConvert.SerializeObject(timeTags, CreateSettings());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDeserialize()
+        {
+            const string json = "[\"[2,3]:ビ\",\"[1,2]:ル\"]";
+
+            var expected = new[]
+            {
+                new RubyTag
+                {
+                    StartIndex = 1,
+                    EndIndex = 2,
+                    Text = "ル"
+                },
+                new RubyTag
+                {
+                    StartIndex = 2,
+                    EndIndex = 3,
+                    Text = "ビ"
+                },
+            };
+            var actual = JsonConvert.DeserializeObject<RubyTag[]>(json, CreateSettings());
+            TextTagAssert.ArePropertyEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TimeTagsConverterTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
+{
+    [TestFixture]
+    public class TimeTagsConverterTest : BaseSingleConverterTest<TimeTagsConverter>
+    {
+        protected override JsonConverter[] CreateExtraConverts()
+            => new JsonConverter[]
+            {
+                new TimeTagConverter(),
+            };
+
+        [Test]
+        public void TestSerialize()
+        {
+            var timeTags = new[]
+            {
+                new TimeTag(new TextIndex(0, TextIndex.IndexState.End), 1000),
+                new TimeTag(new TextIndex(0), 0)
+            };
+
+            const string expected = "[\"[0,start]:0\",\"[0,end]:1000\"]";
+            string actual = JsonConvert.SerializeObject(timeTags, CreateSettings());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDeserialize()
+        {
+            const string json = "[\"[0,end]:1000\",\"[0,start]:0\"]";
+
+            var expected = new[]
+            {
+                new TimeTag(new TextIndex(0), 0),
+                new TimeTag(new TextIndex(0, TextIndex.IndexState.End), 1000),
+            };
+            var actual = JsonConvert.DeserializeObject<TimeTag[]>(json, CreateSettings());
+            TimeTagAssert.ArePropertyEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
@@ -17,8 +17,11 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
             var globalSetting = JsonSerializableExtensions.CreateGlobalSettings();
             globalSetting.Converters.Add(new CultureInfoConverter());
             globalSetting.Converters.Add(new RomajiTagConverter());
+            globalSetting.Converters.Add(new RomajiTagsConverter());
             globalSetting.Converters.Add(new RubyTagConverter());
+            globalSetting.Converters.Add(new RubyTagsConverter());
             globalSetting.Converters.Add(new TimeTagConverter());
+            globalSetting.Converters.Add(new TimeTagsConverter());
             globalSetting.Converters.Add(new ToneConverter());
 
             // create id if object is by reference.

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapEncoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapEncoder.cs
@@ -15,8 +15,11 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
             var globalSetting = JsonSerializableExtensions.CreateGlobalSettings();
             globalSetting.Converters.Add(new CultureInfoConverter());
             globalSetting.Converters.Add(new RomajiTagConverter());
+            globalSetting.Converters.Add(new RomajiTagsConverter());
             globalSetting.Converters.Add(new RubyTagConverter());
+            globalSetting.Converters.Add(new RubyTagsConverter());
             globalSetting.Converters.Add(new TimeTagConverter());
+            globalSetting.Converters.Add(new TimeTagsConverter());
             globalSetting.Converters.Add(new ToneConverter());
 
             // replace string stream.ReadToEnd().Serialize(output);

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/RomajiTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/RomajiTagsConverter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public class RomajiTagsConverter : SortableJsonConvertor<RomajiTag>
+    {
+        protected override IEnumerable<RomajiTag> GetSortedValue(IEnumerable<RomajiTag> objects)
+            => TextTagsUtils.Sort(objects);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/RubyTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/RubyTagsConverter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public class RubyTagsConverter : SortableJsonConvertor<RubyTag>
+    {
+        protected override IEnumerable<RubyTag> GetSortedValue(IEnumerable<RubyTag> objects)
+            => TextTagsUtils.Sort(objects);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/SortableJsonConvertor.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/SortableJsonConvertor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public abstract class SortableJsonConvertor<TObject> : JsonConverter<IEnumerable<TObject>>
+    {
+        public sealed override IEnumerable<TObject> ReadJson(JsonReader reader, Type objectType, IEnumerable<TObject> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var obj = JArray.Load(reader);
+            var timeTags = obj.Select(x => serializer.Deserialize<TObject>(x.CreateReader()));
+            return GetSortedValue(timeTags);
+        }
+
+        public override void WriteJson(JsonWriter writer, IEnumerable<TObject> value, JsonSerializer serializer)
+        {
+            // see: https://stackoverflow.com/questions/3330989/order-of-serialized-fields-using-json-net
+            var sortedTimeTags = GetSortedValue(value);
+
+            writer.WriteStartArray();
+
+            foreach (var timeTag in sortedTimeTags)
+            {
+                serializer.Serialize(writer, timeTag);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        protected abstract IEnumerable<TObject> GetSortedValue(IEnumerable<TObject> objects);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TimeTagsConverter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public class TimeTagsConverter : SortableJsonConvertor<TimeTag>
+    {
+        protected override IEnumerable<TimeTag> GetSortedValue(IEnumerable<TimeTag> objects)
+            => TimeTagsUtils.Sort(objects);
+    }
+}


### PR DESCRIPTION
Implement issue #1119
.
Although we are not planned to sort the tags all the time after #1121 merged.
But it's still better to get sorted value in the json beatmap.