### PR TITLE
Should be able to show/hide the waveform graph in the record/adjust mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -37,6 +38,11 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowTick, true);
             SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagTickOpacity, 0.5f, 0, 1, 0.01f);
         }
+
+        /// <summary>
+        /// Binds a local bindable with a configuration-backed bindable.
+        /// </summary>
+        public void BindWith<TValue>(KaraokeRulesetLyricEditorSetting lookup, IBindable<TValue> bindable) => bindable.BindTo(GetOriginalBindable<TValue>(lookup));
     }
 
     public enum KaraokeRulesetLyricEditorSetting

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -26,6 +26,16 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             // Recording
             SetDefault(KaraokeRulesetLyricEditorSetting.RecordingTimeTagMovingCaretMode, MovingTimeTagCaretMode.None);
             SetDefault(KaraokeRulesetLyricEditorSetting.RecordingAutoMoveToNextTimeTag, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowWaveform, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.RecordingTimeTagWaveformOpacity, 0.5f, 0, 1, 0.01f);
+            SetDefault(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowTick, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.RecordingTimeTagTickOpacity, 0.5f, 0, 1, 0.01f);
+
+            // Adjust
+            SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowWaveform, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagWaveformOpacity, 0.5f, 0, 1, 0.01f);
+            SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowTick, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.AdjustTimeTagTickOpacity, 0.5f, 0, 1, 0.01f);
         }
     }
 
@@ -44,5 +54,15 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         // Recording
         RecordingTimeTagMovingCaretMode,
         RecordingAutoMoveToNextTimeTag,
+        RecordingTimeTagShowWaveform,
+        RecordingTimeTagWaveformOpacity,
+        RecordingTimeTagShowTick,
+        RecordingTimeTagTickOpacity,
+
+        // Adjust
+        AdjustTimeTagShowWaveform,
+        AdjustTimeTagWaveformOpacity,
+        AdjustTimeTagShowTick,
+        AdjustTimeTagTickOpacity,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Containers/EditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Containers/EditorScrollContainer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
@@ -20,15 +20,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Containers
             ZoomEasing = Easing.OutQuint;
             ScrollbarVisible = false;
 
-            BindableZoom.MaxValueChanged += (v) =>
-            {
-                MaxZoom = v;
-            };
+            BindableZoom.MaxValueChanged += assignZoomRange;
+            BindableZoom.MinValueChanged += assignZoomRange;
 
-            BindableZoom.MinValueChanged += (v) =>
+            void assignZoomRange(float _)
             {
-                MinZoom = v;
-            };
+                // we should make sure that will not cause error while assigning the size.
+                MaxZoom = Math.Max(BindableZoom.MaxValue, MinZoom);
+                MinZoom = Math.Min(BindableZoom.MinValue, MaxZoom);
+            }
 
             BindableZoom.BindValueChanged(e =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         protected abstract Dictionary<T, EditModeSelectionItem> CreateSelections();
 
-        protected abstract Color4 GetColour(OsuColour colour, T mode, bool active);
+        protected abstract Color4 GetColour(OsuColour colours, T mode, bool active);
 
         private class EditModeButton : OsuButton
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         private readonly OverlayColourProvider overlayColourProvider;
 
         [Resolved]
-        private OsuColour colour { get; set; }
+        private OsuColour colours { get; set; }
 
         private readonly EditModeButton[] buttons;
         private readonly OsuMarkdownTextFlowContainer description;
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             {
                 bool highLight = EqualityComparer<T>.Default.Equals(button.Mode, mode);
                 button.Alpha = highLight ? 0.8f : 0.4f;
-                button.BackgroundColour = GetColour(colour, button.Mode, highLight);
+                button.BackgroundColour = GetColour(colours, button.Mode, highLight);
 
                 if (!highLight)
                     continue;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour, ILyricSelectionState lyricSelectionState)
+        private void load(OsuColour colours, ILyricSelectionState lyricSelectionState)
         {
             selecting = lyricSelectionState.Selecting.GetBoundCopy();
             selecting.BindValueChanged(e =>
             {
                 bool isSelecting = e.NewValue;
-                BackgroundColour = isSelecting ? colour.Blue : colour.Purple;
+                BackgroundColour = isSelecting ? colours.Blue : colours.Purple;
                 Text = isSelecting ? SelectingText : StandardText;
             }, true);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageEditModeSection.cs
@@ -34,11 +34,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
                 }
             };
 
-        protected override Color4 GetColour(OsuColour colour, LanguageEditMode mode, bool active) =>
+        protected override Color4 GetColour(OsuColour colours, LanguageEditMode mode, bool active) =>
             mode switch
             {
-                LanguageEditMode.Generate => active ? colour.Blue : colour.BlueDarker,
-                LanguageEditMode.Verify => active ? colour.Yellow : colour.YellowDarker,
+                LanguageEditMode.Generate => active ? colours.Blue : colours.BlueDarker,
+                LanguageEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageMissingSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageMissingSection.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
         public class LyricLanguageIssueTable : IssueTableContainer
         {
             [Resolved]
-            private OsuColour colour { get; set; }
+            private OsuColour colours { get; set; }
 
             public IEnumerable<Issue> Issues
             {
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
                 {
                     Origin = Anchor.Centre,
                     Size = new Vector2(10),
-                    Colour = colour.Red,
+                    Colour = colours.Red,
                     Margin = new MarginPadding { Left = 10 },
                     Icon = FontAwesome.Solid.Globe,
                 },

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
@@ -37,12 +37,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 }
             };
 
-        protected override Color4 GetColour(OsuColour colour, NoteEditMode mode, bool active) =>
+        protected override Color4 GetColour(OsuColour colours, NoteEditMode mode, bool active) =>
             mode switch
             {
-                NoteEditMode.Generate => active ? colour.Blue : colour.BlueDarker,
-                NoteEditMode.Edit => active ? colour.Red : colour.RedDarker,
-                NoteEditMode.Verify => active ? colour.Yellow : colour.YellowDarker,
+                NoteEditMode.Generate => active ? colours.Blue : colours.BlueDarker,
+                NoteEditMode.Edit => active ? colours.Red : colours.RedDarker,
+                NoteEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/TextTagIssueTable.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/TextTagIssueTable.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
     public abstract class TextTagIssueTable<TInvalid, TTextTag> : IssueTableContainer where TTextTag : ITextTag
     {
         [Resolved]
-        private OsuColour colour { get; set; }
+        private OsuColour colours { get; set; }
 
         public IEnumerable<Issue> Issues
         {
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
             {
                 Origin = Anchor.Centre,
                 Size = new Vector2(10),
-                Colour = colour.Red,
+                Colour = colours.Red,
                 Margin = new MarginPadding { Left = 10 },
                 Icon = FontAwesome.Solid.Tag,
             },

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
@@ -14,12 +14,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Pink;
 
-        protected override Color4 GetColour(OsuColour colour, TextTagEditMode mode, bool active) =>
+        protected override Color4 GetColour(OsuColour colours, TextTagEditMode mode, bool active) =>
             mode switch
             {
-                TextTagEditMode.Generate => active ? colour.Blue : colour.BlueDarker,
-                TextTagEditMode.Edit => active ? colour.Red : colour.RedDarker,
-                TextTagEditMode.Verify => active ? colour.Yellow : colour.YellowDarker,
+                TextTagEditMode.Generate => active ? colours.Blue : colours.BlueDarker,
+                TextTagEditMode.Edit => active ? colours.Red : colours.RedDarker,
+                TextTagEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/Components/LabelledOpacityAdjustment.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/Components/LabelledOpacityAdjustment.cs
@@ -1,0 +1,96 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags.Components
+{
+    public class LabelledOpacityAdjustment : LabelledSwitchButton
+    {
+        protected const float CONFIG_BUTTON_SIZE = 20f;
+
+        private readonly OpacityButton opacityButton;
+
+        public LabelledOpacityAdjustment()
+        {
+            if (InternalChildren[1] is not FillFlowContainer fillFlowContainer)
+                return;
+
+            // change padding to place config button.
+            fillFlowContainer.Padding = new MarginPadding
+            {
+                Horizontal = CONTENT_PADDING_HORIZONTAL,
+                Vertical = CONTENT_PADDING_VERTICAL,
+                Right = CONTENT_PADDING_HORIZONTAL + CONFIG_BUTTON_SIZE + CONTENT_PADDING_HORIZONTAL,
+            };
+
+            // add config button.
+            AddInternal(new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding
+                {
+                    Top = CONTENT_PADDING_VERTICAL,
+                    Right = CONTENT_PADDING_HORIZONTAL,
+                },
+                Child = opacityButton = new OpacityButton
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    Size = new Vector2(CONFIG_BUTTON_SIZE),
+                }
+            });
+
+            Component.Current.BindValueChanged(_ => updateConfigButtonOpacity(), true);
+        }
+
+        private void updateConfigButtonOpacity()
+        {
+            bool showOpacityButton = Component.Current.Value;
+            opacityButton.FadeTo(showOpacityButton ? 1 : 0.3f, 200, Easing.OutQuint);
+            opacityButton.Enabled.Value = showOpacityButton;
+        }
+
+        public Bindable<float> Opacity
+        {
+            set => opacityButton.Current = value;
+        }
+
+        private class OpacityButton : IconButton, IHasPopover, IHasCurrentValue<float>
+        {
+            public Bindable<float> Current { get; set; }
+
+            public OpacityButton()
+            {
+                Icon = FontAwesome.Solid.Cog;
+                Action = this.ShowPopover;
+            }
+
+            public Popover GetPopover()
+                => new OsuPopover
+                {
+                    Child = new OpacitySliderBar
+                    {
+                        Width = 150,
+                        Current = Current,
+                    }
+                };
+
+            private class OpacitySliderBar : OsuSliderBar<float>
+            {
+                public override LocalisableString TooltipText => (Current.Value * 100).ToString("N0") + "%";
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAdjustConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAdjustConfigSection.cs
@@ -3,7 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
@@ -14,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
         protected override string Title => "Config";
 
         [BackgroundDependencyLoader]
-        private void load(ITimeTagModeState timeTagModeState)
+        private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager, ITimeTagModeState timeTagModeState)
         {
             Children = new Drawable[]
             {
@@ -23,6 +25,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                     Label = "Time range",
                     Description = "Change time-range to zoom-in/zoom-out the adjust area.",
                     Current = timeTagModeState.BindableAdjustZoom
+                },
+                new LabelledOpacityAdjustment
+                {
+                    Label = "Waveform",
+                    Description = "Show/hide or change the opacity of the waveform.",
+                    Current = lyricEditorConfigManager.GetBindable<bool>(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowWaveform),
+                    Opacity = lyricEditorConfigManager.GetBindable<float>(KaraokeRulesetLyricEditorSetting.AdjustTimeTagWaveformOpacity),
+                },
+                new LabelledOpacityAdjustment
+                {
+                    Label = "Ticks",
+                    Description = "Show/hide or change the opacity of the ticks.",
+                    Current = lyricEditorConfigManager.GetBindable<bool>(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowTick),
+                    Opacity = lyricEditorConfigManager.GetBindable<float>(KaraokeRulesetLyricEditorSetting.AdjustTimeTagTickOpacity),
                 }
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                 }
             };
 
-        protected override Color4 GetColour(OsuColour colour, LyricEditorMode mode, bool active)
+        protected override Color4 GetColour(OsuColour colours, LyricEditorMode mode, bool active)
         {
             return mode switch
             {
-                LyricEditorMode.CreateTimeTag => active ? colour.Blue : colour.BlueDarker,
-                LyricEditorMode.RecordTimeTag => active ? colour.Red : colour.RedDarker,
-                LyricEditorMode.AdjustTimeTag => active ? colour.Yellow : colour.YellowDarker,
+                LyricEditorMode.CreateTimeTag => active ? colours.Blue : colours.BlueDarker,
+                LyricEditorMode.RecordTimeTag => active ? colours.Red : colours.RedDarker,
+                LyricEditorMode.AdjustTimeTag => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
         public class TimeTagIssueTable : IssueTableContainer
         {
             [Resolved]
-            private OsuColour colour { get; set; }
+            private OsuColour colours { get; set; }
 
             public IEnumerable<TimeTagIssue> Issues
             {
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                 {
                     Origin = Anchor.Centre,
                     Size = new Vector2(10),
-                    Colour = colour.Red,
+                    Colour = colours.Red,
                     Margin = new MarginPadding { Left = 10 },
                     Icon = FontAwesome.Solid.AlignLeft
                 },
@@ -182,9 +182,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
             private Color4 getInvalidColour(TimeTagInvalid invalid) =>
                 invalid switch
                 {
-                    TimeTagInvalid.OutOfRange => colour.Red,
-                    TimeTagInvalid.Overlapping => colour.Red,
-                    TimeTagInvalid.EmptyTime => colour.Yellow,
+                    TimeTagInvalid.OutOfRange => colours.Red,
+                    TimeTagInvalid.Overlapping => colours.Red,
+                    TimeTagInvalid.EmptyTime => colours.Yellow,
                     _ => throw new ArgumentOutOfRangeException(nameof(invalid))
                 };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagRecordingConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagRecordingConfigSection.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
@@ -37,6 +38,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                     Label = "Time range",
                     Description = "Change time-range to zoom-in/zoom-out the recording area.",
                     Current = timeTagModeState.BindableRecordZoom
+                },
+                new LabelledOpacityAdjustment
+                {
+                    Label = "Waveform",
+                    Description = "Show/hide or change the opacity of the waveform.",
+                    Current = lyricEditorConfigManager.GetBindable<bool>(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowWaveform),
+                    Opacity = lyricEditorConfigManager.GetBindable<float>(KaraokeRulesetLyricEditorSetting.RecordingTimeTagWaveformOpacity),
+                },
+                new LabelledOpacityAdjustment
+                {
+                    Label = "Ticks",
+                    Description = "Show/hide or change the opacity of the ticks.",
+                    Current = lyricEditorConfigManager.GetBindable<bool>(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowTick),
+                    Opacity = lyricEditorConfigManager.GetBindable<float>(KaraokeRulesetLyricEditorSetting.RecordingTimeTagTickOpacity),
                 }
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
@@ -27,7 +27,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
 
         protected readonly IBindable<bool> ShowWaveformGraph = new BindableBool();
 
+        protected readonly IBindable<float> WaveformOpacity = new BindableFloat();
+
         protected readonly IBindable<bool> ShowTick = new BindableBool();
+
+        protected readonly IBindable<float> TickOpacity = new BindableFloat();
 
         protected double StartTime { get; private set; }
 
@@ -125,7 +129,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
                 waveform.Waveform = b.NewValue.Waveform;
                 Track = b.NewValue.Track;
             }, true);
+
+            ShowWaveformGraph.BindValueChanged(e => updateWaveformOpacity());
+            WaveformOpacity.BindValueChanged(e => updateWaveformOpacity());
+            ShowTick.BindValueChanged(e => updateTickOpacity());
+            TickOpacity.BindValueChanged(e => updateTickOpacity());
         }
+
+        private void updateWaveformOpacity() =>
+            waveform.FadeTo(ShowWaveformGraph.Value ? WaveformOpacity.Value : 0, 200, Easing.OutQuint);
+
+        private void updateTickOpacity() =>
+            ticks.FadeTo(ShowTick.Value ? TickOpacity.Value : 0, 200, Easing.OutQuint);
 
         protected abstract void PostProcessContent(Container content);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -91,14 +90,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
         private void load(IBindable<WorkingBeatmap> beatmap)
         {
             Beatmap.BindTo(beatmap);
-
-            // initialize scroll zone.
-            MaxZoom = getZoomLevelForVisibleMilliseconds(500);
-            MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-            Zoom = getZoomLevelForVisibleMilliseconds(3000);
         }
-
-        private float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(editorClock.TrackLength / milliseconds));
 
         public double GetPreviewTime(TimeTag timeTag)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagEditor.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -57,9 +58,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, ITimeTagModeState timeTagModeState)
+        private void load(OsuColour colours, ITimeTagModeState timeTagModeState, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
             BindableZoom.BindTo(timeTagModeState.BindableRecordZoom);
+
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowWaveform, ShowWaveformGraph);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagWaveformOpacity, WaveformOpacity);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagShowTick, ShowTick);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagTickOpacity, TickOpacity);
 
             AddRangeInternal(new Drawable[]
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagEditor.cs
@@ -3,10 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
@@ -17,7 +14,6 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
 {
@@ -49,31 +45,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
         /// </summary>
         private bool trackWasPlaying;
 
-        private Track track;
+        private readonly CentreMarker centreMarker;
+
+        private OsuSpriteText trackTimer;
 
         public RecordingTimeTagEditor(Lyric lyric)
             : base(lyric)
         {
-            Height = TIMELINE_HEIGHT;
+            // We don't want the centre marker to scroll
+            AddInternal(centreMarker = new CentreMarker());
         }
-
-        private OsuSpriteText trackTimer;
-
-        private Container mainContent;
-
-        private WaveformGraph waveform;
-
-        private TimelineTickDisplay ticks;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, ITimeTagModeState timeTagModeState)
         {
             BindableZoom.BindTo(timeTagModeState.BindableRecordZoom);
-
-            CentreMarker centreMarker;
-
-            // We don't want the centre marker to scroll
-            AddInternal(centreMarker = new CentreMarker());
 
             AddRangeInternal(new Drawable[]
             {
@@ -95,37 +81,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                     Font = OsuFont.GetFont(size: 16, fixedWidth: true),
                 }
             });
+        }
 
-            AddRange(new Drawable[]
+        protected override void PostProcessContent(Container content)
+        {
+            content.Height = TIMELINE_HEIGHT;
+            content.Y = 10;
+            content.AddRange(new[]
             {
-                mainContent = new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = TIMELINE_HEIGHT,
-                    Y = 10,
-                    Depth = float.MaxValue,
-                    Children = new[]
-                    {
-                        waveform = new WaveformGraph
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            BaseColour = colours.Blue.Opacity(0.2f),
-                            LowColour = colours.BlueLighter,
-                            MidColour = colours.BlueDark,
-                            HighColour = colours.BlueDarker,
-                        },
-                        centreMarker.CreateProxy(),
-                        ticks = new TimelineTickDisplay(),
-                        new RecordingTimeTagPart(HitObject),
-                    }
-                },
+                centreMarker.CreateProxy(),
+                new RecordingTimeTagPart(HitObject),
             });
-
-            Beatmap.BindValueChanged(b =>
-            {
-                waveform.Waveform = b.NewValue.Waveform;
-                track = b.NewValue.Track;
-            }, true);
         }
 
         protected override void Update()
@@ -169,16 +135,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
 
         private void seekTrackToCurrent()
         {
-            if (!track.IsLoaded)
+            if (!Track.IsLoaded)
                 return;
 
-            double target = Current / Content.DrawWidth * track.Length;
-            editorClock.Seek(Math.Min(track.Length, target));
+            double target = Current / Content.DrawWidth * Track.Length;
+            editorClock.Seek(Math.Min(Track.Length, target));
         }
 
         private void scrollToTrackTime()
         {
-            if (!track.IsLoaded || track.Length == 0)
+            if (!Track.IsLoaded || Track.Length == 0)
                 return;
 
             // covers the case where the user starts playback after a drag is in progress.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -13,7 +13,6 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
@@ -27,18 +26,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
         [Resolved]
         private EditorClock editorClock { get; set; }
 
+        private CurrentTimeMarker currentTimeMarker;
+
         public TimeTagEditor(Lyric lyric)
             : base(lyric)
         {
             Padding = new MarginPadding { Top = 10 };
-            Height = timeline_height;
         }
-
-        private Container mainContent;
-
-        private CurrentTimeMarker currentTimeMarker;
-
-        private TimelineTickDisplay ticks;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, ITimeTagModeState timeTagModeState)
@@ -53,20 +47,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 Height = timeline_height,
                 Colour = colours.Gray3,
             });
-            AddRange(new Drawable[]
+        }
+
+        protected override void PostProcessContent(Container content)
+        {
+            content.Height = timeline_height;
+            content.AddRange(new Drawable[]
             {
-                mainContent = new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = timeline_height,
-                    Depth = float.MaxValue,
-                    Children = new Drawable[]
-                    {
-                        ticks = new TimelineTickDisplay(),
-                        new TimeTagEditorBlueprintContainer(HitObject),
-                        currentTimeMarker = new CurrentTimeMarker(),
-                    }
-                },
+                new TimeTagEditorBlueprintContainer(HitObject),
+                currentTimeMarker = new CurrentTimeMarker(),
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -35,9 +36,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, ITimeTagModeState timeTagModeState)
+        private void load(OsuColour colours, ITimeTagModeState timeTagModeState, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
             BindableZoom.BindTo(timeTagModeState.BindableAdjustZoom);
+
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowWaveform, ShowWaveformGraph);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.AdjustTimeTagWaveformOpacity, WaveformOpacity);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.AdjustTimeTagShowTick, ShowTick);
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.AdjustTimeTagTickOpacity, TickOpacity);
 
             AddInternal(new Box
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
         private TimelineTickDisplay ticks;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour, ITimeTagModeState timeTagModeState)
+        private void load(OsuColour colours, ITimeTagModeState timeTagModeState)
         {
             BindableZoom.BindTo(timeTagModeState.BindableAdjustZoom);
 
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
                 Depth = 1,
                 RelativeSizeAxes = Axes.X,
                 Height = timeline_height,
-                Colour = colour.Gray3,
+                Colour = colours.Gray3,
             });
             AddRange(new Drawable[]
             {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/155873689-1e564ff9-0dd1-45a9-9ee0-70e6f58cacf7.png)
![image](https://user-images.githubusercontent.com/9100368/155873722-7ac3f813-2795-422a-9bc9-fc138921b774.png)
Implement part of issue #1113 
.
What's done in this PR:
- adjust param naming(`OsuColour colour` -> `OsuColour colours`);
- remove duplicated zoom scale calculation.
- refactor `TimeTagEditorScrollContainer`, moving common logic(e.g: waveform and tick) into here.
- add more config in the `KaraokeRulesetLyricEditorConfigManager`
- apply the config in the record/adjust edit area.
- apply the config in the right-side config area.
- write the component for able to adjust show/hide and opacity of the component.