### PR TITLE
Use EditorRoundedScreen in the singer and translate screen

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/KaraokeEditorScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/KaraokeEditorScreenTestScene.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit;
@@ -19,6 +20,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         [Cached(typeof(EditorBeatmap))]
         [Cached(typeof(IBeatSnapProvider))]
         private readonly EditorBeatmap editorBeatmap;
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Blue);
 
         protected KaraokeEditorScreenTestScene()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
     public class KaraokeEditor : GenericEditor<KaraokeEditorScreenMode>
     {
         [Cached]
-        private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Green);
+        private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Blue);
 
         [Cached]
         private readonly KaraokeRulesetEditConfigManager editConfigManager;

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorRoundedScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorRoundedScreen.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit
+{
+    /// <summary>
+    /// Copied from <see cref="EditorRoundedScreen"/>
+    /// </summary>
+    public class KaraokeEditorRoundedScreen : KaraokeEditorScreen
+    {
+        public const int HORIZONTAL_PADDING = 100;
+
+        private Container roundedContent;
+
+        protected override Container<Drawable> Content => roundedContent;
+
+        public KaraokeEditorRoundedScreen(KaraokeEditorScreenMode type)
+            : base(type)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            base.Content.Add(new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding(50),
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 10,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = colourProvider.Background3,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        roundedContent = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                    }
+                }
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerScreen.cs
@@ -5,8 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
@@ -20,11 +18,8 @@ using osu.Game.Screens.Edit;
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {
     [Cached(typeof(ISingerScreenScrollingInfoProvider))]
-    public class SingerScreen : KaraokeEditorScreen, ISingerScreenScrollingInfoProvider
+    public class SingerScreen : KaraokeEditorRoundedScreen, ISingerScreenScrollingInfoProvider
     {
-        [Cached]
-        protected readonly OverlayColourProvider ColourProvider;
-
         [Cached(typeof(ISingersChangeHandler))]
         private readonly SingersChangeHandler singersChangeHandler;
 
@@ -44,17 +39,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
         public SingerScreen()
             : base(KaraokeEditorScreenMode.Singer)
         {
-            ColourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+            editSingerDialog = new EditSingerDialog();
             AddInternal(singersChangeHandler = new SingersChangeHandler());
             AddInternal(lyricSingerChangeHandler = new LyricSingerChangeHandler());
-            Add(editSingerDialog = new EditSingerDialog
-            {
-                Depth = -1,
-            });
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, EditorBeatmap editorBeatmap, EditorClock editorClock)
+        private void load(EditorBeatmap editorBeatmap, EditorClock editorClock)
         {
             BindablesUtils.Sync(selectedLyrics, editorBeatmap.SelectedHitObjects);
 
@@ -63,37 +54,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
             BindableZoom.MinValue = ZoomableScrollContainerUtils.GetZoomLevelForVisibleMilliseconds(editorClock, 80000);
             BindableZoom.Value = BindableZoom.Default = ZoomableScrollContainerUtils.GetZoomLevelForVisibleMilliseconds(editorClock, 40000);
 
-            AddInternal(new Container
+            Add(new FixedSectionsContainer<Drawable>
             {
+                FixedHeader = new SingerScreenHeader(),
                 RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(50),
-                Child = new Container
+                Children = new[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 10,
-                    Children = new Drawable[]
+                    new SingerEditSection
                     {
-                        new Box
-                        {
-                            Colour = colours.GreySeaFoamDark,
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new FixedSectionsContainer<Drawable>
-                        {
-                            FixedHeader = new SingerScreenHeader(),
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new[]
-                            {
-                                new SingerEditSection
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                },
-                            }
-                        },
-                    }
+                        RelativeSizeAxes = Axes.Both,
+                    },
                 }
             });
+
+            Add(editSingerDialog);
         }
 
         protected override void PopOut()
@@ -108,6 +82,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
         {
             private readonly Container<T> content;
 
+            // todo: check what this shit doing.
             protected override Container<T> Content => content;
 
             public FixedSectionsContainer()

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages;
@@ -21,13 +19,10 @@ using osu.Game.Screens.Edit;
 namespace osu.Game.Rulesets.Karaoke.Edit.Translate
 {
     [Cached(typeof(ITranslateInfoProvider))]
-    public class TranslateScreen : KaraokeEditorScreen, ITranslateInfoProvider
+    public class TranslateScreen : KaraokeEditorRoundedScreen, ITranslateInfoProvider
     {
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
-
-        [Cached]
-        protected readonly OverlayColourProvider ColourProvider;
 
         [Cached(typeof(ILanguagesChangeHandler))]
         private readonly LanguagesChangeHandler languagesChangeHandler;
@@ -38,44 +33,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
         public TranslateScreen()
             : base(KaraokeEditorScreenMode.Translate)
         {
-            ColourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
             AddInternal(languagesChangeHandler = new LanguagesChangeHandler());
             AddInternal(lyricTranslateChangeHandler = new LyricTranslateChangeHandler());
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, DialogOverlay dialogOverlay, LanguageSelectionDialog languageSelectionDialog)
+        private void load(DialogOverlay dialogOverlay, LanguageSelectionDialog languageSelectionDialog)
         {
-            Add(new Container
+            Add(new SectionsContainer<Container>
             {
+                FixedHeader = new TranslateScreenHeader(),
                 RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(50),
-                Child = new Container
+                Children = new Container[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 10,
-                    Children = new Drawable[]
+                    new TranslateEditSection
                     {
-                        new Box
-                        {
-                            Colour = colours.GreySeaFoamDark,
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new SectionsContainer<Container>
-                        {
-                            FixedHeader = new TranslateScreenHeader(),
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new Container[]
-                            {
-                                new TranslateEditSection
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                },
-                            }
-                        },
-                    }
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                    },
                 }
             });
 


### PR DESCRIPTION
Closes issue #1162
.
What's done in this PR:
- implement `KaraokeEditorRoundedScreen` as the base class of sub-editor with rounded background and big padding.
- apply `KaraokeEditorRoundedScreen` in both `SingerEditor` and `TranslateEditor`.
- adjust the color.