### PR TITLE
Implement clear notes section in the edit note mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
@@ -198,5 +198,37 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
                 Assert.AreEqual(new Tone(), h.Tone);
             });
         }
+
+        [Test]
+        public void TestClear()
+        {
+            var lyric = new Lyric();
+
+            // note that lyric and notes should in the selection.
+            PrepareHitObject(lyric);
+            PrepareHitObjects(new[]
+            {
+                new Note
+                {
+                    Text = "カラ",
+                    RubyText = "から",
+                    StartTime = 1000,
+                    Duration = 500,
+                    ParentLyric = lyric,
+                },
+                new Note
+                {
+                    Text = "オケ",
+                    RubyText = "おけ",
+                    StartTime = 1500,
+                    Duration = 500,
+                    ParentLyric = lyric,
+                }
+            }, false);
+
+            TriggerHandlerChanged(c => c.Clear());
+
+            AssertHitObjects(Assert.IsEmpty);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotesChangeHandler.cs
@@ -14,5 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
         void ChangeRubyText(string ruby);
 
         void ChangeDisplayState(bool display);
+
+        void Clear();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
@@ -102,6 +102,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
             });
         }
 
+        public void Clear()
+        {
+            PerformOnLyricSelection(lyric =>
+            {
+                var notes = beatmap.HitObjects.OfType<Note>().Where(n => n.ParentLyric == lyric).ToList();
+                RemoveRange(notes);
+            });
+        }
+
         protected void PerformOnLyricSelection(Action<Lyric> action) => beatmap.PerformOnSelection(h =>
         {
             if (h is Lyric lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/AutoGenerateSection.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap beatmap, ILyricSelectionState lyricSelectionState, OsuColour colours)
         {
+            // should wait until BDL in the parent class has been loaded.
             Schedule(() =>
             {
                 var disableSelectingLyrics = GetDisableSelectingLyrics(beatmap.HitObjects.OfType<Lyric>());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteClearSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteClearSection.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
+{
+    public class NoteClearSection : Section
+    {
+        protected sealed override string Title => "Clear";
+
+        [BackgroundDependencyLoader]
+        private void load(ILyricSelectionState lyricSelectionState, INotesChangeHandler notesChangeHandler)
+        {
+            Children = new Drawable[]
+            {
+                new AutoGenerateButton
+                {
+                    StartSelecting = () => new Dictionary<Lyric, string>()
+                },
+            };
+
+            lyricSelectionState.Action = e =>
+            {
+                if (e != LyricEditorSelectingAction.Apply)
+                    return;
+
+                notesChangeHandler.Clear();
+            };
+        }
+
+        private class AutoGenerateButton : SelectLyricButton
+        {
+            protected override string StandardText => "Clear";
+
+            protected override string SelectingText => "Cancel clear";
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSpecialAction.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSpecialAction.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
+{
+    public enum NoteEditModeSpecialAction
+    {
+        AutoGenerate,
+
+        SyncTime,
+
+        Clear,
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
@@ -2,10 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
         protected override string Title => "Edit property";
 
         [BackgroundDependencyLoader]
-        private void load(Bindable<NoteEditPropertyMode> bindableNoteEditPropertyMode)
+        private void load(IEditNoteModeState editNoteModeState)
         {
             Children = new Drawable[]
             {
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 {
                     Label = "Edit property",
                     Description = "Batch edit text, ruby(alternative) text or display from notes",
-                    Current = bindableNoteEditPropertyMode,
+                    Current = editNoteModeState.NoteEditPropertyMode,
                 },
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -70,9 +70,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
         }
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap, ILyricCaretState lyricCaretState, Bindable<NoteEditPropertyMode> bindableNoteEditPropertyMode)
+        private void load(EditorBeatmap beatmap, ILyricCaretState lyricCaretState, IEditNoteModeState editNoteModeState)
         {
-            this.bindableNoteEditPropertyMode.BindTo(bindableNoteEditPropertyMode);
+            bindableNoteEditPropertyMode.BindTo(editNoteModeState.NoteEditPropertyMode);
             lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
             {
                 var lyric = e.NewValue?.Lyric;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private readonly IBindable<NoteEditMode> bindableMode = new Bindable<NoteEditMode>();
 
-        [Cached]
-        private readonly Bindable<NoteEditPropertyMode> noteEditPropertyMode = new();
 
         public NoteExtend()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private readonly IBindable<NoteEditMode> bindableMode = new Bindable<NoteEditMode>();
 
+        private readonly IBindable<NoteEditModeSpecialAction> bindableModeSpecialAction = new Bindable<NoteEditModeSpecialAction>();
 
         public NoteExtend()
         {
@@ -28,8 +29,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         {
                             new NoteEditModeSection(),
                             new NoteConfigSection(),
-                            new NoteAutoGenerateSection(),
+                            new SwitchSpecialActionSection(),
                         };
+                        updateActionArea();
                         break;
 
                     case NoteEditMode.Edit:
@@ -53,12 +55,44 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                         return;
                 }
             }, true);
+
+            bindableModeSpecialAction.BindValueChanged(e =>
+            {
+                if (bindableMode.Value != NoteEditMode.Generate)
+                    return;
+
+                updateActionArea();
+            }, true);
+
+            void updateActionArea()
+            {
+                RemoveAll(x => x is NoteAutoGenerateSection or NoteClearSection);
+
+                switch (bindableModeSpecialAction.Value)
+                {
+                    case NoteEditModeSpecialAction.AutoGenerate:
+                        Add(new NoteAutoGenerateSection());
+                        break;
+
+                    case NoteEditModeSpecialAction.SyncTime:
+                        // todo: implement
+                        break;
+
+                    case NoteEditModeSpecialAction.Clear:
+                        Add(new NoteClearSection());
+                        break;
+
+                    default:
+                        return;
+                }
+            }
         }
 
         [BackgroundDependencyLoader]
         private void load(IEditNoteModeState editNoteModeState)
         {
             bindableMode.BindTo(editNoteModeState.BindableEditMode);
+            bindableModeSpecialAction.BindTo(editNoteModeState.BindableSpecialAction);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/SwitchSpecialActionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/SwitchSpecialActionSection.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
+{
+    public class SwitchSpecialActionSection : Section
+    {
+        protected sealed override string Title => "Clear";
+
+        [BackgroundDependencyLoader]
+        private void load(IEditNoteModeState editNoteModeState)
+        {
+            Children = new[]
+            {
+                new LabelledEnumDropdown<NoteEditModeSpecialAction>
+                {
+                    Label = "Switch special actions",
+                    Description = "Auto-generate, edit or clear the notes.",
+                    Current = editNoteModeState.BindableSpecialAction,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         public BindableList<Note> SelectedItems { get; } = new();
 
+        public Bindable<NoteEditModeSpecialAction> BindableSpecialAction { get; } = new();
+
         public Bindable<NoteEditPropertyMode> NoteEditPropertyMode { get; } = new();
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         public BindableList<Note> SelectedItems { get; } = new();
 
+        public Bindable<NoteEditPropertyMode> NoteEditPropertyMode { get; } = new();
+
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap editorBeatmap)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditNoteModeState.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
     public interface IEditNoteModeState : IHasEditModeState<NoteEditMode>, IHasBlueprintSelection<Note>
     {
+        Bindable<NoteEditModeSpecialAction> BindableSpecialAction { get; }
 
         Bindable<NoteEditPropertyMode> NoteEditPropertyMode { get; }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditNoteModeState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -8,5 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
     public interface IEditNoteModeState : IHasEditModeState<NoteEditMode>, IHasBlueprintSelection<Note>
     {
+
+        Bindable<NoteEditPropertyMode> NoteEditPropertyMode { get; }
     }
 }


### PR DESCRIPTION
Implement issue #1148 

What's added in this PR:
- should be able to clear the notes in the change handler.
- able to switch auto-generate / change time(not implemented) / clear section.
- implement the clear section.