### PR TITLE
Update font package

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
         {
             if (chunkIndex == whole_chunk_index)
             {
-                TimeTags = TimeTagsUtils.ToDictionary(timeTagsBindable.ToList());
+                TimeTags = TimeTagsUtils.ToTimeBasedDictionary(timeTagsBindable.ToList());
             }
             else
             {

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -291,6 +291,29 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         /// <summary>
+        /// Convert list of time tag to dictionary.
+        /// Used for apply the time-tag to the <see cref="KaraokeSpriteText"/>
+        /// </summary>
+        /// <param name="timeTags">Time tags</param>
+        /// <param name="applyFix">Should auto-fix or not</param>
+        /// <param name="other">Fix way</param>
+        /// <param name="self">Fix way</param>
+        /// <returns>Time tags with dictionary format.</returns>
+        public static IReadOnlyDictionary<double, TextIndex> ToTimeBasedDictionary(IList<TimeTag> timeTags, bool applyFix = true, GroupCheck other = GroupCheck.Asc,
+                                                                                   SelfCheck self = SelfCheck.BasedOnStart)
+        {
+            if (timeTags == null)
+                return new Dictionary<double, TextIndex>();
+
+            // sorted value
+            var sortedTimeTags = applyFix ? FixOverlapping(timeTags, other, self) : Sort(timeTags);
+
+            // convert to dictionary, will get start's smallest time and end's largest time.
+            return sortedTimeTags.Where(x => x.Time != null)
+                                 .ToDictionary(k => k.Time ?? throw new ArgumentNullException(nameof(k)), v => v.Index);
+        }
+
+        /// <summary>
         /// Convert dictionary to list of time tags.
         /// </summary>
         /// <param name="dictionary">Dictionary.</param>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -266,6 +266,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         /// <summary>
         /// Convert list of time tag to dictionary.
+        /// todo: this method will be removed eventually.
         /// </summary>
         /// <param name="timeTags">Time tags</param>
         /// <param name="applyFix">Should auto-fix or not</param>

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="Octokit" Version="0.51.0" />
-    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.505.0" />
+    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.507.1" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.327.0" />
     <PackageReference Include="ppy.osu.Game" Version="2022.501.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />


### PR DESCRIPTION
Update font package and fix the compile error caused in the https://github.com/karaoke-dev/osu-framework-font/pull/181
Also, remove duplicated time-tag job is implemented in the https://github.com/karaoke-dev/osu-framework-font/pull/186