### PR TITLE
Remove duplicated selected items binding in the singer editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditorBlueprintContainer.cs
@@ -35,10 +35,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap, BindableList<Lyric> selectedLyrics)
+        private void load(EditorBeatmap beatmap)
         {
-            SelectedItems.BindTo(selectedLyrics);
-
             var lyrics = beatmap.HitObjects.OfType<Lyric>().ToList();
             foreach (var lyric in lyrics)
                 AddBlueprintFor(lyric);


### PR DESCRIPTION
Fix remain issue in the #1176, following the way by #1187 to fix that shit.