### PR TITLE
Implmenet batch to assign language.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SelectLyricButton.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
         public Func<Dictionary<Lyric, string>> StartSelecting { get; set; }
 
+        [Resolved]
+        private ILyricSelectionState lyricSelectionState { get; set; }
+
         protected SelectLyricButton()
         {
             RelativeSizeAxes = Axes.X;
@@ -30,7 +33,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, ILyricSelectionState lyricSelectionState)
+        private void load(OsuColour colours)
         {
             selecting = lyricSelectionState.Selecting.GetBoundCopy();
             selecting.BindValueChanged(e =>
@@ -42,20 +45,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
             Action = () =>
             {
-                if (selecting.Value)
+                if (!selecting.Value)
                 {
-                    lyricSelectionState.EndSelecting(LyricEditorSelectingAction.Cancel);
+                    StartSelectingLyrics();
                 }
                 else
                 {
-                    // update disabled lyrics list.
-                    var disableLyrics = StartSelecting?.Invoke();
-                    lyricSelectionState.UpdateDisableLyricList(disableLyrics);
-
-                    // then start selecting.
-                    lyricSelectionState.StartSelecting();
+                    EndSelectingLyrics();
                 }
             };
+        }
+
+        protected virtual void StartSelectingLyrics()
+        {
+            // update disabled lyrics list.
+            var disableLyrics = StartSelecting?.Invoke();
+            lyricSelectionState.UpdateDisableLyricList(disableLyrics);
+
+            // then start selecting.
+            lyricSelectionState.StartSelecting();
+        }
+
+        protected virtual void EndSelectingLyrics()
+        {
+            lyricSelectionState.EndSelecting(LyricEditorSelectingAction.Cancel);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/AssignLanguageSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/AssignLanguageSubsection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,6 +12,8 @@ using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
 {
@@ -22,13 +25,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
 
         private readonly Bindable<CultureInfo> bindableLanguage = new();
 
+        private readonly List<HitObject> selectedLyrics = new();
+
         [BackgroundDependencyLoader]
-        private void load(ILyricSelectionState lyricSelectionState, ILyricLanguageChangeHandler lyricLanguageChangeHandler)
+        private void load(ILyricSelectionState lyricSelectionState, ILyricLanguageChangeHandler lyricLanguageChangeHandler, ILyricCaretState lyricCaretState, EditorBeatmap beatmap)
         {
             lyricSelectionState.Action = e =>
             {
                 if (e != LyricEditorSelectingAction.Apply)
                     return;
+
+                selectedLyrics.Clear();
+                selectedLyrics.AddRange(beatmap.SelectedHitObjects);
 
                 this.ShowPopover();
             };
@@ -39,10 +47,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
                 if (language == null)
                     return;
 
+                // Note: because selected hit objects was cleared after end of selection.
+                // So should re-add them into the selection list again.
+                beatmap.SelectedHitObjects.AddRange(selectedLyrics);
                 lyricLanguageChangeHandler.SetLanguage(language);
 
                 this.HidePopover();
                 bindableLanguage.Value = null;
+
+                // after apply the language, should make sure that should sync the selected hit object again.
+                lyricCaretState.SyncSelectedHitObjectWithCaret();
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/AssignLanguageSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/AssignLanguageSubsection.cs
@@ -3,17 +3,24 @@
 
 using System.Globalization;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
 {
-    public class AssignLanguageSubsection : SelectLyricButton
+    public class AssignLanguageSubsection : SelectLyricButton, IHasPopover
     {
         protected override string StandardText => "Change language";
 
         protected override string SelectingText => "Cancel change language";
+
+        private readonly Bindable<CultureInfo> bindableLanguage = new();
 
         [BackgroundDependencyLoader]
         private void load(ILyricSelectionState lyricSelectionState, ILyricLanguageChangeHandler lyricLanguageChangeHandler)
@@ -23,10 +30,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
                 if (e != LyricEditorSelectingAction.Apply)
                     return;
 
-                // todo: should have a popover for user to select the language.
-                var language = new CultureInfo("Ja-jp");
-                lyricLanguageChangeHandler.SetLanguage(language);
+                this.ShowPopover();
             };
+
+            bindableLanguage.BindValueChanged(e =>
+            {
+                var language = e.NewValue;
+                if (language == null)
+                    return;
+
+                lyricLanguageChangeHandler.SetLanguage(language);
+
+                this.HidePopover();
+                bindableLanguage.Value = null;
+            });
         }
+
+        public Popover GetPopover()
+            => new LanguageSelectorPopover(bindableLanguage);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         bool CaretPositionMovable(ICaretPosition position);
 
+        void SyncSelectedHitObjectWithCaret();
+
         bool CaretEnabled { get; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -233,15 +233,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         public bool CaretPositionMovable(ICaretPosition position)
             => algorithm?.PositionMovable(position) ?? false;
 
+        public void SyncSelectedHitObjectWithCaret()
+        {
+            selectedHitObjects.Clear();
+
+            var lyric = bindableCaretPosition.Value?.Lyric;
+            if (lyric != null)
+                selectedHitObjects.Add(lyric);
+        }
+
         public bool CaretEnabled => algorithm != null;
 
         private void postProcess()
         {
-            var caretPosition = bindableCaretPosition.Value;
-            navigateToTByCaretPosition(caretPosition);
-            updateEditorBeatmapSelectedHitObject(caretPosition?.Lyric);
+            SyncSelectedHitObjectWithCaret();
 
-            void navigateToTByCaretPosition(ICaretPosition position)
+            var caretPosition = bindableCaretPosition.Value;
+            navigateToTimeByCaretPosition(caretPosition);
+
+            void navigateToTimeByCaretPosition(ICaretPosition position)
             {
                 if (position is not TimeTagCaretPosition timeTagCaretPosition)
                     return;
@@ -249,14 +259,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 double? timeTagTime = timeTagCaretPosition.TimeTag.Time;
                 if (timeTagTime.HasValue && !editorClock.IsRunning && bindableRecordingChangeTimeWhileMovingTheCaret.Value)
                     editorClock.SeekSmoothlyTo(timeTagTime.Value);
-            }
-
-            void updateEditorBeatmapSelectedHitObject(HitObject hitObject)
-            {
-                selectedHitObjects.Clear();
-
-                if (hitObject != null)
-                    selectedHitObjects.Add(hitObject);
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -60,9 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             beatmap.SelectedHitObjects.Clear();
 
             // should add selected lyric back.
-            var caretPosition = lyricCaretState.BindableCaretPosition.Value;
-            if (caretPosition?.Lyric != null)
-                beatmap.SelectedHitObjects.Add(caretPosition.Lyric);
+            lyricCaretState.SyncSelectedHitObjectWithCaret();
         }
 
         public void Select(Lyric lyric)


### PR DESCRIPTION
It's the remaining part of #1170

What's changed in this PR:
- Expose the method for syncing the selected hit object with the caret.
- Refactor the base selection button.
- Should show the popover after clicking the start selection button.

Also, there are two versions for this PR:
1. Show the popover after the end of the selection
2. Let the user select the language first before starting selecting.

Guess the point of UX is similar for those two ways, but the second way will not have tricky code.
So just use the second way.