### PR TITLE
Fix submit lyric property value failed in some cases.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -10,6 +10,8 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
@@ -20,9 +22,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         protected new ObjectFieldTextBox Component => (ObjectFieldTextBox)base.Component;
 
+        [Resolved]
+        private ILyricCaretState lyricCaretState { get; set; }
+
         private readonly T item;
 
-        protected LabelledObjectFieldTextBox(T item)
+        protected LabelledObjectFieldTextBox(Lyric lyric, T item)
         {
             this.item = item;
 
@@ -32,6 +37,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             // should change preview text box if selected ruby/romaji changed.
             OnCommit += (sender, _) =>
             {
+                // because selected lyric might changed if user click another lyric before on commit triggered.
+                // so should force to select the lyric back.
+                if (lyricCaretState.BindableCaretPosition.Value.Lyric != lyric)
+                    lyricCaretState.MoveCaretToTargetPosition(lyric);
+
                 ApplyValue(item, sender.Text);
             };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             private INotesChangeHandler notesChangeHandler { get; set; }
 
             public LabelledNoteTextTextBox(Note item)
-                : base(item)
+                : base(item.ParentLyric, item)
             {
             }
 
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             private INotesChangeHandler notesChangeHandler { get; set; }
 
             public LabelledNoteRubyTextTextBox(Note item)
-                : base(item)
+                : base(item.ParentLyric, item)
             {
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osuTK;
 
@@ -18,8 +19,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
 
         public Action OnDeleteButtonClick;
 
-        protected LabelledTextTagTextBox(T textTag)
-            : base(textTag)
+        protected LabelledTextTagTextBox(Lyric lyric, T textTag)
+            : base(lyric, textTag)
         {
             if (InternalChildren[1] is not FillFlowContainer fillFlowContainer)
                 return;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -53,9 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             }
 
             protected override void SetText(RomajiTag item, string value)
-            {
-                romajiTagsChangeHandler.SetText(item, value);
-            }
+                => romajiTagsChangeHandler.SetText(item, value);
 
             [BackgroundDependencyLoader]
             private void load(IEditRomajiModeState editRomajiModeState)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
@@ -37,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         }
 
         protected override LabelledTextTagTextBox<RomajiTag> CreateLabelledTextTagTextBox(RomajiTag textTag)
-            => new LabelledRomajiTagTextBox(textTag);
+            => new LabelledRomajiTagTextBox(Lyric, textTag);
 
         protected override void RemoveTextTag(RomajiTag textTag)
             => romajiTagsChangeHandler.Remove(textTag);
@@ -47,9 +48,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             [Resolved]
             private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
 
-            public LabelledRomajiTagTextBox(RomajiTag textTag)
-                : base(textTag)
+            public LabelledRomajiTagTextBox(Lyric lyric, RomajiTag textTag)
+                : base(lyric, textTag)
             {
+                Debug.Assert(lyric.RomajiTags.Contains(textTag));
             }
 
             protected override void SetText(RomajiTag item, string value)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -53,9 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             }
 
             protected override void SetText(RubyTag item, string value)
-            {
-                rubyTagsChangeHandler.SetText(item, value);
-            }
+                => rubyTagsChangeHandler.SetText(item, value);
 
             [BackgroundDependencyLoader]
             private void load(IEditRubyModeState editRubyModeState)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
@@ -37,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         }
 
         protected override LabelledTextTagTextBox<RubyTag> CreateLabelledTextTagTextBox(RubyTag textTag)
-            => new LabelledRubyTagTextBox(textTag);
+            => new LabelledRubyTagTextBox(Lyric, textTag);
 
         protected override void RemoveTextTag(RubyTag textTag)
             => rubyTagsChangeHandler.Remove(textTag);
@@ -47,9 +48,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             [Resolved]
             private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
 
-            public LabelledRubyTagTextBox(RubyTag textTag)
-                : base(textTag)
+            public LabelledRubyTagTextBox(Lyric lyric, RubyTag textTag)
+                : base(lyric, textTag)
             {
+                Debug.Assert(lyric.RubyTags.Contains(textTag));
             }
 
             protected override void SetText(RubyTag item, string value)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/156925812-9556b1ef-1526-4cac-9cc0-28b413e355c1.png)
Fix change ruby, romaji, or note text failed if click to another lyric before submit.