### PR TITLE
Fix apply lyric property broken at some place.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
+        [Resolved]
+        private ILyricCaretState lyricCaretState { get; set; }
+
         private readonly BindableBool selecting = new();
 
         public void StartSelecting()
@@ -52,6 +55,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             // after being applied, should clear the selection.
             beatmap.SelectedHitObjects.Clear();
+
+            // should add selected lyric back.
+            var caretPosition = lyricCaretState.BindableCaretPosition.Value;
+            if (caretPosition?.Lyric != null)
+                beatmap.SelectedHitObjects.Add(caretPosition.Lyric);
         }
 
         public void Select(Lyric lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -41,6 +41,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void EndSelecting(LyricEditorSelectingAction action)
         {
+            if (selecting.Value == false)
+                return;
+
             selecting.Value = false;
 
             if (beatmap == null)


### PR DESCRIPTION
Fix after #1185, change lyric properties will be broken after changed to another editing mode.
.
Should re-add the lyric into selecting hit object after the end of the selection.
Those kinds of errors do not figure out before is because there's not able to change the property in the create mode.