### PR TITLE
Use keyboard to change the start/end index in the ruby/romaji tag.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextTagUtilsTest.cs
@@ -98,6 +98,48 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(expected, actual);
         }
 
+        [TestCase("[0,1]:ka", 0, true)]
+        [TestCase("[0,1]:ka", 1, false)]
+        [TestCase("[0,1]:ka", -1, true)] // should be ok with negative value because we only check if valid with current text-tag index.
+        [TestCase("[2,1]:ka", 0, true)]
+        [TestCase("[2,1]:ka", 1, false)]
+        [TestCase("[2,1]:ka", 2, false)]
+        public void TestValidNewStartIndex(string textTag, int newStartIndex, bool expected)
+        {
+            var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
+
+            bool actual = TextTagUtils.ValidNewStartIndex(rubyTag, newStartIndex);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase("[0,1]:ka", 1, true)]
+        [TestCase("[0,1]:ka", 0, false)]
+        [TestCase("[0,1]:ka", 1000, true)] // should be ok with large value because we only check if valid with current text-tag index.
+        [TestCase("[2,1]:ka", 0, false)]
+        [TestCase("[2,1]:ka", 1, false)]
+        [TestCase("[2,1]:ka", 2, false)]
+        [TestCase("[2,1]:ka", 3, true)]
+        public void TestValidNewEndIndex(string textTag, int newEndIndex, bool expected)
+        {
+            var rubyTag = TestCaseTagHelper.ParseRubyTag(textTag);
+
+            bool actual = TextTagUtils.ValidNewEndIndex(rubyTag, newEndIndex);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase("karaoke", 0, false)]
+        [TestCase("karaoke", 7, false)]
+        [TestCase("karaoke", -1, true)]
+        [TestCase("karaoke", 8, true)]
+        [TestCase("", -1, true)]
+        [TestCase("", 0, true)]
+        [TestCase("", 1, true)]
+        public void TestOutOfRange(string lyric, int index, bool expected)
+        {
+            bool actual = TextTagUtils.OutOfRange(lyric, index);
+            Assert.AreEqual(expected, actual);
+        }
+
         [TestCase("[0,1]:ka", false)]
         [TestCase("[0,1]:", true)]
         public void TestEmptyText(string textTag, bool expected)

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -74,6 +74,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
                 if (endIndex != null)
                     textTag.EndIndex = endIndex.Value;
+
+                // after change the index, should check if index is valid.
+                if (TextTagUtils.OutOfRange(textTag, lyric.Text))
+                    throw new InvalidOperationException($"{nameof(startIndex)} or {nameof(endIndex)} is not valid");
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -25,11 +25,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
 
-        private readonly T item;
+        protected readonly T Item;
 
         protected LabelledObjectFieldTextBox(Lyric lyric, T item)
         {
-            this.item = item;
+            this.Item = item;
 
             // apply current text from text-tag.
             Component.Text = GetFieldValue(item);
@@ -88,16 +88,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
                 if (selected)
                 {
                     // not trigger again if already focus.
-                    if (SelectedItems.Contains(item) && SelectedItems.Count == 1)
+                    if (SelectedItems.Contains(Item) && SelectedItems.Count == 1)
                         return;
 
                     // trigger selected.
                     SelectedItems.Clear();
-                    SelectedItems.Add(item);
+                    SelectedItems.Add(Item);
                 }
                 else
                 {
-                    SelectedItems.Remove(item);
+                    SelectedItems.Remove(Item);
                 }
             }
         };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -2,13 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
@@ -18,6 +25,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
         protected const float DELETE_BUTTON_SIZE = 20f;
 
         public Action OnDeleteButtonClick;
+
+        private readonly IndexShiftingPart indexShiftingPart;
 
         protected LabelledTextTagTextBox(Lyric lyric, T textTag)
             : base(lyric, textTag)
@@ -67,6 +76,80 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
                     }
                 }
             });
+
+            // add the index shifting component at the bottom of the text box.
+            AddInternal(new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding
+                {
+                    Top = CONTENT_PADDING_VERTICAL + 45,
+                    Right = CONTENT_PADDING_HORIZONTAL + DELETE_BUTTON_SIZE + CONTENT_PADDING_HORIZONTAL,
+                },
+                Child = indexShiftingPart = new IndexShiftingPart
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    Width = 120,
+                    Selected = selected =>
+                    {
+                        if (selected)
+                        {
+                            // not trigger again if already focus.
+                            if (SelectedItems.Contains(Item) && SelectedItems.Count == 1)
+                                return;
+
+                            // trigger selected.
+                            SelectedItems.Clear();
+                            SelectedItems.Add(Item);
+                        }
+                        else
+                        {
+                            SelectedItems.Remove(Item);
+                        }
+                    },
+                    Action = (indexType, action) =>
+                    {
+                        int index = getNewIndex(textTag, indexType);
+                        int newIndex = calculateNewIndex(index, action);
+                        if (TextTagUtils.OutOfRange(lyric.Text, newIndex))
+                            return;
+
+                        switch (indexType)
+                        {
+                            case AdjustIndex.Start:
+                                if (TextTagUtils.ValidNewStartIndex(textTag, newIndex))
+                                    SetIndex(textTag, newIndex, null);
+                                break;
+
+                            case AdjustIndex.End:
+                                if (TextTagUtils.ValidNewEndIndex(textTag, newIndex))
+                                    SetIndex(textTag, null, newIndex);
+                                break;
+
+                            default:
+                                throw new InvalidOperationException();
+                        }
+
+                        static int getNewIndex(T textTag, AdjustIndex index) =>
+                            index switch
+                            {
+                                AdjustIndex.Start => textTag.StartIndex,
+                                AdjustIndex.End => textTag.EndIndex,
+                                _ => throw new InvalidOperationException()
+                            };
+
+                        static int calculateNewIndex(int index, AdjustAction action) =>
+                            action switch
+                            {
+                                AdjustAction.Decrease => index - 1,
+                                AdjustAction.Increase => index + 1,
+                                _ => throw new InvalidOperationException()
+                            };
+                    },
+                }
+            });
         }
 
         protected sealed override string GetFieldValue(T item)
@@ -92,6 +175,158 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
                 return;
 
             base.OnFocus(e);
+        }
+
+        public new CompositeDrawable TabbableContentContainer
+        {
+            set
+            {
+                base.TabbableContentContainer = value;
+                indexShiftingPart.TabbableContentContainer = value;
+            }
+        }
+
+        private class IndexShiftingPart : TabbableContainer, IKeyBindingHandler<KaraokeEditAction>
+        {
+            private const int button_size = 20;
+            private const int button_spacing = 5;
+
+            public override bool AcceptsFocus => true;
+
+            public Action<AdjustIndex, AdjustAction> Action;
+
+            private readonly Box background;
+            private readonly IconButton reduceStartIndexButton;
+            private readonly IconButton increaseStartIndexButton;
+            private readonly IconButton reduceEndIndexButton;
+            private readonly IconButton increaseEndIndexButton;
+
+            public Action<bool> Selected;
+
+            public IndexShiftingPart()
+            {
+                AutoSizeAxes = Axes.Y;
+                Masking = true;
+                CornerRadius = 5;
+
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(5),
+                        Children = new[]
+                        {
+                            reduceStartIndexButton = new IconButton
+                            {
+                                Size = new Vector2(button_size),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Icon = FontAwesome.Regular.CaretSquareLeft,
+                                Action = () => Action?.Invoke(AdjustIndex.Start, AdjustAction.Decrease)
+                            },
+                            increaseStartIndexButton = new IconButton
+                            {
+                                Size = new Vector2(button_size),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                X = button_size + button_spacing,
+                                Icon = FontAwesome.Regular.CaretSquareRight,
+                                Action = () => Action?.Invoke(AdjustIndex.Start, AdjustAction.Increase)
+                            },
+                            reduceEndIndexButton = new IconButton
+                            {
+                                Size = new Vector2(button_size),
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                X = -button_size - button_spacing,
+                                Icon = FontAwesome.Regular.CaretSquareLeft,
+                                Action = () => Action?.Invoke(AdjustIndex.End, AdjustAction.Decrease)
+                            },
+                            increaseEndIndexButton = new IconButton
+                            {
+                                Size = new Vector2(button_size),
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Icon = FontAwesome.Regular.CaretSquareRight,
+                                Action = () => Action?.Invoke(AdjustIndex.End, AdjustAction.Increase)
+                            },
+                        }
+                    }
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colour)
+            {
+                background.Colour = colour.Yellow;
+            }
+
+            protected override void OnFocus(FocusEvent e)
+            {
+                background.FadeTo(0.6f, 100);
+                Selected?.Invoke(true);
+                base.OnFocus(e);
+            }
+
+            protected override void OnFocusLost(FocusLostEvent e)
+            {
+                background.FadeOut(100);
+                Selected?.Invoke(false);
+                base.OnFocusLost(e);
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
+            {
+                if (!HasFocus)
+                    return false;
+
+                switch (e.Action)
+                {
+                    case KaraokeEditAction.EditTextTagReduceStartIndex:
+                        reduceStartIndexButton.TriggerClick();
+                        return true;
+
+                    case KaraokeEditAction.EditTextTagIncreaseStartIndex:
+                        increaseStartIndexButton.TriggerClick();
+                        return true;
+
+                    case KaraokeEditAction.EditTextTagReduceEndIndex:
+                        reduceEndIndexButton.TriggerClick();
+                        return true;
+
+                    case KaraokeEditAction.EditTextTagIncreaseEndIndex:
+                        increaseEndIndexButton.TriggerClick();
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)
+            {
+            }
+        }
+
+        private enum AdjustIndex
+        {
+            Start,
+
+            End
+        }
+
+        private enum AdjustAction
+        {
+            Decrease,
+
+            Increase
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -82,6 +82,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
 
         protected abstract void SetText(T item, string value);
 
+        protected abstract void SetIndex(T item, int? startIndex, int? endIndex);
+
         protected override void OnFocus(FocusEvent e)
         {
             // do not trigger origin focus event if this drawable has been removed.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Description;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
@@ -22,7 +23,41 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate romajies in the lyric.")
                 },
                 {
-                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric romajies in here.")
+                    TextTagEditMode.Edit,
+                    new EditModeSelectionItem("Edit", new DescriptionFormat
+                    {
+                        Text = "Create / delete and edit lyric rubies in here.\n"
+                               + "Click [key](directions) to select the target lyric.\n"
+                               + "Press `Tab` to switch between the romaji tags.\n"
+                               + "Than, press [key](adjust_text_tag_index) or button to adjust romaji index after hover to edit index area.",
+                        Keys = new Dictionary<string, InputKey>
+                        {
+                            {
+                                "directions", new InputKey
+                                {
+                                    Text = "Up or down",
+                                    AdjustableActions = new List<KaraokeEditAction>
+                                    {
+                                        KaraokeEditAction.Up,
+                                        KaraokeEditAction.Down
+                                    }
+                                }
+                            },
+                            {
+                                "adjust_text_tag_index", new InputKey
+                                {
+                                    Text = "Keys",
+                                    AdjustableActions = new List<KaraokeEditAction>
+                                    {
+                                        KaraokeEditAction.EditTextTagReduceStartIndex,
+                                        KaraokeEditAction.EditTextTagIncreaseStartIndex,
+                                        KaraokeEditAction.EditTextTagReduceEndIndex,
+                                        KaraokeEditAction.EditTextTagIncreaseEndIndex,
+                                    }
+                                }
+                            }
+                        }
+                    })
                 },
                 {
                     TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid romajies in here.")

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -41,6 +41,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             protected override void SetText(RomajiTag item, string value)
                 => romajiTagsChangeHandler.SetText(item, value);
 
+            protected override void SetIndex(RomajiTag item, int? startIndex, int? endIndex)
+                => romajiTagsChangeHandler.SetIndex(item, startIndex, endIndex);
+
             [BackgroundDependencyLoader]
             private void load(IEditRomajiModeState editRomajiModeState)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Description;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
@@ -22,7 +23,41 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                     TextTagEditMode.Generate, new EditModeSelectionItem("Generate", "Auto-generate rubies in the lyric.")
                 },
                 {
-                    TextTagEditMode.Edit, new EditModeSelectionItem("Edit", "Create / delete and edit lyric rubies in here.")
+                    TextTagEditMode.Edit,
+                    new EditModeSelectionItem("Edit", new DescriptionFormat
+                    {
+                        Text = "Create / delete and edit lyric rubies in here.\n"
+                               + "Click [key](directions) to select the target lyric.\n"
+                               + "Press `Tab` to switch between the ruby tags.\n"
+                               + "Than, press [key](adjust_text_tag_index) or button to adjust ruby index after hover to edit index area.",
+                        Keys = new Dictionary<string, InputKey>
+                        {
+                            {
+                                "directions", new InputKey
+                                {
+                                    Text = "Up or down",
+                                    AdjustableActions = new List<KaraokeEditAction>
+                                    {
+                                        KaraokeEditAction.Up,
+                                        KaraokeEditAction.Down
+                                    }
+                                }
+                            },
+                            {
+                                "adjust_text_tag_index", new InputKey
+                                {
+                                    Text = "Keys",
+                                    AdjustableActions = new List<KaraokeEditAction>
+                                    {
+                                        KaraokeEditAction.EditTextTagReduceStartIndex,
+                                        KaraokeEditAction.EditTextTagIncreaseStartIndex,
+                                        KaraokeEditAction.EditTextTagReduceEndIndex,
+                                        KaraokeEditAction.EditTextTagIncreaseEndIndex,
+                                    }
+                                }
+                            }
+                        }
+                    })
                 },
                 {
                     TextTagEditMode.Verify, new EditModeSelectionItem("Verify", "Check invalid rubies in here.")

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -41,6 +41,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             protected override void SetText(RubyTag item, string value)
                 => rubyTagsChangeHandler.SetText(item, value);
 
+            protected override void SetIndex(RubyTag item, int? startIndex, int? endIndex)
+                => rubyTagsChangeHandler.SetIndex(item, startIndex, endIndex);
+
             [BackgroundDependencyLoader]
             private void load(IEditRubyModeState editRubyModeState)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/TextTagBlueprintContainer.cs
@@ -107,8 +107,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
                 {
                     case Anchor.CentreLeft:
                         int newStartIndex = calculateNewIndex(selectedTextTag, deltaScaleSize, anchor);
-                        if (newStartIndex >= selectedTextTag.EndIndex)
-
+                        if (!TextTagUtils.ValidNewStartIndex(selectedTextTag, newStartIndex))
                             return false;
 
                         SetTextTagIndex(selectedTextTag, newStartIndex, null);
@@ -116,7 +115,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 
                     case Anchor.CentreRight:
                         int newEndIndex = calculateNewIndex(selectedTextTag, deltaScaleSize, anchor);
-                        if (newEndIndex <= selectedTextTag.StartIndex)
+                        if (!TextTagUtils.ValidNewEndIndex(selectedTextTag, newEndIndex))
                             return false;
 
                         SetTextTagIndex(selectedTextTag, null, newEndIndex);

--- a/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
@@ -36,6 +36,19 @@ namespace osu.Game.Rulesets.Karaoke
         [Description("Last")]
         Last,
 
+        // Edit Ruby / romaji tag.
+        [Description("Reduce start index")]
+        EditTextTagReduceStartIndex,
+
+        [Description("Increase start index")]
+        EditTextTagIncreaseStartIndex,
+
+        [Description("Reduce end index")]
+        EditTextTagReduceEndIndex,
+
+        [Description("Increase end index")]
+        EditTextTagIncreaseEndIndex,
+
         // Edit
         [Description("Create new")]
         Create,

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -100,6 +100,12 @@ namespace osu.Game.Rulesets.Karaoke
                     new KeyBinding(InputKey.PageUp, KaraokeEditAction.First),
                     new KeyBinding(InputKey.PageDown, KaraokeEditAction.Last),
 
+                    // Edit Ruby / romaji tag.
+                    new KeyBinding(new[] { InputKey.Control, InputKey.Left }, KaraokeEditAction.EditTextTagReduceStartIndex),
+                    new KeyBinding(new[] { InputKey.Control, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseStartIndex),
+                    new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, KaraokeEditAction.EditTextTagReduceEndIndex),
+                    new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseEndIndex),
+
                     // edit
                     new KeyBinding(InputKey.N, KaraokeEditAction.Create),
                     new KeyBinding(InputKey.Delete, KaraokeEditAction.Remove),

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -101,10 +101,10 @@ namespace osu.Game.Rulesets.Karaoke
                     new KeyBinding(InputKey.PageDown, KaraokeEditAction.Last),
 
                     // Edit Ruby / romaji tag.
-                    new KeyBinding(new[] { InputKey.Control, InputKey.Left }, KaraokeEditAction.EditTextTagReduceStartIndex),
-                    new KeyBinding(new[] { InputKey.Control, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseStartIndex),
-                    new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, KaraokeEditAction.EditTextTagReduceEndIndex),
-                    new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseEndIndex),
+                    new KeyBinding(new[] { InputKey.Z, InputKey.Left }, KaraokeEditAction.EditTextTagReduceStartIndex),
+                    new KeyBinding(new[] { InputKey.Z, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseStartIndex),
+                    new KeyBinding(new[] { InputKey.X, InputKey.Left }, KaraokeEditAction.EditTextTagReduceEndIndex),
+                    new KeyBinding(new[] { InputKey.X, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseEndIndex),
 
                     // edit
                     new KeyBinding(InputKey.N, KaraokeEditAction.Create),

--- a/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextTagUtils.cs
@@ -21,18 +21,34 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         public static bool OutOfRange<T>(T textTag, string lyric) where T : ITextTag
         {
+            return OutOfRange(lyric, textTag.StartIndex) || OutOfRange(lyric, textTag.EndIndex);
+        }
+
+        public static bool ValidNewStartIndex<T>(T textTag, int newStartIndex) where T : ITextTag
+        {
+            if (textTag == null)
+                throw new ArgumentNullException(nameof(textTag));
+
+            return newStartIndex < textTag.EndIndex;
+        }
+
+        public static bool ValidNewEndIndex<T>(T textTag, int newEndIndex) where T : ITextTag
+        {
+            if (textTag == null)
+                throw new ArgumentNullException(nameof(textTag));
+
+            return newEndIndex > textTag.StartIndex;
+        }
+
+        public static bool OutOfRange(string lyric, int index)
+        {
             if (string.IsNullOrEmpty(lyric))
                 return true;
 
-            return outOfRange(lyric, textTag.StartIndex) || outOfRange(lyric, textTag.EndIndex);
+            const int min_index = 0;
+            int maxIndex = lyric.Length;
 
-            static bool outOfRange(string lyric, int index)
-            {
-                const int min_index = 0;
-                int maxIndex = lyric.Length;
-
-                return index < min_index || index > maxIndex;
-            }
+            return index < min_index || index > maxIndex;
         }
 
         public static bool EmptyText<T>(T textTag) where T : ITextTag


### PR DESCRIPTION
Closes issue #1172
.
![image](https://user-images.githubusercontent.com/9100368/158390156-cf4c823f-02d5-4f42-bdf5-d17c49a4998f.png)
What's done in this PR:
- add some utils for checking the ruby/romaji tag index.
- add more keys for edit the tag start/end index.
- should make sure that the tag is valid in the change handler.
- Implemented text-tag edit area on the button of the edit text area.