### PR TITLE
Adjust toast text in the gameplay.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -113,7 +113,14 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
         public override TrackedSettings CreateTrackedSettings() => new()
         {
-            new TrackedSetting<double>(KaraokeRulesetSetting.ScrollTime, v => new SettingDescription(v, "Scroll Time", $"{v}ms"))
+            new TrackedSetting<double>(KaraokeRulesetSetting.ScrollTime, v => new SettingDescription(v, "Scroll Time", $"{v}ms")),
+            new TrackedSetting<bool>(KaraokeRulesetSetting.DisplayNoteRubyText, b => new SettingDescription(b, "Toggle display", b ? "Show" : "Hide")),
+            new TrackedSetting<bool>(KaraokeRulesetSetting.ShowCursor, b => new SettingDescription(b, "Cursor display", b ? "Show" : "Hide")),
+            new TrackedSetting<bool>(KaraokeRulesetSetting.UseTranslate, b => new SettingDescription(b, "Display translate", b ? "Show" : "Hide")),
+            new TrackedSetting<CultureInfo>(KaraokeRulesetSetting.PreferLanguage, c => new SettingDescription(c, "Translate language", c.DisplayName)),
+            new TrackedSetting<bool>(KaraokeRulesetSetting.DisplayRuby, b => new SettingDescription(b, "Display ruby", b ? "Show" : "Hide")),
+            new TrackedSetting<bool>(KaraokeRulesetSetting.DisplayRomaji, b => new SettingDescription(b, "Display romaji", b ? "Show" : "Hide")),
+            new TrackedSetting<string>(KaraokeRulesetSetting.MicrophoneDevice, d => new SettingDescription(d, "Change to the new microphone device", d)),
         };
     }
 

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetConfigManager.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             // Visual
             SetDefault(KaraokeRulesetSetting.ScrollTime, 5000.0, 1000.0, 10000.0, 100.0);
             SetDefault(KaraokeRulesetSetting.ScrollDirection, KaraokeScrollingDirection.Left);
-            SetDefault(KaraokeRulesetSetting.DisplayRubyText, false);
+            SetDefault(KaraokeRulesetSetting.DisplayNoteRubyText, false);
             SetDefault(KaraokeRulesetSetting.ShowCursor, false);
             SetDefault(KaraokeRulesetSetting.NoteAlpha, 1, 0.2, 1, 0.01);
             SetDefault(KaraokeRulesetSetting.LyricAlpha, 1, 0.2, 1, 0.01);
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         // Visual
         ScrollTime,
         ScrollDirection,
-        DisplayRubyText,
+        DisplayNoteRubyText,
         ShowCursor,
         NoteAlpha,
         LyricAlpha,

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// <summary>
         /// Ruby text.
         /// Should placing something like ruby, 拼音 or ふりがな.
-        /// Will be display only if <see cref="KaraokeRulesetSetting.DisplayRubyText"/> is true.
+        /// Will be display only if <see cref="KaraokeRulesetSetting.DisplayNoteRubyText"/> is true.
         /// </summary>
         /// <example>
         /// はな

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/NoteSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/NoteSettings.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Sections.Gameplay
                 new SettingsCheckbox
                 {
                     LabelText = "Display ruby text",
-                    Current = Config.GetBindable<bool>(KaraokeRulesetSetting.DisplayRubyText)
+                    Current = Config.GetBindable<bool>(KaraokeRulesetSetting.DisplayNoteRubyText)
                 },
             };
         }


### PR DESCRIPTION
Trying to start to implement #1200
.
What's done in this PR:
- fix the config naming.
- add more toasts.

Also, notice that some of the configs are in the `KaraokeSessionStatics`, which will cause not trigger the event.
Need to make the investment that needs to use this class or not(some of the configs are over-designed)?