### PR TITLE
Write the test case for caret state.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
@@ -1,0 +1,347 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
+{
+    [HeadlessTest]
+    public class LyricCaretStateTest : OsuTestScene
+    {
+        private readonly IBeatmap beatmap;
+        private ILyricEditorState state;
+        private LyricCaretState lyricCaretState;
+
+        public LyricCaretStateTest()
+        {
+            beatmap = new KaraokeBeatmap
+            {
+                BeatmapInfo =
+                {
+                    Ruleset = new KaraokeRuleset().RulesetInfo,
+                },
+                HitObjects = new List<KaraokeHitObject>
+                {
+                    new Lyric
+                    {
+                        Text = "First lyric",
+                    },
+                    new Lyric
+                    {
+                        Text = "Second lyric"
+                    },
+                    new Lyric
+                    {
+                        Text = "Third lyric"
+                    },
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var editorBeatmap = new EditorBeatmap(beatmap);
+            var bindableLyrics = new BindableList<Lyric>(beatmap.HitObjects.OfType<Lyric>());
+
+            Dependencies.Cache(editorBeatmap);
+            Dependencies.Cache(new EditorClock());
+            Dependencies.CacheAs(state = new TestLyricEditorState());
+            Dependencies.Cache(new KaraokeRulesetLyricEditorConfigManager());
+
+            Child = lyricCaretState = new LyricCaretState(bindableLyrics);
+        }
+
+        #region Changing mode
+
+        [Test]
+        public void TestChangeFromViewModeToEditMode()
+        {
+            // change from view mode to another mode that contains algorithm.
+            changeMode(LyricEditorMode.View);
+            changeMode(LyricEditorMode.Manage);
+
+            // get the action
+            assertCaretPosition(Assert.IsNotNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void TestChangeFromEditModeToViewMode()
+        {
+            // change from edit mode to view mode for checking that caret position should be clear.
+            changeMode(LyricEditorMode.Manage);
+            changeMode(LyricEditorMode.View);
+
+            // get the action
+            assertCaretPosition(Assert.IsNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void TestChangeFromEditModeToEditMode()
+        {
+            // change from edit mode to view mode for checking that caret position should be clear.
+            changeMode(LyricEditorMode.Manage);
+            changeMode(LyricEditorMode.RecordTimeTag);
+
+            // get the action
+            assertCaretPosition(Assert.IsInstanceOf<TimeTagCaretPosition>);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        #endregion
+
+        #region Moving caret with action
+
+        [Test]
+        public void MovingCaretWithViewMode()
+        {
+            changeMode(LyricEditorMode.View);
+            movingCaret(MovingCaretAction.First);
+
+            // get the action
+            assertCaretPosition(Assert.IsNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void MovingCaretWithEditMode()
+        {
+            changeMode(LyricEditorMode.Manage);
+            movingCaret(MovingCaretAction.First);
+
+            // get the action
+            assertCaretPosition(Assert.IsInstanceOf<TextCaretPosition>);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        #endregion
+
+        #region Moving caret by lyric
+
+        [Test]
+        public void MovingCaretByLyricWithViewMode()
+        {
+            changeMode(LyricEditorMode.View);
+
+            var targetLyric = getLyricFromBeatmap(1);
+            movingCaretByLyric(targetLyric);
+
+            // get the action
+            assertCaretPosition(Assert.IsNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void MovingCaretByLyricWithEditMode()
+        {
+            changeMode(LyricEditorMode.Manage);
+
+            var targetLyric = getLyricFromBeatmap(1);
+            movingCaretByLyric(targetLyric);
+
+            // get the action
+            assertCaretPosition(Assert.IsInstanceOf<TextCaretPosition>);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        #endregion
+
+        #region Moving caret by caret position
+
+        [Test]
+        public void MovingCaretByCaretPositionWithViewMode()
+        {
+            changeMode(LyricEditorMode.View);
+
+            var targetLyric = getLyricFromBeatmap(1);
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric));
+
+            // should not change the caret position if algorithm is null.
+            assertCaretPosition(Assert.IsNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void MovingCaretByCaretPositionWithEditMode()
+        {
+            changeMode(LyricEditorMode.Singer);
+
+            var targetLyric = getLyricFromBeatmap(1);
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric));
+
+            // yes, should change the position if contains algorithm.
+            assertCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void MovingCaretByCaretPositionWithWrongCaretPosition()
+        {
+            changeMode(LyricEditorMode.Manage);
+
+            var targetLyric = getLyricFromBeatmap(1);
+
+            // should throw the exception if caret position type not match.
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric), false);
+        }
+
+        #endregion
+
+        #region Moving hover caret by caret position
+
+        [Test]
+        public void MovingHoverCaretByCaretPositionWithViewMode()
+        {
+            changeMode(LyricEditorMode.View);
+
+            var targetLyric = getLyricFromBeatmap(1);
+            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric));
+
+            // should not change the caret position if algorithm is null.
+            assertCaretPosition(Assert.IsNull);
+            assertHoverCaretPosition(Assert.IsNull);
+        }
+
+        [Test]
+        public void MovingHoverCaretByCaretPositionWithEditMode()
+        {
+            changeMode(LyricEditorMode.Singer);
+
+            var firstLyric = getLyricFromBeatmap(0);
+            var targetLyric = getLyricFromBeatmap(1);
+            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric));
+
+            // because switch to the singer lyric, so current caret position will at the first lyric.
+            assertCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);
+            assertCaretPosition(x => Assert.AreEqual(firstLyric, x.Lyric));
+
+            // yes, should change the position if contains algorithm.
+            assertHoverCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);
+            assertHoverCaretPosition(x => Assert.AreEqual(targetLyric, x.Lyric));
+        }
+
+        [Test]
+        public void MovingHoverCaretByCaretPositionWithWrongCaretPosition()
+        {
+            changeMode(LyricEditorMode.Manage);
+
+            var targetLyric = getLyricFromBeatmap(1);
+
+            // should throw the exception if caret position type not match.
+            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric), false);
+        }
+
+        #endregion
+
+        #region Test utility
+
+        private void changeMode(LyricEditorMode mode)
+        {
+            AddStep("Switch to edit mode", () =>
+            {
+                state.SwitchMode(mode);
+            });
+        }
+
+        private void movingCaret(MovingCaretAction action)
+        {
+            AddStep("Moving caret by action", () =>
+            {
+                lyricCaretState.MoveCaret(action);
+            });
+        }
+
+        private void movingCaretByLyric(Lyric lyric)
+        {
+            AddStep("Moving caret by action", () =>
+            {
+                lyricCaretState.MoveCaretToTargetPosition(lyric);
+            });
+        }
+
+        private void movingCaretByLyric(ICaretPosition caretPosition, bool exceptSuccess = true)
+        {
+            AddStep("Moving caret by caret position", () =>
+            {
+                try
+                {
+                    lyricCaretState.MoveCaretToTargetPosition(caretPosition);
+                    Assert.IsTrue(exceptSuccess);
+                }
+                catch
+                {
+                    Assert.IsFalse(exceptSuccess);
+                }
+            });
+        }
+
+        private void movingHoverCaretByLyric(ICaretPosition caretPosition, bool exceptSuccess = true)
+        {
+            AddStep("Moving hover caret by caret position", () =>
+            {
+                try
+                {
+                    lyricCaretState.MoveHoverCaretToTargetPosition(caretPosition);
+                    Assert.IsTrue(exceptSuccess);
+                }
+                catch
+                {
+                    Assert.IsFalse(exceptSuccess);
+                }
+            });
+        }
+
+        private Lyric getLyricFromBeatmap(int index)
+            => beatmap.HitObjects[index] as Lyric;
+
+        private void assertCaretPosition(Action<ICaretPosition> caretPosition)
+        {
+            AddStep("Assert caret position", () =>
+            {
+                caretPosition.Invoke(lyricCaretState.BindableCaretPosition.Value);
+            });
+        }
+
+        private void assertHoverCaretPosition(Action<ICaretPosition> caretPosition)
+        {
+            AddStep("Assert hover caret position", () =>
+            {
+                caretPosition.Invoke(lyricCaretState.BindableHoverCaretPosition.Value);
+            });
+        }
+
+        #endregion
+
+        private class TestLyricEditorState : ILyricEditorState
+        {
+            private readonly Bindable<LyricEditorMode> bindableMode = new();
+
+            public IBindable<LyricEditorMode> BindableMode => bindableMode;
+
+            public LyricEditorMode Mode => bindableMode.Value;
+
+            public void SwitchMode(LyricEditorMode mode)
+                => bindableMode.Value = mode;
+
+            public void NavigateToFix(LyricEditorMode mode)
+                => throw new NotImplementedException();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/AssignLanguage/AssignLanguageStepScreen.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.AssignLanguage
         protected override Drawable CreateContent()
             => base.CreateContent().With(_ =>
             {
-                LyricEditorMode = LyricEditorMode.Language;
+                SwitchLyricEditorMode(LyricEditorMode.Language);
             });
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricStepScreen.cs
@@ -37,18 +37,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
         protected override Drawable CreateContent()
             => base.CreateContent().With(_ =>
             {
-                LyricEditorMode = LyricEditorMode.Manage;
+                // todo : will cause text update because has ScheduleAfterChildren in lyric editor.
+                SwitchLyricEditorMode(LyricEditorMode.Manage);
             });
 
         public override void Complete()
         {
             ScreenStack.Push(LyricImporterStep.AssignLanguage);
-        }
-
-        internal void SwitchLyricEditorMode(LyricEditorMode mode)
-        {
-            // todo : will cause text update because has ScheduleAfterChildren in lyric editor.
-            LyricEditorMode = mode;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateRubyRomaji/GenerateRubyRomajiStepScreen.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
         protected override Drawable CreateContent()
             => base.CreateContent().With(_ =>
             {
-                LyricEditorMode = LyricEditorMode.EditRomaji;
+                SwitchLyricEditorMode(LyricEditorMode.EditRomaji);
             });
 
         protected override void LoadComplete()
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
 
         internal void AskForAutoGenerateRuby()
         {
-            LyricEditorMode = LyricEditorMode.EditRuby;
+            SwitchLyricEditorMode(LyricEditorMode.EditRuby);
 
             DialogOverlay.Push(new UseAutoGenerateRubyPopupDialog(ok =>
             {
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateRubyRomaji
 
         internal void AskForAutoGenerateRomaji()
         {
-            LyricEditorMode = LyricEditorMode.EditRomaji;
+            SwitchLyricEditorMode(LyricEditorMode.EditRomaji);
 
             DialogOverlay.Push(new UseAutoGenerateRomajiPopupDialog(ok =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/GenerateTimeTag/GenerateTimeTagStepScreen.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.GenerateTimeTag
         protected override Drawable CreateContent()
             => base.CreateContent().With(_ =>
             {
-                LyricEditorMode = LyricEditorMode.CreateTimeTag;
+                SwitchLyricEditorMode(LyricEditorMode.CreateTimeTag);
             });
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
@@ -35,10 +35,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
             };
 
         public LyricEditorMode LyricEditorMode
-        {
-            get => lyricEditor.Mode;
-            protected set => lyricEditor.SwitchMode(value);
-        }
+            => lyricEditor.Mode;
+
+        public virtual void SwitchLyricEditorMode(LyricEditorMode mode)
+            => lyricEditor.SwitchMode(mode);
 
         protected void PrepareAutoGenerate()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         public LyricEditorMode LyricEditorMode
         {
             get => lyricEditor.Mode;
-            protected set => lyricEditor.Mode = value;
+            protected set => lyricEditor.SwitchMode(value);
         }
 
         protected void PrepareAutoGenerate()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public abstract class CaretPositionAlgorithm<T> : ICaretPositionAlgorithm where T : class, ICaretPosition
+    public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlgorithm where TCaretPosition : class, ICaretPosition
     {
         // Lyrics is not lock and can be accessible.
         protected readonly Lyric[] Lyrics;
@@ -16,36 +17,61 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Lyrics = LyricsUtils.FindUnlockLyrics(OrderUtils.Sorted(lyrics));
         }
 
-        public abstract bool PositionMovable(T position);
+        public abstract bool PositionMovable(TCaretPosition position);
 
-        public abstract T MoveUp(T currentPosition);
+        public abstract TCaretPosition MoveUp(TCaretPosition currentPosition);
 
-        public abstract T MoveDown(T currentPosition);
+        public abstract TCaretPosition MoveDown(TCaretPosition currentPosition);
 
-        public abstract T MoveLeft(T currentPosition);
+        public abstract TCaretPosition MoveLeft(TCaretPosition currentPosition);
 
-        public abstract T MoveRight(T currentPosition);
+        public abstract TCaretPosition MoveRight(TCaretPosition currentPosition);
 
-        public abstract T MoveToFirst();
+        public abstract TCaretPosition MoveToFirst();
 
-        public abstract T MoveToLast();
+        public abstract TCaretPosition MoveToLast();
 
-        public abstract T MoveToTarget(Lyric lyric);
+        public abstract TCaretPosition MoveToTarget(Lyric lyric);
 
         public bool PositionMovable(ICaretPosition position)
-            => PositionMovable(position as T);
+        {
+            if (position is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(position));
+
+            return PositionMovable(tCaretPosition);
+        }
 
         public ICaretPosition MoveUp(ICaretPosition currentPosition)
-            => MoveUp(currentPosition as T);
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveUp(tCaretPosition);
+        }
 
         public ICaretPosition MoveDown(ICaretPosition currentPosition)
-            => MoveDown(currentPosition as T);
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveDown(tCaretPosition);
+        }
 
         public ICaretPosition MoveLeft(ICaretPosition currentPosition)
-            => MoveLeft(currentPosition as T);
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveLeft(tCaretPosition);
+        }
 
         public ICaretPosition MoveRight(ICaretPosition currentPosition)
-            => MoveRight(currentPosition as T);
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveRight(tCaretPosition);
+        }
 
         ICaretPosition ICaretPositionAlgorithm.MoveToFirst()
             => MoveToFirst();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LyricEditorEditModeSection.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         protected override void UpdateEditMode(LyricEditorMode mode)
         {
             // update mode back to lyric editor.
-            state.Mode = mode;
+            state.SwitchMode(mode);
 
             base.UpdateEditMode(mode);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorState.cs
@@ -9,7 +9,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
     {
         IBindable<LyricEditorMode> BindableMode { get; }
 
-        LyricEditorMode Mode { get; set; }
+        LyricEditorMode Mode { get; }
+
+        void SwitchMode(LyricEditorMode mode);
 
         void NavigateToFix(LyricEditorMode mode);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -405,12 +405,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             }
         }
 
-        public LyricEditorMode Mode
-        {
-            get => bindableMode.Value;
-            set => bindableMode.Value = value;
-        }
-
         public virtual void NavigateToFix(LyricEditorMode mode)
         {
             switch (mode)
@@ -418,13 +412,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.Typing:
                 case LyricEditorMode.Language:
                 case LyricEditorMode.AdjustTimeTag:
-                    Mode = mode;
+                    SwitchMode(mode);
                     break;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode));
             }
         }
+
+        public LyricEditorMode Mode
+            => bindableMode.Value;
+
+        public void SwitchMode(LyricEditorMode mode)
+            => bindableMode.Value = mode;
 
         private class LocalScrollingInfo : IScrollingInfo
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             });
             bindableLyricEditorMode.BindValueChanged(e =>
             {
-                lyricEditor.Mode = e.NewValue;
+                lyricEditor.SwitchMode(e.NewValue);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             // refresh caret position
             var lyric = bindableCaretPosition.Value?.Lyric;
             bindableCaretPosition.Value = getCaretPosition(algorithm, lyric);
-            bindableHoverCaretPosition.Value = getCaretPosition(algorithm, lyric);
+            bindableHoverCaretPosition.Value = null;
 
             // should update selection if selected lyric changed.
             updateEditorBeatmapSelectedHitObject(bindableCaretPosition.Value?.Lyric);


### PR DESCRIPTION
Closes issue #1175
For the safety of implementing #1174.

What's changed in the PR:
- Instead of simply using `getter`/`setter`, should be better to use the method to declare what does it actually does in the lyric editor.
- should throw the exception in the caret algorithm if the input type is not matched.
- write the test case for the caret state in the lyric editor.