### PR TITLE
Move all sub edit mode into state namespace.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreenWithLyricEditor.cs
@@ -6,8 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/DrawableLyricEditListItem.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Notes;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteAutoGenerateSubsection.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Configs.Generator.Notes;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditModeSection.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/BlueprintLayer.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/EditLyricRow.cs
@@ -15,7 +15,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.FixedInfo;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -9,7 +9,6 @@ using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditRomajiModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditRomajiModeState.cs
@@ -1,7 +1,6 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditRubyModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditRubyModeState.cs
@@ -1,7 +1,6 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ITimeTagModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ITimeTagModeState.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/LanguageEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/LanguageEditMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
     public enum LanguageEditMode
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/NoteEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/NoteEditMode.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public enum TextTagEditMode
+    public enum NoteEditMode
     {
         Generate,
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextTagEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextTagEditMode.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public enum NoteEditMode
+    public enum TextTagEditMode
     {
         Generate,
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagEditMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
     public enum TimeTagEditMode
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;


### PR DESCRIPTION
Inspired from #1247.
Because we might change some place (e.g: blueprint or badge) by the sub-edit mode.
So should be better to move them into the mode state namespace.