### PR TITLE
Refactor singing lyrics collect loglc.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetSession.PlaybackSpeed, overridePlaybackSpeed ? playbackSpeedValue : 0, -10, 10);
 
             // Practice
-            SetDefault<Lyric[]>(KaraokeRulesetSession.NowLyrics, null);
+            SetDefault<Lyric[]>(KaraokeRulesetSession.SingingLyrics, null);
 
             // Saiten status
             SetDefault(KaraokeRulesetSession.SaitenStatus, SaitenStatusMode.NotInitialized);
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         PlaybackSpeed,
 
         // Practice
-        NowLyrics,
+        SingingLyrics,
 
         // Saiten status
         SaitenStatus,

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetSession.PlaybackSpeed, overridePlaybackSpeed ? playbackSpeedValue : 0, -10, 10);
 
             // Practice
-            SetDefault<Lyric>(KaraokeRulesetSession.NowLyrics, null);
+            SetDefault<Lyric[]>(KaraokeRulesetSession.NowLyrics, null);
 
             // Saiten status
             SetDefault(KaraokeRulesetSession.SaitenStatus, SaitenStatusMode.NotInitialized);

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeSessionStatics.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetSession.PlaybackSpeed, overridePlaybackSpeed ? playbackSpeedValue : 0, -10, 10);
 
             // Practice
-            SetDefault<Lyric>(KaraokeRulesetSession.NowLyric, null);
+            SetDefault<Lyric>(KaraokeRulesetSession.NowLyrics, null);
 
             // Saiten status
             SetDefault(KaraokeRulesetSession.SaitenStatus, SaitenStatusMode.NotInitialized);
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         PlaybackSpeed,
 
         // Practice
-        NowLyric,
+        NowLyrics,
 
         // Saiten status
         SaitenStatus,

--- a/osu.Game.Rulesets.Karaoke/Difficulty/KaraokeDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Difficulty/KaraokeDifficultyCalculator.cs
@@ -39,9 +39,6 @@ namespace osu.Game.Rulesets.Karaoke.Difficulty
             if (beatmap.HitObjects.Count == 0)
                 return new KaraokeDifficultyAttributes { Mods = mods };
 
-            HitWindows hitWindows = new KaraokeHitWindows();
-            hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
-
             return new KaraokeDifficultyAttributes
             {
                 StarRating = skills[0].DifficultyValue() * star_scaling_factor,

--- a/osu.Game.Rulesets.Karaoke/Judgements/KaraokeLyricJudgement.cs
+++ b/osu.Game.Rulesets.Karaoke/Judgements/KaraokeLyricJudgement.cs
@@ -7,19 +7,8 @@ namespace osu.Game.Rulesets.Karaoke.Judgements
 {
     public class KaraokeLyricJudgement : KaraokeJudgement
     {
-        public LyricTime Time { get; set; }
-
         public override HitResult MaxResult => HitResult.Perfect;
 
         protected override double HealthIncreaseFor(HitResult result) => 0;
-    }
-
-    public enum LyricTime
-    {
-        NotYet,
-
-        Available,
-
-        Exceed
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/KaraokeHitObject.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/KaraokeHitObject.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
@@ -11,7 +9,5 @@ namespace osu.Game.Rulesets.Karaoke.Objects
     {
         public double TimePreempt = 600;
         public double TimeFadeIn = 400;
-
-        protected override HitWindows CreateHitWindows() => new KaraokeHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -12,8 +12,10 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
@@ -202,5 +204,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             StartTime = LyricStartTime;
             Duration = LyricDuration;
         }
+
+        protected override HitWindows CreateHitWindows() => new KaraokeLyricHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -7,7 +7,9 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
@@ -100,5 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         }
 
         public override Judgement CreateJudgement() => new KaraokeNoteJudgement();
+
+        protected override HitWindows CreateHitWindows() => new KaraokeNoteHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Scoring/KaraokeHitWindows.cs
+++ b/osu.Game.Rulesets.Karaoke/Scoring/KaraokeHitWindows.cs
@@ -5,28 +5,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Karaoke.Scoring
 {
-    public class KaraokeHitWindows : HitWindows
+    public abstract class KaraokeHitWindows : HitWindows
     {
-        private static readonly DifficultyRange[] karaoke_ranges =
-        {
-            new(HitResult.Perfect, 80, 50, 20),
-            new(HitResult.Meh, 80, 50, 20),
-            new(HitResult.Miss, 2000, 1500, 1000),
-        };
-
-        public override bool IsHitResultAllowed(HitResult result)
-        {
-            // In karaoke ruleset, time range is not the first thing.
-            return result switch
-            {
-                // Karaoke note hit result
-                HitResult.Perfect => true,
-                // Lyric hit result
-                HitResult.Meh => true,
-                _ => false
-            };
-        }
-
-        protected override DifficultyRange[] GetRanges() => karaoke_ranges;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Scoring/KaraokeLyricHitWindows.cs
+++ b/osu.Game.Rulesets.Karaoke/Scoring/KaraokeLyricHitWindows.cs
@@ -1,0 +1,26 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Karaoke.Scoring
+{
+    public class KaraokeLyricHitWindows : KaraokeHitWindows
+    {
+        public const HitResult DEFAULT_HIT_RESULT = HitResult.Perfect;
+
+        private static readonly DifficultyRange[] lyric_ranges =
+        {
+            new(DEFAULT_HIT_RESULT, 40, 20, 10),
+        };
+
+        public override bool IsHitResultAllowed(HitResult result) =>
+            result switch
+            {
+                DEFAULT_HIT_RESULT => true,
+                _ => false
+            };
+
+        protected override DifficultyRange[] GetRanges() => lyric_ranges;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Scoring/KaraokeNoteHitWindows.cs
+++ b/osu.Game.Rulesets.Karaoke/Scoring/KaraokeNoteHitWindows.cs
@@ -1,0 +1,27 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Karaoke.Scoring
+{
+    public class KaraokeNoteHitWindows : KaraokeHitWindows
+    {
+        private static readonly DifficultyRange[] karaoke_ranges =
+        {
+            new(HitResult.Perfect, 80, 50, 20),
+            new(HitResult.Meh, 80, 50, 20),
+            new(HitResult.Miss, 2000, 1500, 1000),
+        };
+
+        public override bool IsHitResultAllowed(HitResult result) =>
+            result switch
+            {
+                HitResult.Perfect => true,
+                HitResult.Meh => true,
+                _ => false
+            };
+
+        protected override DifficultyRange[] GetRanges() => karaoke_ranges;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/LyricPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/LyricPreview.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay
                         Text = "karaoke"
                     },
                 },
-                HitWindows = new KaraokeHitWindows(),
+                HitWindows = new KaraokeLyricHitWindows(),
             };
 
         private IDictionary<CultureInfo, string> createPreviewTranslate(CultureInfo cultureInfo)

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay
                 StartTime = startTime,
                 Duration = 1000,
                 Text = "Note",
-                HitWindows = new KaraokeHitWindows(),
+                HitWindows = new KaraokeNoteHitWindows(),
             });
 
             notePlayfield.Add(new BarLine

--- a/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Karaoke.UI
         {
             // Practice
             rulesetConfig.BindWith(KaraokeRulesetSetting.PracticePreemptTime, preemptTime);
-            session.BindWith(KaraokeRulesetSession.NowLyric, nowLyric);
+            session.BindWith(KaraokeRulesetSession.NowLyrics, nowLyric);
 
             RegisterPool<Lyric, DrawableLyric>(50);
         }

--- a/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/LyricPlayfield.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.UI
 {
     public class LyricPlayfield : Playfield
     {
-        private readonly Bindable<Lyric[]> nowLyrics = new();
+        private readonly Bindable<Lyric[]> singingLyrics = new();
 
         protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
         {
@@ -31,31 +31,31 @@ namespace osu.Game.Rulesets.Karaoke.UI
 
         private void onLyricStart(DrawableLyric drawableLyric)
         {
-            var lyrics = nowLyrics.Value ?? Array.Empty<Lyric>();
+            var lyrics = singingLyrics.Value ?? Array.Empty<Lyric>();
             var lyric = drawableLyric.HitObject;
 
             if (lyrics.Contains(lyric))
                 return;
 
-            nowLyrics.Value = lyrics.Concat(new[] { lyric }).ToArray();
+            singingLyrics.Value = lyrics.Concat(new[] { lyric }).ToArray();
         }
 
         private void onLyricEnd(DrawableLyric drawableLyric)
         {
-            var lyrics = nowLyrics.Value ?? Array.Empty<Lyric>();
+            var lyrics = singingLyrics.Value ?? Array.Empty<Lyric>();
             var lyric = drawableLyric.HitObject;
 
             if (!lyrics.Contains(lyric))
                 return;
 
-            nowLyrics.Value = lyrics.Where(x => x != lyric).ToArray();
+            singingLyrics.Value = lyrics.Where(x => x != lyric).ToArray();
         }
 
         [BackgroundDependencyLoader]
         private void load(KaraokeSessionStatics session)
         {
             // Practice
-            session.BindWith(KaraokeRulesetSession.NowLyrics, nowLyrics);
+            session.BindWith(KaraokeRulesetSession.SingingLyrics, singingLyrics);
 
             RegisterPool<Lyric, DrawableLyric>(50);
         }

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
     public class LyricsPreview : CompositeDrawable
     {
         private readonly Bindable<double> bindablePreemptTime = new();
-        private readonly Bindable<Lyric[]> selectedLyrics = new();
+        private readonly Bindable<Lyric[]> singingLyrics = new();
 
         private readonly FillFlowContainer<ClickableLyric> lyricTable;
 
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 }
             };
 
-            selectedLyrics.BindValueChanged(value =>
+            singingLyrics.BindValueChanged(value =>
             {
                 var oldValue = value.OldValue;
                 if (oldValue != null)
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
 
             // because playback might not clear singing lyrics, so we should re-assign the lyric here.
             // todo: find a better place.
-            selectedLyrics.Value = new[] { lyric };
+            singingLyrics.Value = new[] { lyric };
         }
 
         public Vector2 Spacing
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
         private void load(KaraokeRulesetConfigManager config, KaraokeSessionStatics session)
         {
             config.BindWith(KaraokeRulesetSetting.PracticePreemptTime, bindablePreemptTime);
-            session.BindWith(KaraokeRulesetSession.NowLyrics, selectedLyrics);
+            session.BindWith(KaraokeRulesetSession.SingingLyrics, singingLyrics);
         }
 
         private class ClickableLyric : ClickableContainer

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
 {
     public class LyricsPreview : CompositeDrawable
     {
-        public Bindable<Lyric> SelectedLyric { get; } = new();
+        public Bindable<Lyric[]> SelectedLyrics { get; } = new();
 
         private readonly FillFlowContainer<ClickableLyric> lyricTable;
 
@@ -43,24 +43,24 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 }
             };
 
-            SelectedLyric.BindValueChanged(value =>
+            SelectedLyrics.BindValueChanged(value =>
             {
                 var oldValue = value.OldValue;
                 if (oldValue != null)
-                    lyricTable.Where(x => x.HitObject == oldValue).ForEach(x => { x.Selected = false; });
+                    lyricTable.Where(x => oldValue.Contains(x.HitObject)).ForEach(x => { x.Selected = false; });
 
                 var newValue = value.NewValue;
                 if (newValue != null)
-                    lyricTable.Where(x => x.HitObject == newValue).ForEach(x => { x.Selected = true; });
+                    lyricTable.Where(x => newValue.Contains(x.HitObject)).ForEach(x => { x.Selected = true; });
             });
         }
 
         private void triggerLyric(Lyric lyric)
         {
-            if (SelectedLyric.Value == lyric)
-                SelectedLyric.TriggerChange();
+            if (SelectedLyrics.Value?.Contains(lyric) ?? false)
+                SelectedLyrics.TriggerChange();
             else
-                SelectedLyric.Value = lyric;
+                SelectedLyrics.Value = new[] { lyric };
         }
 
         public Vector2 Spacing

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -10,8 +10,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
@@ -21,9 +23,13 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
 {
     public class LyricsPreview : CompositeDrawable
     {
-        public Bindable<Lyric[]> SelectedLyrics { get; } = new();
+        private readonly Bindable<double> bindablePreemptTime = new();
+        private readonly Bindable<Lyric[]> selectedLyrics = new();
 
         private readonly FillFlowContainer<ClickableLyric> lyricTable;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
 
         public LyricsPreview(IEnumerable<Lyric> lyrics)
         {
@@ -35,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
                     Direction = FillDirection.Vertical,
-                    Children = lyrics.Select(x => CreateLyricContainer(x).With(c =>
+                    Children = lyrics.Select(x => createLyricContainer(x).With(c =>
                     {
                         c.Selected = false;
                         c.Action = () => triggerLyric(x);
@@ -43,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 }
             };
 
-            SelectedLyrics.BindValueChanged(value =>
+            selectedLyrics.BindValueChanged(value =>
             {
                 var oldValue = value.OldValue;
                 if (oldValue != null)
@@ -55,12 +61,16 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
             });
         }
 
+        private ClickableLyric createLyricContainer(Lyric lyric) => new(lyric);
+
         private void triggerLyric(Lyric lyric)
         {
-            if (SelectedLyrics.Value?.Contains(lyric) ?? false)
-                SelectedLyrics.TriggerChange();
-            else
-                SelectedLyrics.Value = new[] { lyric };
+            double time = lyric.LyricStartTime - bindablePreemptTime.Value;
+            beatmap.Value.Track.Seek(time);
+
+            // because playback might not clear singing lyrics, so we should re-assign the lyric here.
+            // todo: find a better place.
+            selectedLyrics.Value = new[] { lyric };
         }
 
         public Vector2 Spacing
@@ -69,9 +79,14 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
             set => lyricTable.Spacing = value;
         }
 
-        protected virtual ClickableLyric CreateLyricContainer(Lyric lyric) => new(lyric);
+        [BackgroundDependencyLoader]
+        private void load(KaraokeRulesetConfigManager config, KaraokeSessionStatics session)
+        {
+            config.BindWith(KaraokeRulesetSetting.PracticePreemptTime, bindablePreemptTime);
+            session.BindWith(KaraokeRulesetSession.NowLyrics, selectedLyrics);
+        }
 
-        public class ClickableLyric : ClickableContainer
+        private class ClickableLyric : ClickableContainer
         {
             private const float fade_duration = 100;
 
@@ -94,12 +109,12 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                     {
                         RelativeSizeAxes = Axes.Both
                     },
-                    icon = CreateIcon(),
-                    previewLyric = CreateLyric(lyric),
+                    icon = createIcon(),
+                    previewLyric = createLyric(lyric),
                 };
             }
 
-            protected virtual PreviewLyricSpriteText CreateLyric(Lyric lyric) => new(lyric)
+            private PreviewLyricSpriteText createLyric(Lyric lyric) => new(lyric)
             {
                 Font = new FontUsage(size: 25),
                 RubyFont = new FontUsage(size: 10),
@@ -107,7 +122,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 Margin = new MarginPadding { Left = 25 }
             };
 
-            protected virtual Drawable CreateIcon() => new SpriteIcon
+            private Drawable createIcon() => new SpriteIcon
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
         private void load(KaraokeRulesetConfigManager config, KaraokeSessionStatics session)
         {
             preemptTimeSliderBar.Current = config.GetBindable<double>(KaraokeRulesetSetting.PracticePreemptTime);
-            session.BindWith(KaraokeRulesetSession.NowLyrics, lyricsPreview.SelectedLyric);
+            session.BindWith(KaraokeRulesetSession.NowLyrics, lyricsPreview.SelectedLyrics);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
     public class PracticeSettings : PlayerSettingsGroup, IKeyBindingHandler<KaraokeAction>
     {
         private readonly PlayerSliderBar<double> preemptTimeSliderBar;
-        private readonly LyricsPreview lyricsPreview;
 
         public PracticeSettings(IBeatmap beatmap)
             : base("Practice")
@@ -36,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 {
                     Text = "Lyric:"
                 },
-                lyricsPreview = new LyricsPreview(lyrics)
+                new LyricsPreview(lyrics)
                 {
                     Height = 580,
                     RelativeSizeAxes = Axes.X,
@@ -77,10 +76,9 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
         }
 
         [BackgroundDependencyLoader]
-        private void load(KaraokeRulesetConfigManager config, KaraokeSessionStatics session)
+        private void load(KaraokeRulesetConfigManager config)
         {
             preemptTimeSliderBar.Current = config.GetBindable<double>(KaraokeRulesetSetting.PracticePreemptTime);
-            session.BindWith(KaraokeRulesetSession.NowLyrics, lyricsPreview.SelectedLyrics);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/PracticeSettings.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
         private void load(KaraokeRulesetConfigManager config, KaraokeSessionStatics session)
         {
             preemptTimeSliderBar.Current = config.GetBindable<double>(KaraokeRulesetSetting.PracticePreemptTime);
-            session.BindWith(KaraokeRulesetSession.NowLyric, lyricsPreview.SelectedLyric);
+            session.BindWith(KaraokeRulesetSession.NowLyrics, lyricsPreview.SelectedLyric);
         }
     }
 }


### PR DESCRIPTION
What's done in this PR:]
- Make lyric and notes has it's own hit windows(Because lyric is not scored).
- Rename enum in the session config.
- Make session config support multiple singing lyrics at the same time.
- Refactor the logic to collect the start/end lyric.