### PR TITLE
Refactor the usage of DefaultLyricPiece

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
@@ -10,9 +10,9 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Extensions;
+using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
-using osu.Game.Rulesets.Karaoke.Skinning.Default;
 using osu.Game.Rulesets.Karaoke.Skinning.Elements;
 using osu.Game.Rulesets.Karaoke.Skinning.Tools;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -21,7 +21,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
 {
-    public class EditorLyricPiece : DefaultLyricPiece<EditorLyricPiece.EditorLyricSpriteText>
+    public class EditorLyricPiece : DrawableKaraokeSpriteText<EditorLyricPiece.EditorLyricSpriteText>
     {
         private const int time_tag_spacing = 8;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/EditorLyricPiece.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components
         public Vector2 GetTimeTagPosition(TimeTag timeTag)
         {
             var basePosition = GetTextIndexPosition(timeTag.Index);
-            float extraPosition = extraSpacing(TimeTagsBindable, timeTag);
+            float extraPosition = extraSpacing(HitObject.TimeTags, timeTag);
             return basePosition + new Vector2(extraPosition, 0);
 
             static float extraSpacing(IEnumerable<TimeTag> timeTagsInLyric, TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -21,7 +20,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
 {
     public abstract class TimeTagEditorScrollContainer : EditorScrollContainer
     {
+        private readonly IBindable<int> timeTagsVersion = new Bindable<int>();
         private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();
+
         private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
         protected readonly IBindable<bool> ShowWaveformGraph = new BindableBool();
@@ -42,31 +43,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
             HitObject = lyric;
             RelativeSizeAxes = Axes.X;
 
-            timeTagsBindable.BindCollectionChanged((_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var obj in args.NewItems.OfType<TimeTag>())
-                        {
-                            obj.TimeBindable.BindValueChanged(_ =>
-                            {
-                                updateTimeRange();
-                            });
-                        }
+            timeTagsVersion.BindValueChanged(_ => updateTimeRange());
+            timeTagsBindable.BindCollectionChanged((_, _) => updateTimeRange());
 
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var obj in args.OldItems.OfType<TimeTag>())
-                        {
-                            obj.TimeBindable.UnbindEvents();
-                        }
-
-                        break;
-                }
-            });
-
+            timeTagsVersion.BindTo(lyric.TimeTagsVersion);
             timeTagsBindable.BindTo(lyric.TimeTagsBindable);
 
             updateTimeRange();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/Components/TimeTagEditorScrollContainer.cs
@@ -21,16 +21,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
 {
     public abstract class TimeTagEditorScrollContainer : EditorScrollContainer
     {
-        protected readonly IBindableList<TimeTag> TimeTagsBindable = new BindableList<TimeTag>();
-
-        protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
+        private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();
+        private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
         protected readonly IBindable<bool> ShowWaveformGraph = new BindableBool();
-
         protected readonly IBindable<float> WaveformOpacity = new BindableFloat();
-
         protected readonly IBindable<bool> ShowTick = new BindableBool();
-
         protected readonly IBindable<float> TickOpacity = new BindableFloat();
 
         protected double StartTime { get; private set; }
@@ -46,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
             HitObject = lyric;
             RelativeSizeAxes = Axes.X;
 
-            TimeTagsBindable.BindCollectionChanged((_, args) =>
+            timeTagsBindable.BindCollectionChanged((_, args) =>
             {
                 switch (args.Action)
                 {
@@ -71,15 +67,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
                 }
             });
 
-            TimeTagsBindable.BindTo(lyric.TimeTagsBindable);
+            timeTagsBindable.BindTo(lyric.TimeTagsBindable);
 
             updateTimeRange();
         }
 
         private void updateTimeRange()
         {
-            var fistTimeTag = TimeTagsBindable.FirstOrDefault();
-            var lastTimeTag = TimeTagsBindable.LastOrDefault();
+            var fistTimeTag = timeTagsBindable.FirstOrDefault();
+            var lastTimeTag = timeTagsBindable.LastOrDefault();
 
             if (fistTimeTag != null && lastTimeTag != null)
             {
@@ -100,7 +96,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, IBindable<WorkingBeatmap> beatmap)
         {
-            Beatmap.BindTo(beatmap);
+            this.beatmap.BindTo(beatmap);
 
             Container container;
 
@@ -124,7 +120,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.Components
 
             PostProcessContent(container);
 
-            Beatmap.BindValueChanged(b =>
+            this.beatmap.BindValueChanged(b =>
             {
                 waveform.Waveform = b.NewValue.Waveform;
                 Track = b.NewValue.Track;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/TimeTagLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/TimeTagLayer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Parts;
@@ -14,22 +16,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows
         [Resolved]
         private EditorLyricPiece lyricPiece { get; set; }
 
+        private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();
+
         public TimeTagLayer(Lyric lyric)
         {
-            lyric.TimeTagsBindable.BindCollectionChanged((_, _) =>
+            timeTagsBindable.BindCollectionChanged((_, _) =>
             {
                 ScheduleAfterChildren(updateTimeTags);
-            }, true);
+            });
+
+            timeTagsBindable.BindTo(lyric.TimeTagsBindable);
         }
 
         private void updateTimeTags()
         {
             ClearInternal();
-            var timeTags = lyricPiece.TimeTagsBindable;
-            if (timeTags == null)
-                return;
 
-            foreach (var timeTag in timeTags)
+            foreach (var timeTag in timeTagsBindable)
             {
                 var position = lyricPiece.GetTimeTagPosition(timeTag);
                 AddInternal(new DrawableTimeTag(timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/Components/TranslateLyricSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/Components/TranslateLyricSpriteText.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Translate.Components
 {
-    public class TranslateLyricSpriteText : PreviewLyricSpriteText, IHasCustomTooltip<Lyric>
+    public class TranslateLyricSpriteText : DrawableLyricSpriteText, IHasCustomTooltip<Lyric>
     {
         public TranslateLyricSpriteText(Lyric hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Karaoke/Edit/Translate/Components/TranslateLyricSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Translate/Components/TranslateLyricSpriteText.cs
@@ -13,10 +13,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Translate.Components
         public TranslateLyricSpriteText(Lyric hitObject)
             : base(hitObject)
         {
+            TooltipContent = hitObject;
         }
 
         public ITooltip<Lyric> GetCustomTooltip() => new LyricTooltip();
 
-        public Lyric TooltipContent => HitObject;
+        public Lyric TooltipContent { get; }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/LyricToolTip.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
 
             lastLyric = lyric;
 
-            Child = new PreviewLyricSpriteText(lyric)
+            Child = new DrawableLyricSpriteText(lyric)
             {
                 Margin = new MarginPadding(10),
                 Font = new FontUsage(size: 32),

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
@@ -1,0 +1,183 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
+{
+    public class DrawableKaraokeSpriteText<TSpriteText> : KaraokeSpriteText<TSpriteText> where TSpriteText : LyricSpriteText, new()
+    {
+        private const int whole_chunk_index = -1;
+
+        public readonly IBindable<string> TextBindable = new Bindable<string>();
+        public readonly IBindableList<TimeTag> TimeTagsBindable = new BindableList<TimeTag>();
+        public readonly IBindableList<RubyTag> RubyTagsBindable = new BindableList<RubyTag>();
+        public readonly IBindableList<RomajiTag> RomajiTagsBindable = new BindableList<RomajiTag>();
+
+        private readonly Lyric hitObject;
+        private readonly int chunkIndex;
+
+        protected DrawableKaraokeSpriteText(Lyric hitObject, int chunkIndex = whole_chunk_index)
+        {
+            this.hitObject = hitObject;
+            this.chunkIndex = chunkIndex;
+
+            TextBindable.BindValueChanged(text => applyText(text.NewValue));
+            TimeTagsBindable.BindCollectionChanged((_, _) => applyTimeTag(TimeTagsBindable));
+            RubyTagsBindable.BindCollectionChanged((_, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var obj in args.NewItems.OfType<RubyTag>())
+                        {
+                            obj.StartIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
+                            obj.EndIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
+                            obj.TextBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
+                        }
+
+                        break;
+
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var obj in args.OldItems.OfType<RubyTag>())
+                        {
+                            obj.StartIndexBindable.UnbindEvents();
+                            obj.EndIndexBindable.UnbindEvents();
+                            obj.TextBindable.UnbindEvents();
+                        }
+
+                        break;
+                }
+
+                applyRuby(RubyTagsBindable);
+            });
+            RomajiTagsBindable.BindCollectionChanged((_, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var obj in args.NewItems.OfType<RomajiTag>())
+                        {
+                            obj.StartIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
+                            obj.EndIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
+                            obj.TextBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
+                        }
+
+                        break;
+
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var obj in args.OldItems.OfType<RomajiTag>())
+                        {
+                            obj.StartIndexBindable.UnbindEvents();
+                            obj.EndIndexBindable.UnbindEvents();
+                            obj.TextBindable.UnbindEvents();
+                        }
+
+                        break;
+                }
+
+                applyRomaji(RomajiTagsBindable);
+            });
+
+            TextBindable.BindTo(hitObject.TextBindable);
+            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
+            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
+            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
+        }
+
+        private void applyText(string text)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Text = text;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyTimeTag(IEnumerable<TimeTag> timeTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                TimeTags = TimeTagsUtils.ToDictionary(timeTags.ToList());
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyRuby(IEnumerable<RubyTag> rubyTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Rubies = DisplayRuby ? rubyTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private void applyRomaji(IEnumerable<RomajiTag> romajiTags)
+        {
+            if (chunkIndex == whole_chunk_index)
+            {
+                Romajies = DisplayRomaji ? romajiTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+            }
+            else
+            {
+                throw new NotImplementedException("Chunk lyric will be available until V2");
+            }
+        }
+
+        private bool displayRuby = true;
+
+        public bool DisplayRuby
+        {
+            get => displayRuby;
+            set
+            {
+                if (displayRuby == value)
+                    return;
+
+                displayRuby = value;
+                Schedule(() => applyRuby(hitObject.RubyTags));
+            }
+        }
+
+        private bool displayRomaji = true;
+
+        public bool DisplayRomaji
+        {
+            get => displayRomaji;
+            set
+            {
+                if (displayRomaji == value)
+                    return;
+
+                displayRomaji = value;
+                Schedule(() => applyRomaji(hitObject.RomajiTags));
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            TextBindable.UnbindFrom(hitObject.TextBindable);
+            TimeTagsBindable.UnbindFrom(hitObject.TimeTagsBindable);
+            RubyTagsBindable.UnbindFrom(hitObject.RubyTagsBindable);
+            RomajiTagsBindable.UnbindFrom(hitObject.RomajiTagsBindable);
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -16,87 +14,42 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
     {
         private const int whole_chunk_index = -1;
 
-        public readonly IBindable<string> TextBindable = new Bindable<string>();
-        public readonly IBindableList<TimeTag> TimeTagsBindable = new BindableList<TimeTag>();
-        public readonly IBindableList<RubyTag> RubyTagsBindable = new BindableList<RubyTag>();
-        public readonly IBindableList<RomajiTag> RomajiTagsBindable = new BindableList<RomajiTag>();
+        private readonly IBindable<string> textBindable = new Bindable<string>();
+        private readonly IBindable<int> timeTagsVersion = new Bindable<int>();
+        private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();
+        private readonly IBindable<int> rubyTagsVersion = new Bindable<int>();
+        private readonly IBindableList<RubyTag> rubyTagsBindable = new BindableList<RubyTag>();
+        private readonly IBindable<int> romajiTagsVersion = new Bindable<int>();
+        private readonly IBindableList<RomajiTag> romajiTagsBindable = new BindableList<RomajiTag>();
 
-        private readonly Lyric hitObject;
         private readonly int chunkIndex;
 
-        protected DrawableKaraokeSpriteText(Lyric hitObject, int chunkIndex = whole_chunk_index)
+        protected DrawableKaraokeSpriteText(Lyric lyric, int chunkIndex = whole_chunk_index)
         {
-            this.hitObject = hitObject;
             this.chunkIndex = chunkIndex;
 
-            TextBindable.BindValueChanged(text => applyText(text.NewValue));
-            TimeTagsBindable.BindCollectionChanged((_, _) => applyTimeTag(TimeTagsBindable));
-            RubyTagsBindable.BindCollectionChanged((_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var obj in args.NewItems.OfType<RubyTag>())
-                        {
-                            obj.StartIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                            obj.EndIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                            obj.TextBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                        }
+            textBindable.BindValueChanged(_ => updateText(), true);
+            timeTagsVersion.BindValueChanged(_ => updateTimeTags());
+            timeTagsBindable.BindCollectionChanged((_, _) => updateTimeTags());
+            rubyTagsVersion.BindValueChanged(_ => updateRubies());
+            rubyTagsBindable.BindCollectionChanged((_, _) => updateRubies());
+            romajiTagsVersion.BindValueChanged(_ => updateRubies());
+            romajiTagsBindable.BindCollectionChanged((_, _) => updateRomajies());
 
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var obj in args.OldItems.OfType<RubyTag>())
-                        {
-                            obj.StartIndexBindable.UnbindEvents();
-                            obj.EndIndexBindable.UnbindEvents();
-                            obj.TextBindable.UnbindEvents();
-                        }
-
-                        break;
-                }
-
-                applyRuby(RubyTagsBindable);
-            });
-            RomajiTagsBindable.BindCollectionChanged((_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var obj in args.NewItems.OfType<RomajiTag>())
-                        {
-                            obj.StartIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                            obj.EndIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                            obj.TextBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                        }
-
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var obj in args.OldItems.OfType<RomajiTag>())
-                        {
-                            obj.StartIndexBindable.UnbindEvents();
-                            obj.EndIndexBindable.UnbindEvents();
-                            obj.TextBindable.UnbindEvents();
-                        }
-
-                        break;
-                }
-
-                applyRomaji(RomajiTagsBindable);
-            });
-
-            TextBindable.BindTo(hitObject.TextBindable);
-            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
-            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
-            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
+            textBindable.BindTo(lyric.TextBindable);
+            timeTagsVersion.BindTo(lyric.TimeTagsVersion);
+            timeTagsBindable.BindTo(lyric.TimeTagsBindable);
+            rubyTagsVersion.BindTo(lyric.RubyTagsVersion);
+            rubyTagsBindable.BindTo(lyric.RubyTagsBindable);
+            romajiTagsVersion.BindTo(lyric.RomajiTagsVersion);
+            romajiTagsBindable.BindTo(lyric.RomajiTagsBindable);
         }
 
-        private void applyText(string text)
+        private void updateText()
         {
             if (chunkIndex == whole_chunk_index)
             {
-                Text = text;
+                Text = textBindable.Value;
             }
             else
             {
@@ -104,11 +57,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void applyTimeTag(IEnumerable<TimeTag> timeTags)
+        private void updateTimeTags()
         {
             if (chunkIndex == whole_chunk_index)
             {
-                TimeTags = TimeTagsUtils.ToDictionary(timeTags.ToList());
+                TimeTags = TimeTagsUtils.ToDictionary(timeTagsBindable.ToList());
             }
             else
             {
@@ -116,11 +69,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void applyRuby(IEnumerable<RubyTag> rubyTags)
+        private void updateRubies()
         {
             if (chunkIndex == whole_chunk_index)
             {
-                Rubies = DisplayRuby ? rubyTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+                Rubies = DisplayRuby ? rubyTagsBindable?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
             }
             else
             {
@@ -128,11 +81,11 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void applyRomaji(IEnumerable<RomajiTag> romajiTags)
+        private void updateRomajies()
         {
             if (chunkIndex == whole_chunk_index)
             {
-                Romajies = DisplayRomaji ? romajiTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
+                Romajies = DisplayRomaji ? romajiTagsBindable?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
             }
             else
             {
@@ -151,7 +104,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
                     return;
 
                 displayRuby = value;
-                Schedule(() => applyRuby(hitObject.RubyTags));
+                Schedule(updateRubies);
             }
         }
 
@@ -166,18 +119,8 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
                     return;
 
                 displayRomaji = value;
-                Schedule(() => applyRomaji(hitObject.RomajiTags));
+                Schedule(updateRomajies);
             }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            TextBindable.UnbindFrom(hitObject.TextBindable);
-            TimeTagsBindable.UnbindFrom(hitObject.TimeTagsBindable);
-            RubyTagsBindable.UnbindFrom(hitObject.RubyTagsBindable);
-            RomajiTagsBindable.UnbindFrom(hitObject.RomajiTagsBindable);
-
-            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableLyricSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableLyricSpriteText.cs
@@ -7,11 +7,11 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
 {
-    public class PreviewLyricSpriteText : LyricSpriteText
+    public class DrawableLyricSpriteText : LyricSpriteText
     {
         public readonly Lyric HitObject;
 
-        public PreviewLyricSpriteText(Lyric hitObject)
+        public DrawableLyricSpriteText(Lyric hitObject)
         {
             HitObject = hitObject;
 

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableLyricSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableLyricSpriteText.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -9,15 +10,35 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
 {
     public class DrawableLyricSpriteText : LyricSpriteText
     {
-        public readonly Lyric HitObject;
+        private readonly IBindable<string> textBindable = new Bindable<string>();
+        private readonly IBindable<int> rubyTagsVersion = new Bindable<int>();
+        private readonly IBindableList<RubyTag> rubyTagsBindable = new BindableList<RubyTag>();
+        private readonly IBindable<int> romajiTagsVersion = new Bindable<int>();
+        private readonly IBindableList<RomajiTag> romajiTagsBindable = new BindableList<RomajiTag>();
 
-        public DrawableLyricSpriteText(Lyric hitObject)
+        public DrawableLyricSpriteText(Lyric lyric)
         {
-            HitObject = hitObject;
+            textBindable.BindValueChanged(text => { Text = text.NewValue; }, true);
+            rubyTagsVersion.BindValueChanged(_ => updateRubies());
+            rubyTagsBindable.BindCollectionChanged((_, _) => updateRubies());
+            romajiTagsVersion.BindValueChanged(_ => updateRubies());
+            romajiTagsBindable.BindCollectionChanged((_, _) => updateRomajies());
 
-            hitObject.TextBindable.BindValueChanged(text => { Text = text.NewValue; }, true);
-            hitObject.RubyTagsBindable.BindCollectionChanged((_, _) => { Rubies = hitObject.RubyTagsBindable.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray(); }, true);
-            hitObject.RomajiTagsBindable.BindCollectionChanged((_, _) => { Romajies = hitObject.RomajiTagsBindable.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray(); }, true);
+            textBindable.BindTo(lyric.TextBindable);
+            rubyTagsVersion.BindTo(lyric.RubyTagsVersion);
+            rubyTagsBindable.BindTo(lyric.RubyTagsBindable);
+            romajiTagsVersion.BindTo(lyric.RomajiTagsVersion);
+            romajiTagsBindable.BindTo(lyric.RomajiTagsBindable);
+        }
+
+        private void updateRubies()
+        {
+            Rubies = rubyTagsBindable.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray();
+        }
+
+        private void updateRomajies()
+        {
+            Romajies = romajiTagsBindable.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -9,6 +10,18 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 {
     public class RomajiTag : ITextTag
     {
+        /// <summary>
+        /// Invoked when any property of this <see cref="RomajiTag"/> is changed.
+        /// </summary>
+        public event Action Changed;
+
+        public RomajiTag()
+        {
+            TextBindable.ValueChanged += _ => Changed?.Invoke();
+            StartIndexBindable.ValueChanged += _ => Changed?.Invoke();
+            EndIndexBindable.ValueChanged += _ => Changed?.Invoke();
+        }
+
         [JsonIgnore]
         public readonly Bindable<string> TextBindable = new();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -9,6 +10,18 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 {
     public class RubyTag : ITextTag
     {
+        /// <summary>
+        /// Invoked when any property of this <see cref="RubyTag"/> is changed.
+        /// </summary>
+        public event Action Changed;
+
+        public RubyTag()
+        {
+            TextBindable.ValueChanged += _ => Changed?.Invoke();
+            StartIndexBindable.ValueChanged += _ => Changed?.Invoke();
+            EndIndexBindable.ValueChanged += _ => Changed?.Invoke();
+        }
+
         [JsonIgnore]
         public readonly Bindable<string> TextBindable = new();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 
@@ -8,10 +10,17 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 {
     public class TimeTag
     {
+        /// <summary>
+        /// Invoked when any property of this <see cref="RubyTag"/> is changed.
+        /// </summary>
+        public event Action Changed;
+
         public TimeTag(TextIndex index, double? time = null)
         {
             Index = index;
             Time = time;
+
+            TimeBindable.ValueChanged += _ => Changed?.Invoke();
         }
 
         /// <summary>
@@ -20,6 +29,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// </summary>
         public TextIndex Index { get; }
 
+        [JsonIgnore]
         public readonly Bindable<double?> TimeBindable = new();
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/DefaultLyricPiece.cs
@@ -1,199 +1,22 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Default
 {
     /// <summary>
     /// This component is focusing on display ruby and romaji.
     /// </summary>
-    public class DefaultLyricPiece : DefaultLyricPiece<LyricSpriteText>
+    public class DefaultLyricPiece : DrawableKaraokeSpriteText<LyricSpriteText>
     {
         private const int whole_chunk_index = -1;
 
         public DefaultLyricPiece(Lyric hitObject, int chunkIndex = whole_chunk_index)
             : base(hitObject, chunkIndex)
         {
-        }
-    }
-
-    /// <summary>
-    /// This component is focusing on display ruby and romaji.
-    /// </summary>
-    public abstract class DefaultLyricPiece<T> : KaraokeSpriteText<T> where T : LyricSpriteText, new()
-    {
-        private const int whole_chunk_index = -1;
-
-        public readonly IBindable<string> TextBindable = new Bindable<string>();
-        public readonly IBindableList<TimeTag> TimeTagsBindable = new BindableList<TimeTag>();
-        public readonly IBindableList<RubyTag> RubyTagsBindable = new BindableList<RubyTag>();
-        public readonly IBindableList<RomajiTag> RomajiTagsBindable = new BindableList<RomajiTag>();
-
-        private readonly Lyric hitObject;
-        private readonly int chunkIndex;
-
-        protected DefaultLyricPiece(Lyric hitObject, int chunkIndex = whole_chunk_index)
-        {
-            this.hitObject = hitObject;
-            this.chunkIndex = chunkIndex;
-
-            TextBindable.BindValueChanged(text => applyText(text.NewValue));
-            TimeTagsBindable.BindCollectionChanged((_, _) => applyTimeTag(TimeTagsBindable));
-            RubyTagsBindable.BindCollectionChanged((_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var obj in args.NewItems.OfType<RubyTag>())
-                        {
-                            obj.StartIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                            obj.EndIndexBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                            obj.TextBindable.BindValueChanged(_ => applyRuby(RubyTagsBindable));
-                        }
-
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var obj in args.OldItems.OfType<RubyTag>())
-                        {
-                            obj.StartIndexBindable.UnbindEvents();
-                            obj.EndIndexBindable.UnbindEvents();
-                            obj.TextBindable.UnbindEvents();
-                        }
-
-                        break;
-                }
-
-                applyRuby(RubyTagsBindable);
-            });
-            RomajiTagsBindable.BindCollectionChanged((_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var obj in args.NewItems.OfType<RomajiTag>())
-                        {
-                            obj.StartIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                            obj.EndIndexBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                            obj.TextBindable.BindValueChanged(_ => applyRomaji(RomajiTagsBindable));
-                        }
-
-                        break;
-
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var obj in args.OldItems.OfType<RomajiTag>())
-                        {
-                            obj.StartIndexBindable.UnbindEvents();
-                            obj.EndIndexBindable.UnbindEvents();
-                            obj.TextBindable.UnbindEvents();
-                        }
-
-                        break;
-                }
-
-                applyRomaji(RomajiTagsBindable);
-            });
-
-            TextBindable.BindTo(hitObject.TextBindable);
-            TimeTagsBindable.BindTo(hitObject.TimeTagsBindable);
-            RubyTagsBindable.BindTo(hitObject.RubyTagsBindable);
-            RomajiTagsBindable.BindTo(hitObject.RomajiTagsBindable);
-        }
-
-        private void applyText(string text)
-        {
-            if (chunkIndex == whole_chunk_index)
-            {
-                Text = text;
-            }
-            else
-            {
-                throw new NotImplementedException("Chunk lyric will be available until V2");
-            }
-        }
-
-        private void applyTimeTag(IEnumerable<TimeTag> timeTags)
-        {
-            if (chunkIndex == whole_chunk_index)
-            {
-                TimeTags = TimeTagsUtils.ToDictionary(timeTags.ToList());
-            }
-            else
-            {
-                throw new NotImplementedException("Chunk lyric will be available until V2");
-            }
-        }
-
-        private void applyRuby(IEnumerable<RubyTag> rubyTags)
-        {
-            if (chunkIndex == whole_chunk_index)
-            {
-                Rubies = DisplayRuby ? rubyTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
-            }
-            else
-            {
-                throw new NotImplementedException("Chunk lyric will be available until V2");
-            }
-        }
-
-        private void applyRomaji(IEnumerable<RomajiTag> romajiTags)
-        {
-            if (chunkIndex == whole_chunk_index)
-            {
-                Romajies = DisplayRomaji ? romajiTags?.Select(x => new PositionText(x.Text, x.StartIndex, x.EndIndex)).ToArray() : null;
-            }
-            else
-            {
-                throw new NotImplementedException("Chunk lyric will be available until V2");
-            }
-        }
-
-        private bool displayRuby = true;
-
-        public bool DisplayRuby
-        {
-            get => displayRuby;
-            set
-            {
-                if (displayRuby == value)
-                    return;
-
-                displayRuby = value;
-                Schedule(() => applyRuby(hitObject.RubyTags));
-            }
-        }
-
-        private bool displayRomaji = true;
-
-        public bool DisplayRomaji
-        {
-            get => displayRomaji;
-            set
-            {
-                if (displayRomaji == value)
-                    return;
-
-                displayRomaji = value;
-                Schedule(() => applyRomaji(hitObject.RomajiTags));
-            }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            TextBindable.UnbindFrom(hitObject.TextBindable);
-            TimeTagsBindable.UnbindFrom(hitObject.TimeTagsBindable);
-            RubyTagsBindable.UnbindFrom(hitObject.RubyTagsBindable);
-            RomajiTagsBindable.UnbindFrom(hitObject.RomajiTagsBindable);
-
-            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
+++ b/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
@@ -97,11 +97,11 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                 {
                     var oldValue = value.OldValue;
                     if (oldValue != null)
-                        lyricTable.Where(x => x.HitObject == oldValue).ForEach(x => { x.Selected = false; });
+                        lyricTable.Where(x => x.Lyric == oldValue).ForEach(x => { x.Selected = false; });
 
                     var newValue = value.NewValue;
                     if (newValue != null)
-                        lyricTable.Where(x => x.HitObject == newValue).ForEach(x => { x.Selected = true; });
+                        lyricTable.Where(x => x.Lyric == newValue).ForEach(x => { x.Selected = true; });
                 });
             }
 
@@ -132,8 +132,12 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                 private readonly Drawable icon;
                 private readonly DrawableLyricSpriteText drawableLyric;
 
+                public Lyric Lyric;
+
                 public ClickableLyric(Lyric lyric)
                 {
+                    Lyric = lyric;
+
                     AutoSizeAxes = Axes.Y;
                     RelativeSizeAxes = Axes.X;
                     Masking = true;
@@ -182,8 +186,6 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                         drawableLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
                     }
                 }
-
-                public Lyric HitObject => drawableLyric.HitObject;
 
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)

--- a/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
+++ b/osu.Game.Rulesets.Karaoke/Statistics/SaitenResultGraph.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
 
                 private readonly Box background;
                 private readonly Drawable icon;
-                private readonly PreviewLyricSpriteText previewLyric;
+                private readonly DrawableLyricSpriteText drawableLyric;
 
                 public ClickableLyric(Lyric lyric)
                 {
@@ -145,11 +145,11 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                             RelativeSizeAxes = Axes.Both
                         },
                         icon = CreateIcon(),
-                        previewLyric = CreateLyric(lyric),
+                        drawableLyric = CreateLyric(lyric),
                     };
                 }
 
-                protected virtual PreviewLyricSpriteText CreateLyric(Lyric lyric) => new(lyric)
+                protected virtual DrawableLyricSpriteText CreateLyric(Lyric lyric) => new(lyric)
                 {
                     Font = new FontUsage(size: 25),
                     RubyFont = new FontUsage(size: 10),
@@ -179,11 +179,11 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
 
                         background.FadeTo(Selected ? 1 : 0, fade_duration);
                         icon.FadeTo(Selected ? 1 : 0, fade_duration);
-                        previewLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
+                        drawableLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
                     }
                 }
 
-                public Lyric HitObject => previewLyric.HitObject;
+                public Lyric HitObject => drawableLyric.HitObject;
 
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)
@@ -191,7 +191,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                     hoverTextColour = colours.Yellow;
                     idolTextColour = colours.Gray9;
 
-                    previewLyric.Colour = idolTextColour;
+                    drawableLyric.Colour = idolTextColour;
                     background.Colour = colours.Blue;
                     background.Alpha = 0;
                     icon.Colour = hoverTextColour;
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                 {
                 }
 
-                protected override PreviewLyricSpriteText CreateLyric(Lyric lyric)
+                protected override DrawableLyricSpriteText CreateLyric(Lyric lyric)
                     => new(lyric)
                     {
                         Font = new FontUsage(size: 15),

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
 
             private readonly Box background;
             private readonly Drawable icon;
-            private readonly PreviewLyricSpriteText previewLyric;
+            private readonly DrawableLyricSpriteText drawableLyric;
 
             public ClickableLyric(Lyric lyric)
             {
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                         Margin = new MarginPadding { Left = 5 },
                         Alpha = 0,
                     },
-                    previewLyric = new PreviewLyricSpriteText(lyric)
+                    drawableLyric = new DrawableLyricSpriteText(lyric)
                     {
                         Font = new FontUsage(size: 25),
                         RubyFont = new FontUsage(size: 10),
@@ -141,11 +141,11 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
 
                     background.FadeTo(Selected ? 1 : 0, fade_duration);
                     icon.FadeTo(Selected ? 1 : 0, fade_duration);
-                    previewLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
+                    drawableLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
                 }
             }
 
-            public Lyric HitObject => previewLyric.HitObject;
+            public Lyric HitObject => drawableLyric.HitObject;
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                 hoverTextColour = colours.Yellow;
                 idolTextColour = colours.Gray9;
 
-                previewLyric.Colour = idolTextColour;
+                drawableLyric.Colour = idolTextColour;
                 background.Colour = colours.Blue;
                 icon.Colour = hoverTextColour;
             }

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -48,11 +48,11 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
             {
                 var oldValue = value.OldValue;
                 if (oldValue != null)
-                    lyricTable.Where(x => oldValue.Contains(x.HitObject)).ForEach(x => { x.Selected = false; });
+                    lyricTable.Where(x => oldValue.Contains(x.Lyric)).ForEach(x => { x.Selected = false; });
 
                 var newValue = value.NewValue;
                 if (newValue != null)
-                    lyricTable.Where(x => newValue.Contains(x.HitObject)).ForEach(x => { x.Selected = true; });
+                    lyricTable.Where(x => newValue.Contains(x.Lyric)).ForEach(x => { x.Selected = true; });
             });
 
             Schedule(() =>
@@ -96,8 +96,12 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
             private readonly Drawable icon;
             private readonly DrawableLyricSpriteText drawableLyric;
 
+            public readonly Lyric Lyric;
+
             public ClickableLyric(Lyric lyric)
             {
+                Lyric = lyric;
+
                 AutoSizeAxes = Axes.Y;
                 RelativeSizeAxes = Axes.X;
                 Masking = true;
@@ -144,8 +148,6 @@ namespace osu.Game.Rulesets.Karaoke.UI.PlayerSettings
                     drawableLyric.FadeColour(Selected ? hoverTextColour : idolTextColour, fade_duration);
                 }
             }
-
-            public Lyric HitObject => drawableLyric.HitObject;
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)


### PR DESCRIPTION
Closes issue #1288

What's done in this PR:
- Add Changed action in the ruby, romaji and time-tag.
- Add ruby, romaji and time-tag version in the lyric class.
- Rename some base drawable karaoke or lyric sprite text, and give them the better namespace.
- Refactor those classes.