### PR TITLE
Should have a better way to get event before caret position changed.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -149,15 +149,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToLast(lyrics, caretPosition, algorithms => algorithms.Mode = mode);
         }
 
-        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0)]
-        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0)]
-        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 4)]
-        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, not_exist_tag)]
-        public void TestMoveToTarget(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index)
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, 0)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, 4)]
+        [TestCase(nameof(singleLyricWithoutTimeTag), MovingTimeTagCaretMode.None, 0, NOT_EXIST, not_exist_tag)] // should not hover to the lyric if contains no time-tag in the lyric.
+        [TestCase(nameof(singleLyricWithoutTimeTag), MovingTimeTagCaretMode.OnlyStartTag, 0, NOT_EXIST, not_exist_tag)]
+        [TestCase(nameof(singleLyricWithoutTimeTag), MovingTimeTagCaretMode.OnlyEndTag, 0, NOT_EXIST, not_exist_tag)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, NOT_EXIST, not_exist_tag)] // should not hover to the lyric if contains no text and no time-tag in the lyric
+        public void TestMoveToTarget(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int expectedLyricIndex, int expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[lyricIndex];
-            var caretPosition = createTimeTagCaretPosition(lyrics, lyricIndex, index);
+            var caretPosition = createTimeTagCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check move to target position.
             TestMoveToTarget(lyrics, lyric, caretPosition, algorithms => algorithms.Mode = mode);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
@@ -98,10 +98,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
         {
             // change from edit mode to view mode for checking that caret position should be clear.
             changeMode(LyricEditorMode.Manage);
-            changeMode(LyricEditorMode.RecordTimeTag);
+            changeMode(LyricEditorMode.EditRuby);
 
             // get the action
-            assertCaretPosition(Assert.IsInstanceOf<TimeTagCaretPosition>);
+            assertCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);
             assertHoverCaretPosition(Assert.IsNull);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -94,7 +94,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         public override TimeTagCaretPosition MoveToTarget(Lyric lyric)
         {
             var targetTimeTag = lyric.TimeTags?.FirstOrDefault(timeTagMovable);
-            return new TimeTagCaretPosition(lyric, targetTimeTag);
+
+            // should not move to lyric if contains no time-tag.
+            return targetTimeTag == null ? null : new TimeTagCaretPosition(lyric, targetTimeTag);
         }
 
         private TimeTagCaretPosition timeTagToPosition(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
@@ -22,8 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         protected new ObjectFieldTextBox Component => (ObjectFieldTextBox)base.Component;
 
-        [Resolved]
-        private ILyricCaretState lyricCaretState { get; set; }
+        private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
 
         private readonly T item;
 
@@ -34,13 +34,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             // apply current text from text-tag.
             Component.Text = GetFieldValue(item);
 
+            // should commit the editing text if caret lyric changed.
+            bindableCaretPosition.BindValueChanged(e =>
+            {
+                if (!Component.HasFocus || e.NewValue.Lyric == lyric)
+                    return;
+
+                ApplyValue(item, Component.Text);
+            });
+
             // should change preview text box if selected ruby/romaji changed.
             OnCommit += (sender, _) =>
             {
-                // because selected lyric might changed if user click another lyric before on commit triggered.
-                // so should force to select the lyric back.
-                if (lyricCaretState.BindableCaretPosition.Value.Lyric != lyric)
-                    lyricCaretState.MoveCaretToTargetPosition(lyric);
+                // prevent duplicated submit after lyric position changed.
+                if (bindableCaretPosition.Value.Lyric != lyric)
+                    return;
 
                 ApplyValue(item, sender.Text);
             };
@@ -93,6 +101,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
                 }
             }
         };
+
+        [BackgroundDependencyLoader]
+        private void load(ILyricCaretState lyricCaretState)
+        {
+            bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
+        }
 
         protected class ObjectFieldTextBox : OsuTextBox
         {


### PR DESCRIPTION
Closes issue #1174
.
What's done in this PR:
- fix the recording caret position algorithm.
- refactor the caret state class.
- have a better way to submit the text change before the caret position changed.