### PR TITLE
Should update toolbar mode selection after switch the mode by extend area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneEditorMenuBar.cs
@@ -3,12 +3,14 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Menus;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Tests.Visual;
 
@@ -45,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                                 new EditorMenuItem("Export to json", MenuItemType.Destructive, () => { }),
                             }
                         },
-                        new LyricEditorModeMenu(lyricEditorConfig, "Mode"),
+                        new LyricEditorModeMenu(new Bindable<LyricEditorMode>(), "Mode"),
                         new MenuItem("View")
                         {
                             Items = new MenuItem[]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
@@ -16,6 +17,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
 {
     public class TestSceneLyricEditorScreen : KaraokeEditorScreenTestScene<LyricEditorScreen>
     {
+        [Cached]
+        private readonly Bindable<LyricEditorMode> bindableLyricEditorMode = new();
+
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         protected override LyricEditorScreen CreateEditorScreen() => new();
@@ -56,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         {
             AddStep($"switch to mode {Enum.GetName(typeof(LyricEditorMode), mode)}", () =>
             {
-                lyricEditorConfigManager.SetValue(KaraokeRulesetLyricEditorSetting.LyricEditorMode, mode);
+                bindableLyricEditorMode.Value = mode;
             });
             AddWaitStep("wait for switch to new mode", 5);
         }

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // General
             SetDefault(KaraokeRulesetLyricEditorSetting.LyricEditorFontSize, 28f);
-            SetDefault(KaraokeRulesetLyricEditorSetting.LyricEditorMode, LyricEditorMode.View);
             SetDefault(KaraokeRulesetLyricEditorSetting.AutoFocusToEditLyric, true);
             SetDefault(KaraokeRulesetLyricEditorSetting.AutoFocusToEditLyricSkipRows, 1, 0, 4);
             SetDefault(KaraokeRulesetLyricEditorSetting.ClickToLockLyricState, LockState.Partial);
@@ -50,7 +49,6 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
     {
         // General
         LyricEditorFontSize,
-        LyricEditorMode,
         AutoFocusToEditLyric,
         AutoFocusToEditLyricSkipRows,
         ClickToLockLyricState,

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/EnumMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/EnumMenu.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Configuration;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
@@ -12,18 +11,16 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menus
 {
-    public abstract class EnumMenu<TSetting, T> : MenuItem where TSetting : struct, Enum
+    public abstract class EnumMenu<T> : MenuItem where T : struct, Enum
     {
         private readonly Bindable<T> bindableEnum = new();
 
-        protected abstract TSetting Setting { get; }
-
-        protected EnumMenu(ConfigManager<TSetting> config, string text)
+        protected EnumMenu(Bindable<T> bindable, string text)
             : base(text)
         {
             Items = createMenuItems();
 
-            config.BindWith(Setting, bindableEnum);
+            bindableEnum.BindTo(bindable);
             bindableEnum.BindValueChanged(e =>
             {
                 var newSelection = e.NewValue;

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/LockStateMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/LockStateMenu.cs
@@ -11,12 +11,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menus
     /// <summary>
     /// If click the lock icon in <see cref="LyricEditor"/>, will apply <see cref="LockState.Partial"/> or <see cref="LockState.Full"/>
     /// </summary>
-    public class LockStateMenu : EnumMenu<KaraokeRulesetLyricEditorSetting, LockState>
+    public class LockStateMenu : EnumMenu<LockState>
     {
-        protected override KaraokeRulesetLyricEditorSetting Setting => KaraokeRulesetLyricEditorSetting.ClickToLockLyricState;
-
         public LockStateMenu(KaraokeRulesetLyricEditorConfigManager config, string text)
-            : base(config, text)
+            : base(config.GetBindable<LockState>(KaraokeRulesetLyricEditorSetting.ClickToLockLyricState), text)
         {
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/LyricEditorModeMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Menus/LyricEditorModeMenu.cs
@@ -2,16 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Menus
 {
-    public class LyricEditorModeMenu : EnumMenu<KaraokeRulesetLyricEditorSetting, LyricEditorMode>
+    public class LyricEditorModeMenu : EnumMenu<LyricEditorMode>
     {
-        protected override KaraokeRulesetLyricEditorSetting Setting => KaraokeRulesetLyricEditorSetting.LyricEditorMode;
-
-        public LyricEditorModeMenu(KaraokeRulesetLyricEditorConfigManager config, string text)
+        public LyricEditorModeMenu(Bindable<LyricEditorMode> config, string text)
             : base(config, text)
         {
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
                             new EditorMenuItem("Export to json beatmap", MenuItemType.Destructive, () => exportLyricManager.ExportToJsonBeatmap()),
                         }
                     },
-                    new LyricEditorModeMenu(lyricEditorConfigManager, "Mode"),
+                    new LyricEditorModeMenu(bindableLyricEditorMode, "Mode"),
                     new("View")
                     {
                         Items = new MenuItem[]

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
@@ -52,6 +53,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 
         [Cached(typeof(IBeatmapChangeHandler))]
         private readonly BeatmapChangeHandler beatmapChangeHandler;
+
+        [Cached]
+        private readonly Bindable<LyricEditorMode> bindableLyricEditorMode = new();
 
         public KaraokeEditor()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
@@ -16,8 +15,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public class LyricEditorScreen : KaraokeEditorScreen
     {
-        private readonly Bindable<LyricEditorMode> bindableLyricEditorMode = new();
-
         [Cached(typeof(ILyricsChangeHandler))]
         private readonly LyricsChangeHandler lyricsChangeHandler;
 
@@ -77,16 +74,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     RelativeSizeAxes = Axes.Both,
                 }
             });
-            bindableLyricEditorMode.BindValueChanged(e =>
-            {
-                lyricEditor.SwitchMode(e.NewValue);
-            });
         }
 
         [BackgroundDependencyLoader]
-        private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
+        private void load(Bindable<LyricEditorMode> lyricEditorMode)
         {
-            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.LyricEditorMode, bindableLyricEditorMode);
+            lyricEditor.BindableMode.BindTo(lyricEditorMode);
         }
 
         protected override void PopIn()


### PR DESCRIPTION
Closes issue #1135

What's done in this PR:
- remove `KaraokeRulesetLyricEditorSetting.LyricEditorMode` in the karaoke editor config.
- inject bindable<LyricEditorMode> in the karaoke editor main screen.
- refactor the `EnumMenu`, prevent the `XXXConfig` logic in this class.