### PR TITLE
Fix the style in the change log.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangelogBuild.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets.Karaoke.Localisation;
 using osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
 using osuTK.Graphics;
 
@@ -70,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog
                         {
                             new OsuSpriteText
                             {
-                                Text = CommonStrings.RulesetName,
+                                Text = "Karaoke!",
                                 Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 19),
                             },
                             new OsuSpriteText


### PR DESCRIPTION
Closes issue #1299

Seems it's the default behavior, only left-side navigation cannot be scrolled