### PR TITLE
Implement json reference resolver

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -32,6 +32,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 
             // create id if object is by reference.
             globalSetting.PreserveReferencesHandling = PreserveReferencesHandling.Objects;
+
+            // also notice that it might have a bug that cannot deserializer the reference normally, so should add those options.
+            // https://stackoverflow.com/questions/25853407/json-net-not-respecting-preservereferenceshandling-on-deserialization
+            // demo: https://dotnetfiddle.net/j1Qhu6
+            // discussion: https://github.com/JamesNK/Newtonsoft.Json/issues/124
+            globalSetting.TypeNameHandling = TypeNameHandling.Auto;
 
             // should not let json decoder to read this line.
             if (stream.PeekLine()?.Contains("// karaoke json file format v") ?? false)

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapEncoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapEncoder.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                 throw new InvalidOperationException();
             }
 
+            // create id if object is by reference.
+            globalSetting.PreserveReferencesHandling = PreserveReferencesHandling.Objects;
+
             // replace string stream.ReadToEnd().Serialize(output);
             string json = JsonConvert.SerializeObject(output, globalSetting);
             return "// karaoke json file format v1" + '\n' + json;

--- a/osu.Game.Rulesets.Karaoke/Edit/Export/ExportLyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Export/ExportLyricManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.IO;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
 using osu.Game.Screens.Edit;
 using SharpCompress.Archives.Zip;
@@ -75,6 +76,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Export
             using (var sw = new StreamWriter(outputStream))
             {
                 sw.WriteLine(generateJsonBeatmap());
+            }
+
+            using (var stream = exportStorage.GetStream(filename))
+            using (var reader = new LineBufferedReader(stream))
+            {
+                // Create stream
+                stream.Position = 0;
+
+                // test decoder
+                var decoder = new KaraokeJsonBeatmapDecoder();
+                decoder.Decode(reader);
             }
 
             exportStorage.PresentFileExternally(filename);

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// Relative lyric.
         /// Technically parent lyric will not change after assign, but should not restrict in model layer.
         /// </summary>
-        [JsonProperty(IsReference = true)]
+        [JsonProperty(IsReference = true, TypeNameHandling = TypeNameHandling.Objects)]
         public Lyric? ReferenceLyric
         {
             get => ReferenceLyricBindable.Value;


### PR DESCRIPTION
It's a attempt to resolve part of issue #1107
.
Trying to fix two parts:
- reduce duplicated object in json beatmap. parent lyric in the first note will record as a lyric instance, not reference id.
- due to the first issue, it will cause reference error in parent lyric property on the note class.