### PR TITLE
Update font package to fix the render issue.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="Octokit" Version="0.51.0" />
-    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.426.0" />
+    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.502.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.327.0" />
     <PackageReference Include="ppy.osu.Game" Version="2022.501.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />


### PR DESCRIPTION
Fix render issue by https://github.com/karaoke-dev/osu-framework-font/pull/169
Also, tested if works in the current project because `karaoke sprite text` only support single shader now.

Before:
![image](https://user-images.githubusercontent.com/9100368/166245513-31096b9b-1677-490d-b263-76d12f7b668c.png)

After:
![image](https://user-images.githubusercontent.com/9100368/166246210-b635a803-355e-4a99-8255-d5bff37b5c98.png)

Seems around 10 fps of improvement.