### PR TITLE
Move some mode specific action into the section

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/CreateTimeTagActionReceiver.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/CreateTimeTagActionReceiver.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+{
+    public class CreateTimeTagActionReceiver : Component, IKeyBindingHandler<KaraokeEditAction>
+    {
+        [Resolved]
+        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
+
+        [Resolved]
+        private ILyricCaretState lyricCaretState { get; set; }
+
+        public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
+        {
+            if (lyricCaretState.BindableCaretPosition.Value is not TimeTagIndexCaretPosition position)
+                throw new NotSupportedException(nameof(position));
+
+            var index = position.Index;
+
+            switch (e.Action)
+            {
+                case KaraokeEditAction.Create:
+                    lyricTimeTagsChangeHandler.AddByPosition(index);
+                    return true;
+
+                case KaraokeEditAction.Remove:
+                    lyricTimeTagsChangeHandler.RemoveByPosition(index);
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/RecordTimeTagActionReceiver.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/RecordTimeTagActionReceiver.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+{
+    public class RecordTimeTagActionReceiver : Component, IKeyBindingHandler<KaraokeEditAction>
+    {
+        [Resolved]
+        private KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager { get; set; }
+
+        [Resolved]
+        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
+
+        [Resolved]
+        private ILyricCaretState lyricCaretState { get; set; }
+
+        [Resolved]
+        private EditorClock editorClock { get; set; }
+
+        public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
+        {
+            var caretPosition = lyricCaretState.BindableCaretPosition.Value;
+            if (caretPosition is not TimeTagCaretPosition timeTagCaretPosition)
+                throw new NotSupportedException(nameof(caretPosition));
+
+            var currentTimeTag = timeTagCaretPosition.TimeTag;
+
+            switch (e.Action)
+            {
+                case KaraokeEditAction.ClearTime:
+                    lyricTimeTagsChangeHandler.ClearTimeTagTime(currentTimeTag);
+                    return true;
+
+                case KaraokeEditAction.SetTime:
+                    double currentTime = editorClock.CurrentTime;
+                    lyricTimeTagsChangeHandler.SetTimeTagTime(currentTimeTag, currentTime);
+
+                    if (lyricEditorConfigManager.Get<bool>(KaraokeRulesetLyricEditorSetting.RecordingAutoMoveToNextTimeTag))
+                        lyricCaretState.MoveCaret(MovingCaretAction.Right);
+
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                             new TimeTagEditModeSection(),
                             new TimeTagAutoGenerateSection(),
                             new TimeTagCreateConfigSection(),
+                            new CreateTimeTagActionReceiver()
                         };
                         break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
                         {
                             new TimeTagEditModeSection(),
                             new TimeTagRecordingConfigSection(),
+                            new RecordTimeTagActionReceiver()
                         };
                         break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -334,7 +334,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return false;
 
                 case LyricEditorMode.CreateTimeTag:
-                    return HandleCreateOrDeleterTimeTagEvent(action);
+                    return false;
 
                 case LyricEditorMode.RecordTimeTag:
                     return HandleSetTimeEvent(action);
@@ -391,31 +391,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     if (lyricEditorConfigManager.Get<bool>(KaraokeRulesetLyricEditorSetting.RecordingAutoMoveToNextTimeTag))
                         lyricCaretState.MoveCaret(MovingCaretAction.Right);
 
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
-        protected bool HandleCreateOrDeleterTimeTagEvent(KaraokeEditAction action)
-        {
-            if (lyricTimeTagsChangeHandler == null)
-                return false;
-
-            if (lyricCaretState.BindableCaretPosition.Value is not TimeTagIndexCaretPosition position)
-                throw new NotSupportedException(nameof(position));
-
-            var index = position.Index;
-
-            switch (action)
-            {
-                case KaraokeEditAction.Create:
-                    lyricTimeTagsChangeHandler.AddByPosition(index);
-                    return true;
-
-                case KaraokeEditAction.Remove:
-                    lyricTimeTagsChangeHandler.RemoveByPosition(index);
                     return true;
 
                 default:

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -13,7 +13,6 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Manage;
@@ -38,15 +37,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
     {
         [Resolved(canBeNull: true)]
         private ILyricsChangeHandler lyricsChangeHandler { get; set; }
-
-        [Resolved(canBeNull: true)]
-        private ILyricTextChangeHandler lyricTextChangeHandler { get; set; }
-
-        [Resolved(canBeNull: true)]
-        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
-
-        [Resolved]
-        private EditorClock editorClock { get; set; }
 
         [Resolved]
         private KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager { get; set; }
@@ -337,7 +327,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                     return false;
 
                 case LyricEditorMode.RecordTimeTag:
-                    return HandleSetTimeEvent(action);
+                    return false;
 
                 case LyricEditorMode.AdjustTimeTag:
                     return false;
@@ -366,37 +356,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 KaraokeEditAction.Last => lyricCaretState.MoveCaret(MovingCaretAction.Last),
                 _ => false
             };
-
-        protected bool HandleSetTimeEvent(KaraokeEditAction action)
-        {
-            if (lyricTimeTagsChangeHandler == null)
-                return false;
-
-            var caretPosition = lyricCaretState.BindableCaretPosition.Value;
-            if (caretPosition is not TimeTagCaretPosition timeTagCaretPosition)
-                throw new NotSupportedException(nameof(caretPosition));
-
-            var currentTimeTag = timeTagCaretPosition.TimeTag;
-
-            switch (action)
-            {
-                case KaraokeEditAction.ClearTime:
-                    lyricTimeTagsChangeHandler.ClearTimeTagTime(currentTimeTag);
-                    return true;
-
-                case KaraokeEditAction.SetTime:
-                    double currentTime = editorClock.CurrentTime;
-                    lyricTimeTagsChangeHandler.SetTimeTagTime(currentTimeTag, currentTime);
-
-                    if (lyricEditorConfigManager.Get<bool>(KaraokeRulesetLyricEditorSetting.RecordingAutoMoveToNextTimeTag))
-                        lyricCaretState.MoveCaret(MovingCaretAction.Right);
-
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
 
         public virtual void NavigateToFix(LyricEditorMode mode)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -306,47 +306,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             };
         }
 
-        public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
-        {
-            var action = e.Action;
-            bool isMoving = HandleMovingEvent(action);
-            if (isMoving)
-                return true;
-
-            switch (Mode)
-            {
-                case LyricEditorMode.View:
-                case LyricEditorMode.Manage:
-                case LyricEditorMode.Typing: // will handle in OnKeyDown
-                case LyricEditorMode.Language:
-                case LyricEditorMode.EditRuby:
-                case LyricEditorMode.EditRomaji:
-                    return false;
-
-                case LyricEditorMode.CreateTimeTag:
-                    return false;
-
-                case LyricEditorMode.RecordTimeTag:
-                    return false;
-
-                case LyricEditorMode.AdjustTimeTag:
-                    return false;
-
-                case LyricEditorMode.EditNote:
-                case LyricEditorMode.Singer:
-                    return false;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(Mode));
-            }
-        }
-
-        public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)
-        {
-        }
-
-        protected bool HandleMovingEvent(KaraokeEditAction action) =>
-            action switch
+        public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e) =>
+            e.Action switch
             {
                 KaraokeEditAction.Up => lyricCaretState.MoveCaret(MovingCaretAction.Up),
                 KaraokeEditAction.Down => lyricCaretState.MoveCaret(MovingCaretAction.Down),
@@ -356,6 +317,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 KaraokeEditAction.Last => lyricCaretState.MoveCaret(MovingCaretAction.Last),
                 _ => false
             };
+
+        public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)
+        {
+        }
 
         public virtual void NavigateToFix(LyricEditorMode mode)
         {


### PR DESCRIPTION
Implement part of #1213.
What's done in this PR:
- move to create time-tag and record time-tag action logic into the specific class.
- lyric editor should only handle the common logic (e.g: move the caret.)