### PR TITLE
Use ILRepack.Lib.MSBuild.Task instead of ILRepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
+      continue-on-error: true # ILRepack.Lib.MSBuild can make dll but with error, so there's no other choice to add this line.
       run: dotnet build osu.Game.Rulesets.Karaoke --configuration Release -p:version=${{env.CURRENT_TAG}} --no-restore
     - name: Create Release
       id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Setup dotnet version
-      uses: actions/setup-dotnet@v1 # Build with netCore 3.1 because ILRepack not support .net5
+      uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x' # SDK Version to use.
+        dotnet-version: '6.0.x' # SDK Version to use.
     - name: Fetch all tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Get current tag

--- a/osu.Game.Rulesets.Karaoke/ILRepack.targets
+++ b/osu.Game.Rulesets.Karaoke/ILRepack.targets
@@ -16,15 +16,8 @@
             <InputAssemblies Include="$(OutputPath)\osu.Game.Rulesets.Karaoke.dll" />
         </ItemGroup>
 
-        <ItemGroup>
-            <InternalizeExcludeAssemblies Include="osu.Game.dll" />
-            <InternalizeExcludeAssemblies Include="osu.Framework.dll" />
-        </ItemGroup>
-
         <ILRepack
                 Parallel="true"
-                Internalize="true"
-                InternalizeExclude="@(InternalizeExcludeAssemblies)"
                 InputAssemblies="@(InputAssemblies)"
                 TargetKind="Dll"
                 OutputFile="$(OutputPath)$(AssemblyName).Packed.dll"

--- a/osu.Game.Rulesets.Karaoke/ILRepack.targets
+++ b/osu.Game.Rulesets.Karaoke/ILRepack.targets
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+        <ItemGroup>
+            <InputAssemblies Include="$(OutputPath)\LanguageDetection.dll" />
+            <InputAssemblies Include="$(OutputPath)\Octokit.dll" />
+            <InputAssemblies Include="$(OutputPath)\osu.Framework.KaraokeFont.dll" />
+            <InputAssemblies Include="$(OutputPath)\osu.Framework.Microphone.dll" />
+            <InputAssemblies Include="$(OutputPath)\NWaves.dll" />
+            <InputAssemblies Include="$(OutputPath)\LyricMaker.dll" />
+            <InputAssemblies Include="$(OutputPath)\NicoKaraParser.dll" />
+            <InputAssemblies Include="$(OutputPath)\SixLabors.Fonts.dll" />
+            <InputAssemblies Include="$(OutputPath)\SixLabors.ImageSharp.Drawing.dll" />
+            <InputAssemblies Include="$(OutputPath)\WanaKanaSharp.dll" />
+            <InputAssemblies Include="$(OutputPath)\Zipangu.dll" />
+            <InputAssemblies Include="$(OutputPath)\osu.Game.Rulesets.Karaoke.dll" />
+        </ItemGroup>
+
+        <ItemGroup>
+            <InternalizeExcludeAssemblies Include="osu.Game.dll" />
+            <InternalizeExcludeAssemblies Include="osu.Framework.dll" />
+        </ItemGroup>
+
+        <ILRepack
+                Parallel="true"
+                Internalize="true"
+                InternalizeExclude="@(InternalizeExcludeAssemblies)"
+                InputAssemblies="@(InputAssemblies)"
+                TargetKind="Dll"
+                OutputFile="$(OutputPath)$(AssemblyName).Packed.dll"
+        />
+    </Target>
+</Project>

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>osu.Game.Rulesets.Karaoke</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
+    <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.214.0" />
@@ -36,32 +36,5 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-
-  <Target Name="ILRepack" AfterTargets="Build" Condition=" '$(Configuration)'=='Release' ">
-    <PropertyGroup>
-      <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <InputAssemblies Include="LanguageDetection.dll" />
-      <InputAssemblies Include="Octokit.dll" />
-      <InputAssemblies Include="osu.Framework.KaraokeFont.dll" />
-      <InputAssemblies Include="osu.Framework.Microphone.dll" />
-      <InputAssemblies Include="NWaves.dll" />
-      <InputAssemblies Include="LyricMaker.dll" />
-      <InputAssemblies Include="NicoKaraParser.dll" />
-      <InputAssemblies Include="SixLabors.Fonts.dll" />
-      <InputAssemblies Include="SixLabors.ImageSharp.Drawing.dll" />
-      <InputAssemblies Include="WanaKanaSharp.dll" />
-      <InputAssemblies Include="Zipangu.dll" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <InternalizeExcludeAssemblies Include="osu.Game.dll" />
-      <InternalizeExcludeAssemblies Include="osu.Framework.dll" />
-    </ItemGroup>
-
-    <ILRepack OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).Packed.dll" InputAssemblies="@(InputAssemblies)" InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" WorkingDirectory="$(WorkingDirectory)" />
-
-  </Target>
+  
 </Project>


### PR DESCRIPTION
Yes, it's another attempt to find another tool to replace `ILRepack`.
And it's not working again.
.
Github:
https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task

And because this repo only support windows, so use this nuget package instead:
https://www.nuget.org/packages/ILRepack.Lib.MSBuild/

See the discussion:
https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task/issues/29