### PR TITLE
[NOT WORKING] Trying to let ILRepack.MSBuild.Task works again.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,6 @@
   <ItemGroup Label="Code Analysis">
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis\BannedSymbols.txt" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Label="Code Analysis">
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis\osu.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
ILRepack.MSBuild.Task not working after #1124.
And this error is caused because upgrade `Microsoft.CodeAnalysis.NetAnalyzers` into 6.0.0
.
so remove un-needed package because it will cause compile error in .netCore 3.1
and ILRepack.MSBuild.Task can only run on this environment.