### PR TITLE
Fix wrong lyric order in the tralslate and singer screen.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
@@ -3,14 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
@@ -57,16 +58,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
         [BackgroundDependencyLoader]
         private void load()
         {
-            var editorBeatmap = new EditorBeatmap(beatmap);
-            var bindableLyrics = new BindableList<Lyric>(beatmap.HitObjects.OfType<Lyric>());
-
-            Dependencies.Cache(editorBeatmap);
+            Dependencies.Cache(new EditorBeatmap(beatmap));
             Dependencies.Cache(new EditorClock());
             Dependencies.CacheAs(state = new TestLyricEditorState());
             Dependencies.CacheAs<ITimeTagModeState>(new TimeTagModeState());
             Dependencies.Cache(new KaraokeRulesetLyricEditorConfigManager());
 
-            Child = lyricCaretState = new LyricCaretState(bindableLyrics);
+            LyricsProvider lyricsProvider = new LyricsProvider();
+            Dependencies.CacheAs<ILyricsProvider>(lyricsProvider);
+
+            Children = new Drawable[]
+            {
+                lyricsProvider,
+                lyricCaretState = new LyricCaretState()
+            };
         }
 
         #region Changing mode

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 
@@ -24,6 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         protected override LyricEditorScreen CreateEditorScreen() => new();
 
         private DialogOverlay dialogOverlay;
+        private LyricsProvider lyricsProvider;
         private LyricCheckerManager lyricCheckManager;
 
         [BackgroundDependencyLoader]
@@ -33,10 +35,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             {
                 Content,
                 dialogOverlay = new DialogOverlay(),
+                lyricsProvider = new LyricsProvider(),
                 lyricCheckManager = new LyricCheckerManager(),
             });
 
             Dependencies.Cache(dialogOverlay);
+            Dependencies.CacheAs<ILyricsProvider>(lyricsProvider);
             Dependencies.Cache(lyricCheckManager);
             Dependencies.Cache(new KaraokeRulesetLyricEditorConfigManager());
             Dependencies.Cache(new KaraokeRulesetEditGeneratorConfigManager());

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
@@ -10,6 +10,7 @@ using osu.Game.Graphics.Cursor;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Singers;
 using osu.Game.Screens.Edit;
 
@@ -62,6 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         }
 
         private DialogOverlay dialogOverlay;
+        private LyricsProvider lyricsProvider;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -73,7 +75,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
                     RelativeSizeAxes = Axes.Both,
                     Child = Content
                 },
-                dialogOverlay = new DialogOverlay()
+                dialogOverlay = new DialogOverlay(),
+                lyricsProvider = new LyricsProvider(),
             });
 
             var beatDivisor = new BindableBeatDivisor
@@ -83,6 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             var editorClock = new EditorClock(Beatmap.Value.Beatmap, beatDivisor) { IsCoupled = false };
             Dependencies.CacheAs(editorClock);
             Dependencies.Cache(beatDivisor);
+            Dependencies.CacheAs<ILyricsProvider>(lyricsProvider);
             Dependencies.Cache(dialogOverlay);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneTranslateScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneTranslateScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Translate;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor
@@ -35,6 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         }
 
         private DialogOverlay dialogOverlay;
+        private LyricsProvider lyricsProvider;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -43,9 +45,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             {
                 Content,
                 dialogOverlay = new DialogOverlay(),
+                lyricsProvider = new LyricsProvider()
             });
 
             Dependencies.Cache(dialogOverlay);
+            Dependencies.CacheAs<ILyricsProvider>(lyricsProvider);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ILyricsProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ILyricsProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit
+{
+    public interface ILyricsProvider
+    {
+        BindableList<Lyric> BindableLyrics { get; }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporter.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         private ImportLyricManager importManager;
 
+        private LyricsProvider lyricsProvider;
+
         private LyricCheckerManager lyricCheckerManager;
 
         private DependencyContainer dependencies;
@@ -98,6 +100,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
             AddInternal(importManager = new ImportLyricManager());
             dependencies.Cache(importManager);
+
+            AddInternal(lyricsProvider = new LyricsProvider());
+            dependencies.CacheAs<ILyricsProvider>(lyricsProvider);
 
             AddInternal(lyricCheckerManager = new LyricCheckerManager());
             dependencies.Cache(lyricCheckerManager);

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -41,6 +41,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached]
         private readonly FontManager fontManager;
 
+        [Cached(typeof(ILyricsProvider))]
+        private readonly LyricsProvider lyricsProvider;
+
         [Cached]
         private readonly ExportLyricManager exportLyricManager;
 
@@ -64,6 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             AddInternal(fontManager = new FontManager());
 
             AddInternal(exportLyricManager = new ExportLyricManager());
+            AddInternal(lyricsProvider = new LyricsProvider());
             AddInternal(lyricCheckerManager = new LyricCheckerManager());
 
             AddInternal(beatmapChangeHandler = new BeatmapChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         private ICaretPositionAlgorithm algorithm => bindableCaretPositionAlgorithm.Value;
 
+        private readonly IBindableList<Lyric> bindableLyrics = new BindableList<Lyric>();
+
         private readonly BindableList<HitObject> selectedHitObjects = new();
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
 
@@ -40,15 +42,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         private readonly IBindable<MovingTimeTagCaretMode> bindableRecordingMovingCaretMode = new Bindable<MovingTimeTagCaretMode>();
         private readonly IBindable<bool> bindableRecordingChangeTimeWhileMovingTheCaret = new Bindable<bool>();
 
-        private readonly IBindableList<Lyric> bindableLyrics;
-
         [Resolved]
         private EditorClock editorClock { get; set; }
 
-        public LyricCaretState(IBindableList<Lyric> bindableLyrics)
+        public LyricCaretState()
         {
-            this.bindableLyrics = bindableLyrics;
-            this.bindableLyrics.BindCollectionChanged((a, b) =>
+            bindableLyrics.BindCollectionChanged((a, b) =>
             {
                 // should reset caret position if not in the list.
                 var caretLyric = BindableCaretPosition.Value?.Lyric;
@@ -160,9 +159,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         }
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap, ILyricEditorState state, ITimeTagModeState timeTagModeState, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
+        private void load(EditorBeatmap beatmap, ILyricsProvider lyricsProvider, ILyricEditorState state, ITimeTagModeState timeTagModeState, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
             selectedHitObjects.BindTo(beatmap.SelectedHitObjects);
+
+            bindableLyrics.BindTo(lyricsProvider.BindableLyrics);
+
             bindableMode.BindTo(state.BindableMode);
 
             bindableTimeTagEditMode.BindTo(timeTagModeState.BindableEditMode);

--- a/osu.Game.Rulesets.Karaoke/Edit/LyricsProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/LyricsProvider.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit
+{
+    public class LyricsProvider : Component, ILyricsProvider
+    {
+        /// <summary>
+        /// Get the bindable lyrics with sorted order.
+        /// </summary>
+        public BindableList<Lyric> BindableLyrics { get; } = new();
+
+        [BackgroundDependencyLoader]
+        private void load(EditorBeatmap beatmap)
+        {
+            // Load the lyric into bindable list.
+            // And notice that order change in the bindable will not affect the order in the editor beatmap.
+            // The hit object in the editor beatmap will auto sort by the time.
+            var lyrics = OrderUtils.Sorted(beatmap.HitObjects.OfType<Lyric>());
+            BindableLyrics.AddRange(lyrics);
+
+            // need to check is there any lyric added or removed.
+            beatmap.HitObjectAdded += e =>
+            {
+                if (e is not Lyric lyric)
+                    return;
+
+                var previousLyric = BindableLyrics.LastOrDefault(x => x.Order < lyric.Order);
+
+                if (previousLyric != null)
+                {
+                    int insertIndex = BindableLyrics.IndexOf(previousLyric) + 1;
+                    BindableLyrics.Insert(insertIndex, lyric);
+                }
+                else
+                {
+                    // insert to first.
+                    BindableLyrics.Insert(0, lyric);
+                }
+            };
+            beatmap.HitObjectRemoved += e =>
+            {
+                if (e is not Lyric lyric)
+                    return;
+
+                BindableLyrics.Remove(lyric);
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerLyricEditor.cs
@@ -38,14 +38,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
             ScrollbarVisible = false;
         }
 
-        private Box background;
-
-        private Container mainContent;
-
         [BackgroundDependencyLoader]
         private void load(ISingerScreenScrollingInfoProvider scrollingInfoProvider, OsuColour colour)
         {
-            AddInternal(background = new Box
+            AddInternal(new Box
             {
                 Name = "Background",
                 Depth = 1,
@@ -57,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
             });
             AddRange(new Drawable[]
             {
-                mainContent = new Container
+                new Container
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = timeline_height,
@@ -66,7 +62,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
                     Depth = float.MaxValue,
                     Children = new Drawable[]
                     {
-                        new LyricBlueprintContainer(Singer),
+                        new LyricBlueprintContainer(),
                     }
                 },
             });

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/ITranslateInfoProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/ITranslateInfoProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Globalization;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -10,7 +9,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
     public interface ITranslateInfoProvider
     {
         string GetLyricTranslate(Lyric lyric, CultureInfo cultureInfo);
-
-        IEnumerable<Lyric> TranslatableLyrics { get; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/TranslateScreen.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,17 +8,11 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Languages;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
-using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Translate
 {
-    [Cached(typeof(ITranslateInfoProvider))]
-    public class TranslateScreen : KaraokeEditorRoundedScreen, ITranslateInfoProvider
+    public class TranslateScreen : KaraokeEditorRoundedScreen
     {
-        [Resolved]
-        private EditorBeatmap beatmap { get; set; }
-
         [Cached(typeof(ILanguagesChangeHandler))]
         private readonly LanguagesChangeHandler languagesChangeHandler;
 
@@ -53,16 +43,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate
                 }
             });
         }
-
-        public string GetLyricTranslate(Lyric lyric, CultureInfo cultureInfo)
-        {
-            if (cultureInfo == null)
-                throw new ArgumentNullException(nameof(cultureInfo));
-
-            return lyric.Translates.TryGetValue(cultureInfo, out string translate) ? translate : null;
-        }
-
-        public IEnumerable<Lyric> TranslatableLyrics => beatmap.HitObjects.OfType<Lyric>();
 
         internal class TranslateScreenHeader : OverlayHeader
         {


### PR DESCRIPTION
Fix part of the issue in the #1239 

What's done in this PR:
- implement the lyric provider to get sorted lyrics.
- apply the lyric provider to the lyric editor screen.
- apply the lyric provider to the singer editor screen.
- apply the lyric provider to the translate editor screen.