### PR TITLE
Implement switch create time tag caret algorithm in the edit time-tag mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Configuration
@@ -21,6 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetLyricEditorSetting.ClickToLockLyricState, LockState.Partial);
 
             // Create time-tag.
+            SetDefault(KaraokeRulesetLyricEditorSetting.CreateTimeTagEditMode, CreateTimeTagEditMode.Create);
             SetDefault(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode, MovingTimeTagCaretMode.None);
 
             // Recording
@@ -54,6 +56,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         ClickToLockLyricState,
 
         // Create time-tag.
+        CreateTimeTagEditMode,
         CreateTimeTagMovingCaretMode,
 
         // Recording

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSection.cs
@@ -2,22 +2,28 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
     public class TimeTagCreateConfigSection : Section
     {
-        protected override string Title => "Config";
+        protected override string Title => "Config Tool";
 
         [BackgroundDependencyLoader]
         private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
-            Children = new[]
+            Children = new Drawable[]
             {
+                new TimeTagCreateConfigSubsection
+                {
+                    Current = lyricEditorConfigManager.GetBindable<CreateTimeTagEditMode>(KaraokeRulesetLyricEditorSetting.CreateTimeTagEditMode)
+                },
                 new LabelledEnumDropdown<MovingTimeTagCaretMode>
                 {
                     Label = "Create tag mode",

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSubsection.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Description;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+{
+    public class TimeTagCreateConfigSubsection : FillFlowContainer, IHasCurrentValue<CreateTimeTagEditMode>
+    {
+        private const int button_vertical_margin = 20;
+        private const int horizontal_padding = 20;
+        private const int corner_radius = 15;
+
+        private readonly EditModeButton[] buttons;
+        private readonly DescriptionTextFlowContainer description;
+
+        private readonly BindableWithCurrent<CreateTimeTagEditMode> current = new();
+
+        public Bindable<CreateTimeTagEditMode> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private readonly Box background;
+
+        public TimeTagCreateConfigSubsection()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Spacing = new Vector2(10);
+
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Masking = true,
+                    CornerRadius = corner_radius,
+                    Children = new Drawable[]
+                    {
+                        background = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            RowDimensions = new[]
+                            {
+                                new Dimension(GridSizeMode.AutoSize)
+                            },
+                            Content = new[]
+                            {
+                                buttons = EnumUtils.GetValues<CreateTimeTagEditMode>().Select(x => new EditModeButton(x)
+                                {
+                                    Text = getButtonTitle(x),
+                                    Margin = new MarginPadding { Vertical = button_vertical_margin },
+                                    Padding = new MarginPadding { Horizontal = horizontal_padding },
+                                    Action = () => current.Value = x,
+                                }).ToArray(),
+                            }
+                        }
+                    }
+                },
+                description = new DescriptionTextFlowContainer
+                {
+                    Padding = new MarginPadding { Horizontal = horizontal_padding },
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                }
+            };
+
+            current.BindValueChanged(e =>
+            {
+                Schedule(() =>
+                {
+                    updateEditMode(e.NewValue);
+                });
+            }, true);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LyricEditorColourProvider colourProvider, ILyricEditorState state)
+        {
+            background.Colour = colourProvider.Background4(state.Mode);
+        }
+
+        private void updateEditMode(CreateTimeTagEditMode mode)
+        {
+            // update button style.
+            foreach (var button in buttons)
+            {
+                bool highLight = EqualityComparer<CreateTimeTagEditMode>.Default.Equals(button.Mode, mode);
+                button.Alpha = highLight ? 0.8f : 0.4f;
+                button.BackgroundColour = getButtonColour(button.Mode, highLight);
+            }
+
+            // update description text.
+            description.Description = getDescription(mode);
+        }
+
+        private LocalisableString getButtonTitle(CreateTimeTagEditMode mode)
+            => mode switch
+            {
+                CreateTimeTagEditMode.Create => "Create",
+                CreateTimeTagEditMode.Modify => "Modify",
+                _ => throw new InvalidOperationException(nameof(mode))
+            };
+
+        private Color4 getButtonColour(CreateTimeTagEditMode mode, bool active)
+            => mode switch
+            {
+                CreateTimeTagEditMode.Create => active ? colours.Green : colours.GreenDarker,
+                CreateTimeTagEditMode.Modify => active ? colours.Pink : colours.PinkDarker,
+                _ => throw new InvalidOperationException(nameof(mode))
+            };
+
+        private DescriptionFormat getDescription(CreateTimeTagEditMode mode) =>
+            mode switch
+            {
+                CreateTimeTagEditMode.Create => new DescriptionFormat
+                {
+                    Text = "Use keyboard to control caret position, press [key](create_time_tag) to create new time-tag and press [key](remove_time_tag) to delete exist time-tag.",
+                    Keys = new Dictionary<string, InputKey>
+                    {
+                        { "create_time_tag", new InputKey { AdjustableActions = new List<KaraokeEditAction> { KaraokeEditAction.Create } } },
+                        { "remove_time_tag", new InputKey { AdjustableActions = new List<KaraokeEditAction> { KaraokeEditAction.Remove } } }
+                    }
+                },
+                CreateTimeTagEditMode.Modify => new DescriptionFormat
+                {
+                    Text = "Press [key](move_time_tag_position) to move the time-tag position. Press [key](remove_time_tag) to delete exist time-tag.",
+                    Keys = new Dictionary<string, InputKey>
+                    {
+                        {
+                            "move_time_tag_position", new InputKey
+                            {
+                                Text = "Shifting Time-tag index keys.",
+                                AdjustableActions = new List<KaraokeEditAction>
+                                {
+                                    KaraokeEditAction.ShiftTheTimeTagLeft,
+                                    KaraokeEditAction.ShiftTheTimeTagRight,
+                                    KaraokeEditAction.ShiftTheTimeTagStateLeft,
+                                    KaraokeEditAction.ShiftTheTimeTagStateRight,
+                                }
+                            }
+                        },
+                        { "remove_time_tag", new InputKey { AdjustableActions = new List<KaraokeEditAction> { KaraokeEditAction.Remove } } }
+                    }
+                },
+                _ => throw new InvalidOperationException(nameof(mode))
+            };
+
+        private class EditModeButton : OsuButton
+        {
+            public CreateTimeTagEditMode Mode { get; }
+
+            public EditModeButton(CreateTimeTagEditMode mode)
+            {
+                Mode = mode;
+                RelativeSizeAxes = Axes.X;
+                Content.CornerRadius = 15;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
@@ -20,26 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
             => new()
             {
                 {
-                    LyricEditorMode.CreateTimeTag,
-                    new EditModeSelectionItem("Create", new DescriptionFormat
-                    {
-                        Text = "Use keyboard to control caret position, press [key](create_time_tag) to create new time-tag and press [key](remove_time_tag) to delete exist time-tag.",
-                        Keys = new Dictionary<string, InputKey>
-                        {
-                            {
-                                "create_time_tag", new InputKey
-                                {
-                                    AdjustableActions = new List<KaraokeEditAction> { KaraokeEditAction.Create }
-                                }
-                            },
-                            {
-                                "remove_time_tag", new InputKey
-                                {
-                                    AdjustableActions = new List<KaraokeEditAction> { KaraokeEditAction.Remove }
-                                }
-                            }
-                        }
-                    })
+                    LyricEditorMode.CreateTimeTag, new EditModeSelectionItem("Adjust", "Create the time-tag or adjust the position.")
                 },
                 {
                     LyricEditorMode.RecordTimeTag, new EditModeSelectionItem("Recording", new DescriptionFormat

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableCaret.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -35,7 +36,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
                 }
 
                 Show();
-                Apply(position as TCaret);
+
+                if (position is not TCaret tCaret)
+                    throw new InvalidCastException();
+
+                Apply(tCaret);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/CreateTimeTagEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/CreateTimeTagEditMode.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
+{
+    public enum CreateTimeTagEditMode
+    {
+        Create,
+
+        Modify,
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
@@ -12,6 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         IBindable<ICaretPosition> BindableHoverCaretPosition { get; }
 
         IBindable<ICaretPosition> BindableCaretPosition { get; }
+
+        IBindable<ICaretPositionAlgorithm> BindableCaretPositionAlgorithm { get; }
 
         bool MoveCaret(MovingCaretAction action);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -21,10 +21,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         public IBindable<ICaretPosition> BindableHoverCaretPosition => bindableHoverCaretPosition;
         public IBindable<ICaretPosition> BindableCaretPosition => bindableCaretPosition;
 
+        public IBindable<ICaretPositionAlgorithm> BindableCaretPositionAlgorithm => bindableCaretPositionAlgorithm;
+
         private readonly Bindable<ICaretPosition> bindableHoverCaretPosition = new();
         private readonly Bindable<ICaretPosition> bindableCaretPosition = new();
+        private readonly Bindable<ICaretPositionAlgorithm> bindableCaretPositionAlgorithm = new();
 
-        private ICaretPositionAlgorithm algorithm;
+        private ICaretPositionAlgorithm algorithm => bindableCaretPositionAlgorithm.Value;
 
         private readonly BindableList<HitObject> selectedHitObjects = new();
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
@@ -90,7 +93,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             var mode = bindableMode.Value;
 
             // refresh algorithm
-            algorithm = getAlgorithmByMode(bindableLyrics.ToArray(), mode);
+            bindableCaretPositionAlgorithm.Value = getAlgorithmByMode(bindableLyrics.ToArray(), mode);
 
             // refresh caret position
             var lyric = bindableCaretPosition.Value?.Lyric;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             selectedHitObjects.BindTo(beatmap.SelectedHitObjects);
             bindableMode.BindTo(state.BindableMode);
 
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagEditMode, bindableCreateTimeTagEditMode);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode, bindableCreateMovingCaretMode);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingTimeTagMovingCaretMode, bindableRecordingMovingCaretMode);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.RecordingChangeTimeWhileMovingTheCaret, bindableRecordingChangeTimeWhileMovingTheCaret);

--- a/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
@@ -49,12 +49,24 @@ namespace osu.Game.Rulesets.Karaoke
         [Description("Increase end index")]
         EditTextTagIncreaseEndIndex,
 
-        // Edit
+        // Edit time-tag.
         [Description("Create new")]
         Create,
 
         [Description("Remove")]
         Remove,
+
+        [Description("Shift the time-tag left.")]
+        ShiftTheTimeTagLeft,
+
+        [Description("Shift the time-tag right.")]
+        ShiftTheTimeTagRight,
+
+        [Description("Shift the time-tag left.")]
+        ShiftTheTimeTagStateLeft,
+
+        [Description("Shift the time-tag right.")]
+        ShiftTheTimeTagStateRight,
 
         [Description("Set time")]
         SetTime,

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -106,9 +106,13 @@ namespace osu.Game.Rulesets.Karaoke
                     new KeyBinding(new[] { InputKey.X, InputKey.Left }, KaraokeEditAction.EditTextTagReduceEndIndex),
                     new KeyBinding(new[] { InputKey.X, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseEndIndex),
 
-                    // edit
+                    // edit time-tag.
                     new KeyBinding(InputKey.N, KaraokeEditAction.Create),
                     new KeyBinding(InputKey.Delete, KaraokeEditAction.Remove),
+                    new KeyBinding(new[] { InputKey.Z, InputKey.Left }, KaraokeEditAction.ShiftTheTimeTagLeft),
+                    new KeyBinding(new[] { InputKey.Z, InputKey.Right }, KaraokeEditAction.ShiftTheTimeTagRight),
+                    new KeyBinding(new[] { InputKey.X, InputKey.Left }, KaraokeEditAction.ShiftTheTimeTagStateLeft),
+                    new KeyBinding(new[] { InputKey.X, InputKey.Right }, KaraokeEditAction.ShiftTheTimeTagStateRight),
                     new KeyBinding(InputKey.Enter, KaraokeEditAction.SetTime),
                     new KeyBinding(InputKey.BackSpace, KaraokeEditAction.ClearTime),
                 },


### PR DESCRIPTION
This is part of the implementation of #1213 (see: https://github.com/karaoke-dev/karaoke/discussions/1213#discussioncomment-2395884).
Notice that it will use multiple caret algorithms(`TimeTagIndexCaretPositionAlgorithm` and `TimeTagCaretPositionAlgorithm`) in the create time-tag mode, so some of the architecture will be changed.

What's done in this PR:
- create the adjusted action keys(those keys do not implement their feature in this PR).
- add the config to record using which algorithm in the create time-tag mode.
- switch the algorithm in the caret state.
- implement the component to switch that state.
- use algorithm instead of the edit mode in the caret layer for creating the caret and deciding the return class after clicked.