### PR TITLE
should cancel the selection after change to the new action.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Description;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
@@ -27,6 +28,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         [Resolved]
         private OsuColour colours { get; set; }
+
+        [Resolved]
+        private ILyricSelectionState lyricSelectionState { get; set; }
 
         private readonly EditModeButton[] buttons;
         private readonly DescriptionTextFlowContainer description;
@@ -70,6 +74,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         protected virtual void UpdateEditMode(T mode)
         {
+            // should cancel the selection after change to the new edit mode.
+            lyricSelectionState?.EndSelecting(LyricEditorSelectingAction.Cancel);
+
             // update button style.
             foreach (var button in buttons)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SpecialActionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SpecialActionSection.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
@@ -14,6 +16,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         protected sealed override string Title => "Action";
 
         private readonly Bindable<TAction> bindableModeSpecialAction = new();
+
+        [Resolved]
+        private ILyricSelectionState lyricSelectionState { get; set; }
 
         protected SpecialActionSection()
         {
@@ -29,6 +34,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
             bindableModeSpecialAction.BindValueChanged(e =>
             {
+                // should cancel the selection after change to the new action.
+                lyricSelectionState?.EndSelecting(LyricEditorSelectingAction.Cancel);
+
                 UpdateActionArea(e.NewValue);
             }, true);
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/158047347-3d85f0d3-c829-4000-91a4-44a5c2cd43dd.png)
Although it might reduce the step of re-click the selecting button.
But will be better to cancel the selection in some cases:
- switch special edit mode.
- switch to another editing mode.