### PR TITLE
Fix packing issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/osu.Game.Rulesets.Karaoke.Packed.dll
+        asset_path: ./osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.dll
         asset_name: osu.Game.Rulesets.Karaoke.dll
         asset_content_type: application/vnd.microsoft.portable-executable
     - name: Generate changelog

--- a/osu.Game.Rulesets.Karaoke/ILRepack.targets
+++ b/osu.Game.Rulesets.Karaoke/ILRepack.targets
@@ -20,7 +20,7 @@
                 Parallel="true"
                 InputAssemblies="@(InputAssemblies)"
                 TargetKind="Dll"
-                OutputFile="$(OutputPath)$(AssemblyName).Packed.dll"
+                OutputFile="$(OutputPath)Packed\$(AssemblyName).dll"
         />
     </Target>
 </Project>

--- a/osu.Game.Rulesets.Karaoke/ILRepack.targets
+++ b/osu.Game.Rulesets.Karaoke/ILRepack.targets
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
         <ItemGroup>
+            <InputAssemblies Include="$(OutputPath)\osu.Game.Rulesets.Karaoke.dll" />
             <InputAssemblies Include="$(OutputPath)\LanguageDetection.dll" />
             <InputAssemblies Include="$(OutputPath)\Octokit.dll" />
             <InputAssemblies Include="$(OutputPath)\osu.Framework.KaraokeFont.dll" />
@@ -13,7 +14,6 @@
             <InputAssemblies Include="$(OutputPath)\SixLabors.ImageSharp.Drawing.dll" />
             <InputAssemblies Include="$(OutputPath)\WanaKanaSharp.dll" />
             <InputAssemblies Include="$(OutputPath)\Zipangu.dll" />
-            <InputAssemblies Include="$(OutputPath)\osu.Game.Rulesets.Karaoke.dll" />
         </ItemGroup>
 
         <ILRepack

--- a/osu.Game.Rulesets.Karaoke/Utils/AssemblyUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/AssemblyUtils.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 return defaultAssembly;
 
             // Note: because multiple assembly might be wrapped into single one by ILRepack, so should find by main dll again if not found.
-            return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName.Contains("osu.Game.Rulesets.Karaoke.Packed"));
+            return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName.Contains("osu.Game.Rulesets.Karaoke"));
         }
     }
 }


### PR DESCRIPTION
Fix the packing issue found while implementing #1107 
- wrong assembly info.
- type not found issue because production dll assembly name is not as what development dll is.