### PR TITLE
Fix back button issue in the import lyric screen

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/DragFile/DragFileStepScreen.cs
@@ -117,6 +117,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.DragFile
             ScreenStack.Push(LyricImporterStep.EditLyric);
         }
 
+        public override void ConfirmRollBackFromStep(ILyricImporterStepScreen fromScreen, Action<bool> callBack)
+        {
+            base.ConfirmRollBackFromStep(fromScreen, ok =>
+            {
+                DialogOverlay.Push(new RollBackResetPopupDialog(fromScreen, reset =>
+                {
+                    if (reset)
+                    {
+                        // Should be better to clear all the lyrics before roll-back to the current page.
+                        importManager.AbortImport();
+                    }
+
+                    callBack?.Invoke(ok);
+                }));
+            });
+        }
+
         public override void OnEntering(IScreen last)
         {
             game.RegisterImportHandler(this);

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/Header.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -151,7 +152,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
                 if (tab.Value is not ILyricImporterStepScreen targetScreen)
                     return;
 
-                currentScreen.CanRollBack(targetScreen, enabled =>
+                if (targetScreen.Step > currentScreen.Step)
+                    throw new InvalidOperationException("Cannot roll back to next step. How did you did that?");
+
+                // Should make sure that
+                targetScreen.ConfirmRollBackFromStep(currentScreen, enabled =>
                 {
                     if (enabled)
                         base.SelectTab(tab);

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ILyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ILyricImporterStepScreen.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         IconUsage Icon { get; }
 
-        void CanRollBack(ILyricImporterStepScreen rollBackScreen, Action<bool> callBack);
+        void ConfirmRollBackFromStep(ILyricImporterStepScreen fromScreen, Action<bool> callBack);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/ImportLyricManager.cs
@@ -64,5 +64,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
                 }
             }
         }
+
+        public void AbortImport()
+        {
+            editorBeatmap.Clear();
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporter.cs
@@ -7,9 +7,12 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
@@ -19,7 +22,7 @@ using osu.Game.Screens.Play;
 namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 {
     [Cached(typeof(IImportStateResolver))]
-    public class LyricImporter : ScreenWithBeatmapBackground, IImportStateResolver
+    public class LyricImporter : ScreenWithBeatmapBackground, IImportStateResolver, IKeyBindingHandler<GlobalAction>
     {
         private readonly LyricImporterWaveContainer waves;
 
@@ -40,6 +43,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+        // Hide the back button because we cannot show it only in the first step.
+        public override bool AllowBackButton => false;
 
         public event Action<IBeatmap> OnImportFinished;
 
@@ -119,6 +125,41 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         {
             this.Exit();
             OnImportFinished?.Invoke(editorBeatmap);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat)
+                return false;
+
+            switch (e.Action)
+            {
+                case GlobalAction.Back:
+                    // as we don't want to display the back button, manual handling of exit action is required.
+                    // follow how editor.cs does.
+                    if (ScreenStack.CurrentScreen is not ILyricImporterStepScreen screen)
+                        throw new InvalidOperationException("Screen stack should only contains step screen");
+
+                    if (screen.Step != LyricImporterStep.ImportLyric)
+                    {
+                        // the better UX behavior should be move to the previous step.
+                        // But it will not asking.
+                        return false;
+
+                        // todo: implement.
+                        // ScreenStack.Exit();
+                    }
+
+                    this.Exit();
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
 
         private class LyricImporterWaveContainer : WaveContainer

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreen.cs
@@ -84,10 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
         {
             DialogOverlay.Push(new RollBackPopupDialog(fromScreen, ok =>
             {
-                if (ok && Step == LyricImporterStep.ImportLyric)
-                    DialogOverlay.Push(new RollBackResetPopupDialog(rollBackScreen, callBack));
-                else
-                    callBack?.Invoke(ok);
+                callBack?.Invoke(ok);
             }));
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/LyricImporterStepScreen.cs
@@ -80,11 +80,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         public abstract void Complete();
 
-        public virtual void CanRollBack(ILyricImporterStepScreen rollBackScreen, Action<bool> callBack)
+        public virtual void ConfirmRollBackFromStep(ILyricImporterStepScreen fromScreen, Action<bool> callBack)
         {
-            DialogOverlay.Push(new RollBackPopupDialog(rollBackScreen, ok =>
+            DialogOverlay.Push(new RollBackPopupDialog(fromScreen, ok =>
             {
-                if (ok && rollBackScreen.Step == LyricImporterStep.ImportLyric)
+                if (ok && Step == LyricImporterStep.ImportLyric)
                     DialogOverlay.Push(new RollBackResetPopupDialog(rollBackScreen, callBack));
                 else
                     callBack?.Invoke(ok);

--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/RollBackResetPopupDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/RollBackResetPopupDialog.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
             BodyText = $"Are you really sure you want to roll-back to step '{screen.Title}'? You might lost every change you made.";
             Buttons = new PopupDialogButton[]
             {
-                new PopupDialogOkButton
+                new PopupDialogDangerousButton
                 {
-                    Text = @"Sure",
+                    Text = @"Forget all changes",
                     Action = () => okAction?.Invoke(true),
                 },
                 new PopupDialogCancelButton


### PR DESCRIPTION
What's fixed in this PR:
- Remove the back button because it will hide the lyric editor.
- Should exit import screen only if in the drag screen(first import lyric step)
- Add abort import feature in the import manager.
- Checking able to roll-back to the target page instead of checking current page if user click the back button.