### PR TITLE
Fix the recording caret algorithm might calculate wrong position if time-tag is not order in the lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
@@ -115,6 +116,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
                 throw new MissingMethodException("Test method is not exist.");
 
             return (Lyric[])theMethod.GetValue(this)!;
+
+            /*
+            var lyrics = theMethod.GetValue(this) as Lyric[] ?? Array.Empty<Lyric>();
+
+            foreach (var lyric in lyrics)
+            {
+                // because time-tag will not always sort by order, so we need to shuffle the time-tag in the list for testing.
+                lyric.TimeTags = TestCaseListHelper.Shuffle(lyric.TimeTags);
+            }
+
+            return lyrics;
+            */
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {

--- a/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseListHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseListHelper.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Helper
+{
+    public static class TestCaseListHelper
+    {
+        private static readonly Random rng = new();
+
+        /// <summary>
+        /// Random the order of the list.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static IList<T> Shuffle<T>(IList<T> list)
+        {
+            // see: https://stackoverflow.com/a/4262134
+            return list.OrderBy(_ => rng.Next()).ToList();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
 
             var expected = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
-            var actual = TimeTagsUtils.Sort(timeTags);
+            var actual = TimeTagsUtils.Sort(timeTags).ToArray();
             TimeTagAssert.ArePropertyEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
@@ -41,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             if (previousLyric == null)
                 return null;
 
-            var timeTags = previousLyric.TimeTags.Where(timeTagMovable).ToArray();
+            var timeTags = sortTimeTag(previousLyric.TimeTags.Where(timeTagMovable)).ToArray();
             var upTimeTag = timeTags.FirstOrDefault(x => x.Index >= currentTimeTag.Index)
                             ?? timeTags.LastOrDefault();
 
@@ -65,7 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             if (nextLyric == null)
                 return null;
 
-            var timeTags = nextLyric.TimeTags.Where(timeTagMovable).ToArray();
+            var timeTags = sortTimeTag(nextLyric.TimeTags.Where(timeTagMovable)).ToArray();
             var downTimeTag = timeTags.FirstOrDefault(x => x.Index >= currentTimeTag.Index)
                               ?? timeTags.LastOrDefault();
 
@@ -77,7 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public override TimeTagCaretPosition? MoveLeft(TimeTagCaretPosition currentPosition)
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var timeTags = getAllSortedTimeTag();
             var previousTimeTag = timeTags.GetPreviousMatch(currentPosition.TimeTag, timeTagMovable);
             if (previousTimeTag == null)
                 return null;
@@ -87,7 +89,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public override TimeTagCaretPosition? MoveRight(TimeTagCaretPosition currentPosition)
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var timeTags = getAllSortedTimeTag();
             var nextTimeTag = timeTags.GetNextMatch(currentPosition.TimeTag, timeTagMovable);
             if (nextTimeTag == null)
                 return null;
@@ -97,7 +99,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public override TimeTagCaretPosition? MoveToFirst()
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var timeTags = getAllSortedTimeTag();
             var firstTimeTag = timeTags.FirstOrDefault(timeTagMovable);
             if (firstTimeTag == null)
                 return null;
@@ -107,7 +109,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public override TimeTagCaretPosition? MoveToLast()
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var timeTags = getAllSortedTimeTag();
             var lastTimeTag = timeTags.LastOrDefault(timeTagMovable);
             if (lastTimeTag == null)
                 return null;
@@ -122,6 +124,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             // should not move to lyric if contains no time-tag.
             return targetTimeTag == null ? null : new TimeTagCaretPosition(lyric, targetTimeTag);
         }
+
+        private IEnumerable<TimeTag> sortTimeTag(IEnumerable<TimeTag> timeTags)
+            => TimeTagsUtils.Sort(timeTags);
+
+        private IEnumerable<TimeTag> getAllSortedTimeTag()
+            => sortTimeTag(Lyrics.SelectMany(x => x.TimeTags));
 
         private TimeTagCaretPosition? timeTagToPosition(TimeTag timeTag)
         {

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -60,10 +60,10 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// </summary>
         /// <param name="timeTags">Time tags</param>
         /// <returns>Sorted time tags</returns>
-        public static IList<TimeTag> Sort(IEnumerable<TimeTag> timeTags)
+        public static IEnumerable<TimeTag> Sort(IEnumerable<TimeTag> timeTags)
         {
             return timeTags.OrderBy(x => x.Index)
-                           .ThenBy(x => x.Time).ToArray();
+                           .ThenBy(x => x.Time);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 }
             }
 
-            return Sort(overlappingTimeTagList.Distinct());
+            return Sort(overlappingTimeTagList.Distinct()).ToArray();
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             if (!timeTags.Any())
                 return timeTags;
 
-            var sortedTimeTags = Sort(timeTags);
+            var sortedTimeTags = Sort(timeTags).ToArray();
             var groupedTimeTags = sortedTimeTags.GroupBy(x => x.Index.Index).ToArray();
 
             var overlappingTimeTags = FindOverlapping(timeTags, other, self);
@@ -200,7 +200,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
             foreach (var overlappingTimeTag in overlappingTimeTags)
             {
-                int listIndex = sortedTimeTags.IndexOf(overlappingTimeTag);
+                int listIndex = Array.IndexOf(sortedTimeTags, overlappingTimeTag);
                 var timeTag = overlappingTimeTag.Index;
 
                 // fix self-overlapping


### PR DESCRIPTION
Trying to fix the case that time-tag might not always be by order in the list, which will cause the caret algorithm to get the wrong position.
