### PR TITLE
Implement switch the edit mode by hotkey.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/EnumUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/EnumUtilsTest.cs
@@ -22,7 +22,25 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(expected, actual);
         }
 
-        internal enum TestEnum
+        [TestCase(TestEnum.Enum1, TestEnum.Enum3)]
+        [TestCase(TestEnum.Enum2, TestEnum.Enum1)]
+        [TestCase(TestEnum.Enum3, TestEnum.Enum2)]
+        public void TestGetPreviousValue(TestEnum current, TestEnum expected)
+        {
+            var actual = EnumUtils.GetPreviousValue(current);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(TestEnum.Enum1, TestEnum.Enum2)]
+        [TestCase(TestEnum.Enum2, TestEnum.Enum3)]
+        [TestCase(TestEnum.Enum3, TestEnum.Enum1)]
+        public void TestGetNextValue(TestEnum current, TestEnum expected)
+        {
+            var actual = EnumUtils.GetNextValue(current);
+            Assert.AreEqual(expected, actual);
+        }
+
+        public enum TestEnum
         {
             Enum1,
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -306,7 +306,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             };
         }
 
-        public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e) =>
+        public virtual bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e) =>
             e.Action switch
             {
                 KaraokeEditAction.Up => lyricCaretState.MoveCaret(MovingCaretAction.Up),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorMode.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public enum LyricEditorMode
@@ -8,56 +10,67 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         /// <summary>
         /// Cannot edit anything except each lyric's left-side part.
         /// </summary>
+        [Description("View")]
         View,
 
         /// <summary>
         /// Can create/delete/mode/split/combine lyric.
         /// </summary>
+        [Description("Manage lyrics")]
         Manage,
 
         /// <summary>
         /// Able to typing lyric.
         /// </summary>
+        [Description("Typing")]
         Typing,
 
         /// <summary>
         /// Can edit each lyric's language.
         /// </summary>
+        [Description("Select language")]
         Language,
 
         /// <summary>
         /// Able to create/delete ruby.
         /// </summary>
+        [Description("Edit ruby")]
         EditRuby,
 
         /// <summary>
         /// Able to create/delete romaji.
         /// </summary>
+        [Description("Edit romaji")]
         EditRomaji,
 
         /// <summary>
         /// Enable to create/delete and reset time tag.
         /// </summary>
+        [Description("Create time tag")]
         CreateTimeTag,
 
         /// <summary>
         /// Click white-space to set current time into time-tag.
         /// </summary>
+        [Description("Record time tag")]
         RecordTimeTag,
 
         /// <summary>
         /// Precisely adjust time-tag time.
         /// </summary>
+        [Description("Adjust time tag")]
         AdjustTimeTag,
 
         /// <summary>
         /// Enable to create/delete notes.
         /// </summary>
+        [Description("Edit note")]
         EditNote,
 
         /// <summary>
         /// Can edit each lyric's singer.
         /// </summary>
+        [Description("Select singer")]
         Singer,
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -1,10 +1,15 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.OSD;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
@@ -96,6 +101,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         {
             private ILyricCaretState lyricCaretState { get; set; }
 
+            [Resolved(canBeNull: true)]
+            private OnScreenDisplay onScreenDisplay { get; set; }
+
             protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             {
                 var dependencies = base.CreateChildDependencies(parent);
@@ -111,16 +119,74 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 {
                     case KaraokeEditAction.PreviousEditMode:
                         SwitchMode(EnumUtils.GetPreviousValue(Mode));
+                        onScreenDisplay?.Display(new LyricEditorEditModeToast(Mode));
                         return true;
 
                     case KaraokeEditAction.NextEditMode:
                         SwitchMode(EnumUtils.GetNextValue(Mode));
+                        onScreenDisplay?.Display(new LyricEditorEditModeToast(Mode));
                         return true;
 
                     default:
                         return base.OnPressed(e);
                 }
             }
+        }
+
+        public class LyricEditorEditModeToast : Toast
+        {
+            public LyricEditorEditModeToast(LyricEditorMode mode)
+                : base(getDescription(mode), getValue(mode), getShortcut())
+            {
+            }
+
+            private static LocalisableString getDescription(LyricEditorMode mode)
+            {
+                switch (mode)
+                {
+                    case LyricEditorMode.View:
+                        return "View the lyric";
+
+                    case LyricEditorMode.Manage:
+                        return "Manage the lyric";
+
+                    case LyricEditorMode.Typing:
+                        return "Typing...";
+
+                    case LyricEditorMode.Language:
+                        return "Manage the language in the lyric.";
+
+                    case LyricEditorMode.EditRuby:
+                        return "Create/edit/delete the ruby";
+
+                    case LyricEditorMode.EditRomaji:
+                        return "Create/edit/delete the romaji";
+
+                    case LyricEditorMode.CreateTimeTag:
+                        return "Create/edit the time-tag.";
+
+                    case LyricEditorMode.RecordTimeTag:
+                        return "Set time to the time-tag.";
+
+                    case LyricEditorMode.AdjustTimeTag:
+                        return "Check the time-tag.";
+
+                    case LyricEditorMode.EditNote:
+                        return "Create the notes for scoring.";
+
+                    case LyricEditorMode.Singer:
+                        return "Assign the singer to lyric.";
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+                }
+            }
+
+            private static LocalisableString getValue(LyricEditorMode mode)
+                => mode.GetDescription();
+
+            private static LocalisableString getShortcut()
+                => "Switch edit mode";
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorScreen.cs
@@ -4,12 +4,14 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.UI.Position;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
@@ -102,6 +104,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             }
 
             public void ResetCaret() => lyricCaretState.MoveCaret(MovingCaretAction.First);
+
+            public override bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
+            {
+                switch (e.Action)
+                {
+                    case KaraokeEditAction.PreviousEditMode:
+                        SwitchMode(EnumUtils.GetPreviousValue(Mode));
+                        return true;
+
+                    case KaraokeEditAction.NextEditMode:
+                        SwitchMode(EnumUtils.GetNextValue(Mode));
+                        return true;
+
+                    default:
+                        return base.OnPressed(e);
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
@@ -36,6 +36,13 @@ namespace osu.Game.Rulesets.Karaoke
         [Description("Last")]
         Last,
 
+        // Switch edit mode.
+        [Description("Previous edit mode")]
+        PreviousEditMode,
+
+        [Description("Next edit mode")]
+        NextEditMode,
+
         // Edit Ruby / romaji tag.
         [Description("Reduce start index")]
         EditTextTagReduceStartIndex,

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -100,6 +100,9 @@ namespace osu.Game.Rulesets.Karaoke
                     new KeyBinding(InputKey.PageUp, KaraokeEditAction.First),
                     new KeyBinding(InputKey.PageDown, KaraokeEditAction.Last),
 
+                    new KeyBinding(new[] { InputKey.Alt, InputKey.BracketLeft }, KaraokeEditAction.PreviousEditMode),
+                    new KeyBinding(new[] { InputKey.Alt, InputKey.BracketRight }, KaraokeEditAction.NextEditMode),
+
                     // Edit Ruby / romaji tag.
                     new KeyBinding(new[] { InputKey.Z, InputKey.Left }, KaraokeEditAction.EditTextTagReduceStartIndex),
                     new KeyBinding(new[] { InputKey.Z, InputKey.Right }, KaraokeEditAction.EditTextTagIncreaseStartIndex),

--- a/osu.Game.Rulesets.Karaoke/Utils/EnumUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/EnumUtils.cs
@@ -2,14 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Game.Rulesets.Karaoke.Utils
 {
     public static class EnumUtils
     {
-        public static T[] GetValues<T>()
-        {
-            return (T[])Enum.GetValues(typeof(T));
-        }
+        public static T[] GetValues<T>() where T : struct
+            => (T[])Enum.GetValues(typeof(T));
+
+        public static T GetPreviousValue<T>(T v) where T : struct
+            => GetValues<T>().Concat(new[] { default(T) }).Reverse().SkipWhile(e => !EqualityComparer<T>.Default.Equals(v, e)).Skip(1).First();
+
+        public static T GetNextValue<T>(T v) where T : struct
+            => GetValues<T>().Concat(new[] { default(T) }).SkipWhile(e => !EqualityComparer<T>.Default.Equals(v, e)).Skip(1).First();
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/160628526-b25ad977-2383-400f-9ca2-d93291c95d61.png)

Implementation of #1195
What's done in this PR:
- Add the description in the lyric editor edit mode.
- Add the key for switching to the previous and next modes.
- Implement switch to previous and next edit mode, also will show the toast.