### PR TITLE
Fix call bindable change issue in hit object.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
@@ -31,7 +31,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
             {
                 StartTime = 100,
                 Duration = 800,
-                Text = "カラオケ"
+                Text = "カラオケ",
+                ParentLyric = new Lyric()
             };
             note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
@@ -116,6 +116,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.UI
                     Duration = duration,
                     Tone = new Tone { Scale = tone },
                     Text = "Here",
+                    ParentLyric = new Lyric(),
                     Display = true
                 };
                 note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/FixedInfo/LockInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/FixedInfo/LockInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -34,9 +35,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.FixedInfo
 
         private readonly Lyric lyric;
 
+        private readonly IBindable<LockState> bindableLockState;
+
         public LockInfo(Lyric lyric)
         {
             this.lyric = lyric;
+            bindableLockState = lyric.LockBindable.GetBoundCopy();
 
             Size = new Vector2(12);
         }
@@ -44,7 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.FixedInfo
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            lyric.LockBindable.BindValueChanged(value =>
+            bindableLockState.BindValueChanged(value =>
             {
                 switch (value.NewValue)
                 {
@@ -71,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.FixedInfo
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (lyric.Lock == LockState.None)
+            if (bindableLockState.Value == LockState.None)
             {
                 // should mark lyric as selected for able to apply the lock state.
                 lyricCaretState.MoveCaretToTargetPosition(lyric);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/FixedInfo/OrderInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/FixedInfo/OrderInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -8,9 +10,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.FixedInfo
 {
     public class OrderInfo : OsuSpriteText
     {
+        private readonly IBindable<int> bindableOrder;
+
         public OrderInfo(Lyric lyric)
         {
-            lyric.OrderBindable.BindValueChanged(value =>
+            bindableOrder = lyric.OrderBindable.GetBoundCopy();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            bindableOrder.BindValueChanged(value =>
             {
                 int order = value.NewValue;
                 Text = $"#{order}";

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/LanguageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/LanguageInfo.cs
@@ -18,12 +18,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
 {
     public class LanguageInfo : SubInfo, IHasPopover
     {
-        private readonly Bindable<CultureInfo> languageBindable = new();
+        private readonly Bindable<CultureInfo> languageBindable;
 
         public LanguageInfo(Lyric lyric)
             : base(lyric)
         {
-            languageBindable.BindTo(Lyric.LanguageBindable);
+            languageBindable = lyric.LanguageBindable.GetBoundCopy();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/SingerInfo.cs
@@ -16,33 +16,35 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
 {
     public class SingerInfo : Container
     {
-        private readonly IBindableList<int> singerIndexesBindable = new BindableList<int>();
+        private readonly Lyric lyric;
+        private readonly SingerDisplay singerDisplay;
 
-        [Resolved]
-        private EditorBeatmap beatmap { get; set; }
+        private readonly IBindableList<int> singerIndexesBindable;
 
         public SingerInfo(Lyric lyric)
         {
+            this.lyric = lyric;
+            singerIndexesBindable = lyric.SingersBindable.GetBoundCopy();
+
             AutoSizeAxes = Axes.Both;
-            SingerDisplay singerDisplay;
 
             Child = singerDisplay = new SingerDisplay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             };
+        }
 
-            singerIndexesBindable.BindTo(lyric.SingersBindable);
+        [BackgroundDependencyLoader]
+        private void load(EditorBeatmap beatmap)
+        {
             singerIndexesBindable.BindCollectionChanged((_, _) =>
             {
-                Schedule(() =>
-                {
-                    if (beatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
-                        return;
+                if (beatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
+                    return;
 
-                    var singers = karaokeBeatmap.Singers?.Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
-                    singerDisplay.Current.Value = singers;
-                });
+                var singers = karaokeBeatmap.Singers?.Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
+                singerDisplay.Current.Value = singers;
             }, true);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/TimeTagInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/TimeTagInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -10,19 +11,28 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
 {
     public class TimeTagInfo : SubInfo
     {
+        private readonly IBindable<int> bindableTimeTagsVersion;
+        private readonly IBindableList<TimeTag> bindableTimeTags;
+
         public TimeTagInfo(Lyric lyric)
             : base(lyric)
         {
-            lyric.TimeTagsBindable.BindCollectionChanged((_, _) =>
-            {
-                BadgeText = LyricUtils.TimeTagTimeFormattedString(Lyric);
-            }, true);
+            bindableTimeTagsVersion = lyric.TimeTagsVersion.GetBoundCopy();
+            bindableTimeTags = lyric.TimeTagsBindable.GetBoundCopy();
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             BadgeColour = colours.Green;
+
+            bindableTimeTagsVersion.BindValueChanged(_ => updateBadgeText());
+            bindableTimeTags.BindCollectionChanged((_, _) => updateBadgeText());
+
+            updateBadgeText();
+
+            void updateBadgeText()
+                => BadgeText = LyricUtils.TimeTagTimeFormattedString(Lyric);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableNote.cs
@@ -96,15 +96,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             RubyTextBindable.BindTo(HitObject.RubyTextBindable);
             DisplayBindable.BindTo(HitObject.DisplayBindable);
             ToneBindable.BindTo(HitObject.ToneBindable);
-
-            if (HitObject.ParentLyric != null)
-            {
-                HitObject.ParentLyricBindable.BindValueChanged(x =>
-                {
-                    SingersBindable.UnbindAll();
-                    SingersBindable.BindTo(x.NewValue.SingersBindable);
-                }, true);
-            }
+            SingersBindable.BindTo(HitObject.ParentLyric.SingersBindable);
         }
 
         protected override void OnFree()
@@ -115,9 +107,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Drawables
             RubyTextBindable.UnbindFrom(HitObject.RubyTextBindable);
             DisplayBindable.UnbindFrom(HitObject.DisplayBindable);
             ToneBindable.UnbindFrom(HitObject.ToneBindable);
-
-            if (HitObject.ParentLyric != null)
-                SingersBindable.UnbindFrom(HitObject.ParentLyric?.SingersBindable);
+            SingersBindable.UnbindFrom(HitObject.ParentLyric.SingersBindable);
         }
 
         protected override void ApplySkin(ISkinSource skin, bool allowFallback)

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Judgements;
@@ -87,8 +88,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public int EndIndex { get; set; }
 
-        [JsonIgnore]
-        public readonly Bindable<Lyric> ParentLyricBindable = new();
+        private Lyric parentLyric;
 
         /// <summary>
         /// Relative lyric.
@@ -97,8 +97,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         [JsonProperty(IsReference = true)]
         public Lyric ParentLyric
         {
-            get => ParentLyricBindable.Value;
-            set => ParentLyricBindable.Value = value;
+            get => parentLyric;
+            set
+            {
+                if (parentLyric != null)
+                    throw new NotSupportedException("Cannot re-assign the parent lyric.");
+
+                parentLyric = value;
+            }
         }
 
         public override Judgement CreateJudgement() => new KaraokeNoteJudgement();

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -100,8 +100,9 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             get => parentLyric;
             set
             {
-                if (parentLyric != null)
-                    throw new NotSupportedException("Cannot re-assign the parent lyric.");
+                // todo: will apply the check until fix the issue in the KaraokeJsonBeatmapDecoder.
+                //if (parentLyric != null)
+                //    throw new NotSupportedException("Cannot re-assign the parent lyric.");
 
                 parentLyric = value;
             }


### PR DESCRIPTION
Remove all the cases like `lyric.BindableXXX.BindValueChanged(x => { })`;
Should use `GetBoundCopy()` or `BindTo()` to clone the value.

What's done in this PR:
- Fix call bindable.valueChange() directly in the lyric hit object.
- Fix the similar issue in the drawable note.
- Remove the bindable parent lyric property in the note because technically will not using it 