### PR TITLE
Fix the caret position is not by order after dragged.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         protected CaretPositionAlgorithm(Lyric[] lyrics)
         {
-            Lyrics = LyricsUtils.FindUnlockLyrics(OrderUtils.Sorted(lyrics));
+            Lyrics = LyricsUtils.FindUnlockLyrics(lyrics);
         }
 
         public abstract bool PositionMovable(TCaretPosition position);


### PR DESCRIPTION
Remove the order utils because the lyric in the list already in order.
Also, it will cause wrong order because reset algorithm will be earlier than the change the order property.