### PR TITLE
Adjust colour theme in the lyric editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Components/TestSceneLyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Components/TestSceneLyricEditorColourProvider.cs
@@ -59,6 +59,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Components
 
             Schedule(() =>
             {
+                var editMOdeColumns = new TableColumn[]
+                {
+                    new TitleTableColumn("Edit mode")
+                };
+                var editModeContent = types.Select(type =>
+                {
+                    return new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = type.ToString()
+                        }
+                    };
+                }).To2DArray();
+
                 var columns = colourName.Select(c => new TitleTableColumn(c)).OfType<TableColumn>().ToArray();
                 var content = types.Select(type =>
                 {
@@ -73,15 +88,30 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Components
                     }).OfType<Drawable>();
                 }).To2DArray();
 
+                const int edit_mode_name_width = 120;
                 Child = new OsuScrollContainer(Direction.Horizontal)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = new TableContainer
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Y,
-                        AutoSizeAxes = Axes.X,
-                        Columns = columns,
-                        Content = content,
+                        new TableContainer
+                        {
+                            RelativeSizeAxes = Axes.Y,
+                            Width = edit_mode_name_width,
+                            Columns = editMOdeColumns,
+                            Content = editModeContent,
+                        },
+                        new TableContainer
+                        {
+                            RelativeSizeAxes = Axes.Y,
+                            AutoSizeAxes = Axes.X,
+                            Columns = columns,
+                            Content = content,
+                            Margin = new MarginPadding
+                            {
+                                Left = edit_mode_name_width
+                            }
+                        }
                     }
                 };
             });

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Components/TestSceneLyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Components/TestSceneLyricEditorColourProvider.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Platform;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+using osu.Game.Rulesets.Karaoke.Extensions;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Tests.Visual;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Components
+{
+    public class TestSceneLyricEditorColourProvider : OsuTestScene
+    {
+        [Test]
+        public void ShowWithNoFetch()
+        {
+            var provider = new LyricEditorColourProvider();
+            var types = EnumUtils.GetValues<LyricEditorMode>();
+
+            string[] colourName =
+            {
+                "Colour1",
+                "Colour2",
+                "Colour3",
+                "Colour4",
+                "Highlight1",
+                "Content1",
+                "Content2",
+                "Light1",
+                "Light2",
+                "Light3",
+                "Light4",
+                "Dark1",
+                "Dark2",
+                "Dark3",
+                "Dark4",
+                "Dark5",
+                "Dark6",
+                "Foreground1",
+                "Background1",
+                "Background2",
+                "Background3",
+                "Background4",
+                "Background5",
+                "Background6",
+            };
+
+            Schedule(() =>
+            {
+                var columns = colourName.Select(c => new TitleTableColumn(c)).OfType<TableColumn>().ToArray();
+                var content = types.Select(type =>
+                {
+                    return colourName.Select(c =>
+                    {
+                        object value = provider.GetType().GetMethod(c)?.Invoke(provider, new object[] { type });
+                        if (value == null)
+                            throw new ArgumentNullException(nameof(value));
+
+                        var colour = (Color4)value;
+                        return new PreviewColourDrawable(colour);
+                    }).OfType<Drawable>();
+                }).To2DArray();
+
+                Child = new OsuScrollContainer(Direction.Horizontal)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new TableContainer
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        AutoSizeAxes = Axes.X,
+                        Columns = columns,
+                        Content = content,
+                    }
+                };
+            });
+        }
+
+        private class TitleTableColumn : TableColumn
+        {
+            public TitleTableColumn(string title)
+                : base(title, Anchor.Centre, new Dimension(GridSizeMode.Absolute, 120))
+            {
+            }
+        }
+
+        private class PreviewColourDrawable : CompositeDrawable
+        {
+            [Resolved]
+            private GameHost host { get; set; }
+
+            private readonly Color4 color;
+
+            public PreviewColourDrawable(Color4 color)
+            {
+                this.color = color;
+
+                RelativeSizeAxes = Axes.Both;
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = color,
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = color.ToHex(),
+                    }
+                };
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                host.GetClipboard()?.SetText(color.ToHex());
+                return base.OnClick(e);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -146,14 +146,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             updateBackgroundColour();
         }
 
-        private bool isDragging;
-
         protected override bool OnDragStart(DragStartEvent e)
         {
             if (!base.OnDragStart(e))
                 return false;
 
-            isDragging = true;
             updateBackgroundColour();
 
             // should mark object as selecting while dragging.
@@ -164,7 +161,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         protected override void OnDragEnd(DragEndEvent e)
         {
-            isDragging = false;
             updateBackgroundColour();
 
             base.OnDragEnd(e);
@@ -177,8 +173,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             Color4 getColour()
             {
                 var mode = bindableMode.Value;
-                if (isDragging)
-                    return colourProvider.Background3(mode);
 
                 if (bindableCaretPosition.Value?.Lyric == Model)
                     return colourProvider.Background3(mode);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     background = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Alpha = 0.5f
+                        Alpha = 0.7f
                     },
                     content = new FillFlowContainer
                     {
@@ -178,9 +178,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return colourProvider.Background3(mode);
 
                 if (bindableHoverCaretPosition.Value?.Lyric == Model)
-                    return colourProvider.Background6(mode);
+                    return colourProvider.Background4(mode);
 
-                return Color4.Black;
+                return colourProvider.Background6(mode);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 {
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 
         protected override Container<Drawable> Content => content;
 
+        private readonly CornerBackground background;
         private readonly FillFlowContainer content;
 
         protected EditExtend()
@@ -24,12 +25,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
             RelativeSizeAxes = Axes.Both;
             InternalChildren = new Drawable[]
             {
-                new CornerBackground
+                background = new CornerBackground
                 {
                     Depth = float.MaxValue,
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0.5f,
-                    Colour = Color4.Black
                 },
                 new OsuScrollContainer
                 {
@@ -41,6 +40,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
                     }
                 }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider)
+        {
+            background.Colour = colourProvider.Background3(state.Mode);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorColourProvider.cs
@@ -42,10 +42,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             switch (mode)
             {
                 case LyricEditorMode.View:
-                    return 182 / 360f; // miku blue
+                    return 200 / 360f; // blue
 
                 case LyricEditorMode.Manage:
-                    return 50 / 360f; // yellow
+                    return 0 / 360f; // red
 
                 case LyricEditorMode.Typing:
                 case LyricEditorMode.Language:
@@ -56,13 +56,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.CreateTimeTag:
                 case LyricEditorMode.RecordTimeTag:
                 case LyricEditorMode.AdjustTimeTag:
-                    return 33 / 360f; // orange
+                    return 45 / 360f; // orange
 
                 case LyricEditorMode.EditNote:
-                    return 203 / 360f; // blue
+                    return 200 / 360f; // blue
 
                 case LyricEditorMode.Singer:
-                    return 271 / 360f; // purple
+                    return 255 / 360f; // purple
 
                 default:
                     throw new InvalidEnumArgumentException($@"{mode} colour scheme does not provide a hue value in {nameof(getBaseHue)}.");


### PR DESCRIPTION
Adjust the color for letting text and the extended area become more clear.

Before:
![image](https://user-images.githubusercontent.com/9100368/157064411-7579fbc3-579d-456c-8a16-bb9c58cefa5a.png)

After:
![image](https://user-images.githubusercontent.com/9100368/157065992-572d44a0-1126-4307-b20c-db4fc0f7c49b.png)
