### PR TITLE
Implement hue selector for singer editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     RomajiName = "Hatsune Miku",
                     EnglishName = "Miku",
                     Description = "International superstar vocaloid Hatsune Miku.",
-                    Hue = 189,
+                    Hue = 189 / 360f,
                 },
                 new(2)
                 {
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     RomajiName = "haku",
                     EnglishName = "andy840119",
                     Description = "Creator of this ruleset.",
-                    Hue = 46
+                    Hue = 46 / 360f,
                 },
                 new(3)
                 {
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     RomajiName = "gomi-pasokonn",
                     EnglishName = "garbage desktop",
                     Description = "My fucking slow desktop.",
-                    Hue = 290,
+                    Hue = 290 / 360f,
                 }
             };
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
@@ -42,7 +42,11 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
         }
 
         [JsonIgnore]
-        public readonly Bindable<float> HueBindable = new();
+        public Bindable<float> HueBindable = new BindableFloat
+        {
+            MinValue = 0,
+            MaxValue = 1
+        };
 
         public float Hue
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
@@ -11,20 +11,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
     {
         protected override string Title => "Avatar";
 
-        [BackgroundDependencyLoader]
-        private void load()
+        public AvatarSection(Singer singer)
         {
             Children = new Drawable[]
             {
                 new LabelledImageSelector
                 {
                     Label = "Avatar",
-                    Description = "Select image to set avatar."
+                    Description = "Select image to set avatar.",
+                    Current = singer.AvatarBindable,
                 },
-                new LabelledColourSelector
+                new LabelledHueSelector
                 {
                     Label = "Colour",
-                    Description = "Select singer colour."
+                    Description = "Select singer colour.",
+                    Current = singer.HueBindable,
                 }
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/EditSingerDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/EditSingerDialog.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
                             Size = new Vector2(1 / section_scale),
                             Children = new EditSingerSection[]
                             {
-                                new AvatarSection(),
+                                new AvatarSection(e.NewValue),
                                 new MetadataSection(e.NewValue),
                             }
                         }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledHueSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LabelledHueSelector.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
+{
+    public class LabelledHueSelector : LabelledComponent<LabelledHueSelector.OsuHueSelector, float>
+    {
+        public LabelledHueSelector()
+            : base(true)
+        {
+        }
+
+        protected override OsuHueSelector CreateComponent()
+            => new();
+
+        private static EdgeEffectParameters createShadowParameters() => new()
+        {
+            Type = EdgeEffectType.Shadow,
+            Offset = new Vector2(0, 1),
+            Radius = 3,
+            Colour = Colour4.Black.Opacity(0.3f)
+        };
+
+        /// <summary>
+        /// Copied from <see cref="OsuHSVColourPicker"/>
+        /// </summary>
+        public class OsuHueSelector : HSVColourPicker.HueSelector, IHasCurrentValue<float>
+        {
+            private const float corner_radius = 10;
+            private const float control_border_thickness = 3;
+
+            public Bindable<float> Current
+            {
+                get => Hue;
+                set
+                {
+                    if (value == null)
+                        throw new ArgumentNullException(nameof(value));
+
+                    Hue.UnbindBindings();
+                    Hue.BindTo(value);
+                }
+            }
+
+            public OsuHueSelector()
+            {
+                SliderBar.CornerRadius = corner_radius;
+                SliderBar.Masking = true;
+            }
+
+            protected override Drawable CreateSliderNub() => new SliderNub(this);
+
+            private class SliderNub : CompositeDrawable
+            {
+                private readonly Bindable<float> hue;
+                private readonly Box fill;
+
+                public SliderNub(OsuHueSelector osuHueSelector)
+                {
+                    hue = osuHueSelector.Hue.GetBoundCopy();
+
+                    InternalChild = new CircularContainer
+                    {
+                        Height = 35,
+                        Width = 10,
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        Masking = true,
+                        BorderColour = Colour4.White,
+                        BorderThickness = control_border_thickness,
+                        EdgeEffect = createShadowParameters(),
+                        Child = fill = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    };
+                }
+
+                protected override void LoadComplete()
+                {
+                    hue.BindValueChanged(h => fill.Colour = Colour4.FromHSV(h.NewValue, 1, 1), true);
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Utils/SingerUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/SingerUtils.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Utils
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         public static Color4 GetContentColour(ISinger singer)
-            => Color4.FromHsl(new Vector4(singer.Hue / 360, 0.4f, 0.6f, 1));
+            => Colour4.FromHSL(singer.Hue, 0.4f, 0.6f);
 
         public static Color4 GetBackgroundColour(ISinger singer)
-            => Color4.FromHsl(new Vector4(singer.Hue / 360, 0.1f, 0.4f, 1));
+            => Colour4.FromHSL(singer.Hue, 0.1f, 0.4f);
     }
 }


### PR DESCRIPTION
Implement missing part of #1222.

What's done in this PR:
- implement labeled hue selector.
- hue value should be restricted between 0 and 1.
- apply bindable in the avatar section and the hue section.