### PR TITLE
Should be better to auto-focus to the first ruby/romaji tag if change to different lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -108,6 +108,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
         }
 
+        public void Focus()
+        {
+            Schedule(() =>
+            {
+                GetContainingInputManager().ChangeFocus(Component);
+            });
+        }
+
         protected class ObjectFieldTextBox : OsuTextBox
         {
             [Resolved]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -3,9 +3,9 @@
 
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -18,24 +18,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         [Resolved]
         private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
 
-        [BackgroundDependencyLoader]
-        private void load(ILyricCaretState lyricCaretState)
-        {
-            lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
-            {
-                Lyric = e.NewValue?.Lyric;
-
-                if (e.OldValue?.Lyric != null)
-                {
-                    TextTags.UnbindFrom(e.OldValue.Lyric.RomajiTagsBindable);
-                }
-
-                if (e.NewValue?.Lyric != null)
-                {
-                    TextTags.BindTo(e.NewValue.Lyric.RomajiTagsBindable);
-                }
-            }, true);
-        }
+        protected override IBindableList<RomajiTag> GetBindableTextTags(Lyric lyric)
+            => lyric.RomajiTagsBindable;
 
         protected override LabelledTextTagTextBox<RomajiTag> CreateLabelledTextTagTextBox(RomajiTag textTag)
             => new LabelledRomajiTagTextBox(Lyric, textTag);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -3,9 +3,9 @@
 
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -18,24 +18,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         [Resolved]
         private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
 
-        [BackgroundDependencyLoader]
-        private void load(ILyricCaretState lyricCaretState)
-        {
-            lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
-            {
-                Lyric = e.NewValue?.Lyric;
-
-                if (e.OldValue?.Lyric != null)
-                {
-                    TextTags.UnbindFrom(e.OldValue.Lyric.RubyTagsBindable);
-                }
-
-                if (e.NewValue?.Lyric != null)
-                {
-                    TextTags.BindTo(e.NewValue.Lyric.RubyTagsBindable);
-                }
-            }, true);
-        }
+        protected override IBindableList<RubyTag> GetBindableTextTags(Lyric lyric)
+            => lyric.RubyTagsBindable;
 
         protected override LabelledTextTagTextBox<RubyTag> CreateLabelledTextTagTextBox(RubyTag textTag)
             => new LabelledRubyTagTextBox(Lyric, textTag);


### PR DESCRIPTION
Trying to resolve issue #1171.
But will cause cannot change lyric until comment out those lines in the `LabelledObjectFieldTextBox`
```csharp
// should change preview text box if selected ruby/romaji changed.
OnCommit += (sender, _) =>
{
    // because selected lyric might changed if user click another lyric before on commit triggered.
    // so should force to select the lyric back.
    //if (lyricCaretState.BindableCaretPosition.Value.Lyric != lyric)
    //    lyricCaretState.MoveCaretToTargetPosition(lyric);

    ApplyValue(item, sender.Text);
};
```

And those two lines are added for preventing text cannot submit in the #1157