### PR TITLE
Remove and refactor some un-need methods in the TimeTagsUtils

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapEncoderTest.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
@@ -32,14 +31,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                         StartTime = start_time,
                         Duration = duration,
                         Text = "カラオケ！",
-                        TimeTags = TimeTagsUtils.ToTimeTagList(new Dictionary<TextIndex, double>
+                        TimeTags = new List<TimeTag>
                         {
-                            { new TextIndex(0), start_time + 500 },
-                            { new TextIndex(1), start_time + 600 },
-                            { new TextIndex(2), start_time + 1000 },
-                            { new TextIndex(3), start_time + 1500 },
-                            { new TextIndex(4), start_time + 2000 },
-                        }),
+                            new(new TextIndex(0), start_time + 500),
+                            new(new TextIndex(1), start_time + 600),
+                            new(new TextIndex(2), start_time + 1000),
+                            new(new TextIndex(3), start_time + 1500),
+                            new(new TextIndex(4), start_time + 2000),
+                        },
                         RubyTags = new[]
                         {
                             new RubyTag

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcEncoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcEncoderTest.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.IO;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Formats;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Tests.Resources;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
@@ -53,6 +54,24 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
                     return legacyDecoded;
                 }
             }
+        }
+
+        [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, new double[] { 1100, 2000, 2100, 3000 })]
+        [TestCase(new[] { "[1,end]:3000", "[1,start]:2100", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000, 2100, 3000 })]
+        [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000 })]
+        [TestCase(new[] { "[0,start]:1000", "[0,start]:1100", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1000, 2000 })]
+        [TestCase(new[] { "[0,start]:", "[0,end]:", "[0,start]:", "[1,start]:", "[1,end]:" }, new double[] { })]
+        [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, new double[] { 2000, 2000 })]
+        [TestCase(new[] { "[0,start]:1100", "[0,end]:2100", "[1,start]:2000", "[1,end]:3000" }, new double[] { 1100, 2100, 2100, 3000 })]
+        [TestCase(new[] { "[0,start]:1000", "[0,end]:5000", "[1,start]:2000", "[1,end]:3000" }, new double[] { 1000, 5000, 5000, 5000 })]
+        [TestCase(new[] { "[0,start]:1000", "[0,end]:2000", "[1,start]:0", "[1,end]:3000" }, new double[] { 1000, 2000, 2000, 3000 })]
+        //[TestCase(new[] { "[0,start]:4000", "[0,end]:3000", "[1,start]:2000", "[1,end]:1000" }, new double[] { 4000, 4000, 4000, 4000 })]
+        public void TestToDictionary(string[] timeTagTexts, double[] expected)
+        {
+            var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
+
+            double[] actual = LrcEncoder.ToDictionary(timeTags).Values.ToArray();
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
@@ -13,6 +13,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
     public class NoteGeneratorTest
     {
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カ", "ラ", "オ", "ケ" })]
+        [TestCase(new[] { "[3,end]:1000", "[3,start]:2000", "[2,start]:3000", "[1,start]:4000", "[0,start]:5000" }, new string[] { })]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カラ", "オ", "ケ" })] // will combine the note if time is duplicated.
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カラ", "オ", "ケ" })] // will combine the note if got no time.
+        [TestCase(new[] { "[0,start]:", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "ラ", "オ", "ケ" })]
+        [TestCase(new[] { "[0,start]:1000" }, new string[] { })]
+        [TestCase(new[] { "[0,start]:" }, new string[] { })]
         public void TestCreateNotes(string[] timeTags, string[] expected)
         {
             var generator = new NoteGenerator(new NoteGeneratorConfig());

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneLyric.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneLyric.cs
@@ -13,7 +13,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
-using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
@@ -46,14 +45,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
                 StartTime = startTime,
                 Duration = duration,
                 Text = "カラオケ！",
-                TimeTags = TimeTagsUtils.ToTimeTagList(new Dictionary<TextIndex, double>
+                TimeTags = new List<TimeTag>
                 {
-                    { new TextIndex(0), startTime + 500 },
-                    { new TextIndex(1), startTime + 600 },
-                    { new TextIndex(2), startTime + 1000 },
-                    { new TextIndex(3), startTime + 1500 },
-                    { new TextIndex(4), startTime + 2000 },
-                }),
+                    new(new TextIndex(0), startTime + 500),
+                    new(new TextIndex(1), startTime + 600),
+                    new(new TextIndex(2), startTime + 1000),
+                    new(new TextIndex(3), startTime + 1500),
+                    new(new TextIndex(4), startTime + 2000),
+                },
                 RubyTags = new[]
                 {
                     new RubyTag

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -162,24 +162,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         }
 
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, new double[] { 1100, 2000, 2100, 3000 })]
-        [TestCase(new[] { "[1,end]:3000", "[1,start]:2100", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000, 2100, 3000 })]
-        [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000 })]
-        [TestCase(new[] { "[0,start]:1000", "[0,start]:1100", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1000, 2000 })]
-        [TestCase(new[] { "[0,start]:", "[0,end]:", "[0,start]:", "[1,start]:", "[1,end]:" }, new double[] { })]
-        [TestCase(new[] { "[0,start]:2000", "[0,end]:1000" }, new double[] { 2000, 2000 })]
-        [TestCase(new[] { "[0,start]:1100", "[0,end]:2100", "[1,start]:2000", "[1,end]:3000" }, new double[] { 1100, 2100, 2100, 3000 })]
-        [TestCase(new[] { "[0,start]:1000", "[0,end]:5000", "[1,start]:2000", "[1,end]:3000" }, new double[] { 1000, 5000, 5000, 5000 })]
-        [TestCase(new[] { "[0,start]:1000", "[0,end]:2000", "[1,start]:0", "[1,end]:3000" }, new double[] { 1000, 2000, 2000, 3000 })]
-        //[TestCase(new[] { "[0,start]:4000", "[0,end]:3000", "[1,start]:2000", "[1,end]:1000" }, new double[] { 4000, 4000, 4000, 4000 })]
-        public void TestToDictionary(string[] timeTagTexts, double[] expected)
-        {
-            var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
-
-            double[] actual = TimeTagsUtils.ToDictionary(timeTags).Values.ToArray();
-            Assert.AreEqual(expected, actual);
-        }
-
-        [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, new double[] { 1100, 2000, 2100, 3000 })]
         [TestCase(new[] { "[0,start]:3000", "[0,end]:2100", "[1,start]:2000", "[1,end]:1100" }, new double[] { 1100, 2000, 2100, 3000 })] // will sort by time.
         [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000 })] // will remove the time-tag with no time.
         [TestCase(new[] { "[0,start]:1000", "[0,start]:1100" }, new double[] { 1000, 1100 })] // will remain the duplicated time-tag index.

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -195,6 +195,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, 1100)]
         [TestCase(new[] { "[1,end]:3000", "[1,start]:2100", "[0,end]:2000", "[0,start]:1100" }, 1100)]
         [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, 1100)]
+        [TestCase(new[] { "[0,start]:" }, null)]
+        [TestCase(new string[] { }, null)]
         public void TestGetStartTime(string[] timeTagTexts, double? expected)
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
@@ -206,6 +208,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, 3000)]
         [TestCase(new[] { "[1,end]:3000", "[1,start]:2100", "[0,end]:2000", "[0,start]:1100" }, 3000)]
         [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, 2000)]
+        [TestCase(new[] { "[0,start]:" }, null)]
+        [TestCase(new string[] { }, null)]
         public void TestGetEndTime(string[] timeTagTexts, double? expected)
         {
             var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -179,6 +179,19 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             Assert.AreEqual(expected, actual);
         }
 
+        [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, new double[] { 1100, 2000, 2100, 3000 })]
+        [TestCase(new[] { "[0,start]:3000", "[0,end]:2100", "[1,start]:2000", "[1,end]:1100" }, new double[] { 1100, 2000, 2100, 3000 })] // will sort by time.
+        [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, new double[] { 1100, 2000 })] // will remove the time-tag with no time.
+        [TestCase(new[] { "[0,start]:1000", "[0,start]:1100" }, new double[] { 1000, 1100 })] // will remain the duplicated time-tag index.
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:1000" }, new double[] { 1000 })] // Should not add duplicated time.
+        public void TestToTimeBasedDictionary(string[] timeTagTexts, double[] expected)
+        {
+            var timeTags = TestCaseTagHelper.ParseTimeTags(timeTagTexts);
+
+            var actual = TimeTagsUtils.ToTimeBasedDictionary(timeTags).Keys;
+            Assert.AreEqual(expected, actual);
+        }
+
         [TestCase(new[] { "[0,start]:1100", "[0,end]:2000", "[1,start]:2100", "[1,end]:3000" }, 1100)]
         [TestCase(new[] { "[1,end]:3000", "[1,start]:2100", "[0,end]:2000", "[0,start]:1100" }, 1100)]
         [TestCase(new[] { "[0,start]:", "[0,start]:", "[0,end]:2000", "[0,start]:1100" }, 1100)]

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using LyricMaker.Extensions;
 using LyricMaker.Parser;
@@ -60,7 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                         // Start time and end time should be re-assigned
                         StartTime = startTime,
                         Duration = duration,
-                        TimeTags = TimeTagsUtils.ToTimeTagList(timeTags),
+                        TimeTags = ToTimeTagList(timeTags),
                         RubyTags = result.QueryRubies(line.Text).Select(ruby => new RubyTag
                         {
                             Text = ruby.Ruby.Ruby,
@@ -79,6 +80,16 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                     throw new FormatException(message, ex);
                 }
             }
+        }
+
+        /// <summary>
+        /// Convert dictionary to list of time tags.
+        /// </summary>
+        /// <param name="dictionary">Dictionary.</param>
+        /// <returns>Time tags</returns>
+        internal static TimeTag[] ToTimeTagList(IReadOnlyDictionary<TextIndex, double> dictionary)
+        {
+            return dictionary.Select(d => new TimeTag(d.Key, d.Value)).ToArray();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/PreviewSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Layout/PreviewSection.cs
@@ -147,11 +147,11 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Layout
                 var defaultLanguage = new CultureInfo("en-US");
                 lyric.Translates.Add(defaultLanguage, translate);
 
-                lyric.TimeTags = TimeTagsUtils.ToTimeTagList(new Dictionary<TextIndex, double>
+                lyric.TimeTags = new List<TimeTag>
                 {
-                    { new TextIndex(0), startTime },
-                    { new TextIndex(4), startTime + duration },
-                });
+                    new(new TextIndex(0), startTime),
+                    new(new TextIndex(4), startTime + duration)
+                };
 
                 return lyric;
             }

--- a/osu.Game.Rulesets.Karaoke/Screens/Skin/Style/LyricStylePreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Skin/Style/LyricStylePreview.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
-using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Style
 {
@@ -44,14 +43,14 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Skin.Style
                 StartTime = startTime,
                 Duration = duration,
                 Text = "カラオケ！",
-                TimeTags = TimeTagsUtils.ToTimeTagList(new Dictionary<TextIndex, double>
+                TimeTags = new List<TimeTag>
                 {
-                    { new TextIndex(0), startTime + 500 },
-                    { new TextIndex(1), startTime + 600 },
-                    { new TextIndex(2), startTime + 1000 },
-                    { new TextIndex(3), startTime + 1500 },
-                    { new TextIndex(4), startTime + 2000 },
-                }),
+                    new(new TextIndex(0), startTime + 500),
+                    new(new TextIndex(1), startTime + 600),
+                    new(new TextIndex(2), startTime + 1000),
+                    new(new TextIndex(3), startTime + 1500),
+                    new(new TextIndex(4), startTime + 2000),
+                },
                 RubyTags = new[]
                 {
                     new RubyTag

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -266,33 +266,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         /// <summary>
         /// Convert list of time tag to dictionary.
-        /// todo: this method will be removed eventually.
-        /// </summary>
-        /// <param name="timeTags">Time tags</param>
-        /// <param name="applyFix">Should auto-fix or not</param>
-        /// <param name="other">Fix way</param>
-        /// <param name="self">Fix way</param>
-        /// <returns>Time tags with dictionary format.</returns>
-        public static IReadOnlyDictionary<TextIndex, double> ToDictionary(IList<TimeTag> timeTags, bool applyFix = true, GroupCheck other = GroupCheck.Asc,
-                                                                          SelfCheck self = SelfCheck.BasedOnStart)
-        {
-            if (timeTags == null)
-                return new Dictionary<TextIndex, double>();
-
-            // sorted value
-            var sortedTimeTags = applyFix ? FixOverlapping(timeTags, other, self) : Sort(timeTags);
-
-            // convert to dictionary, will get start's smallest time and end's largest time.
-            return sortedTimeTags.Where(x => x.Time != null).GroupBy(x => x.Index)
-                                 .Select(x =>
-                                     x.Key.State == TextIndex.IndexState.Start ? x.FirstOrDefault() : x.LastOrDefault())
-                                 .ToDictionary(
-                                     k => k?.Index ?? throw new ArgumentNullException(nameof(k)),
-                                     v => v?.Time ?? throw new ArgumentNullException(nameof(v)));
-        }
-
-        /// <summary>
-        /// Convert list of time tag to dictionary.
         /// WIll sort by the time.
         /// </summary>
         /// <param name="timeTags">Time tags</param>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -287,16 +287,6 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         }
 
         /// <summary>
-        /// Convert dictionary to list of time tags.
-        /// </summary>
-        /// <param name="dictionary">Dictionary.</param>
-        /// <returns>Time tags</returns>
-        public static TimeTag[] ToTimeTagList(IReadOnlyDictionary<TextIndex, double> dictionary)
-        {
-            return dictionary.Select(d => new TimeTag(d.Key, d.Value)).ToArray();
-        }
-
-        /// <summary>
         /// Get start time.
         /// </summary>
         /// <param name="timeTags">Time tags</param>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -293,25 +293,24 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         /// <summary>
         /// Convert list of time tag to dictionary.
-        /// Used for apply the time-tag to the <see cref="KaraokeSpriteText"/>
+        /// WIll sort by the time.
         /// </summary>
         /// <param name="timeTags">Time tags</param>
-        /// <param name="applyFix">Should auto-fix or not</param>
-        /// <param name="other">Fix way</param>
-        /// <param name="self">Fix way</param>
         /// <returns>Time tags with dictionary format.</returns>
-        public static IReadOnlyDictionary<double, TextIndex> ToTimeBasedDictionary(IList<TimeTag> timeTags, bool applyFix = true, GroupCheck other = GroupCheck.Asc,
-                                                                                   SelfCheck self = SelfCheck.BasedOnStart)
+        public static IReadOnlyDictionary<double, TextIndex> ToTimeBasedDictionary(IList<TimeTag> timeTags)
         {
             if (timeTags == null)
                 return new Dictionary<double, TextIndex>();
 
-            // sorted value
-            var sortedTimeTags = applyFix ? FixOverlapping(timeTags, other, self) : Sort(timeTags);
-
             // convert to dictionary, will get start's smallest time and end's largest time.
-            return sortedTimeTags.Where(x => x.Time != null)
-                                 .ToDictionary(k => k.Time ?? throw new ArgumentNullException(nameof(k)), v => v.Index);
+            return timeTags.Where(x => x.Time != null)
+                           .OrderBy(x => x.Time)
+                           .GroupBy(x => x.Time)
+                           .Select(x =>
+                               // will always get the first time-tag for now.
+                               x.FirstOrDefault())
+                           .ToDictionary(k => k?.Time ?? throw new ArgumentNullException(nameof(k)),
+                               v => v?.Index ?? throw new ArgumentNullException(nameof(v)));
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TimeTagsUtils.cs
@@ -330,7 +330,11 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <returns>Start time</returns>
         public static double? GetStartTime(IList<TimeTag> timeTags)
         {
-            return ToDictionary(timeTags).FirstOrDefault().Value;
+            var dictionary = ToTimeBasedDictionary(timeTags);
+            if (!dictionary.Any())
+                return null;
+
+            return dictionary.First().Key;
         }
 
         /// <summary>
@@ -340,7 +344,11 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <returns>End time</returns>
         public static double? GetEndTime(IList<TimeTag> timeTags)
         {
-            return ToDictionary(timeTags).LastOrDefault().Value;
+            var dictionary = ToTimeBasedDictionary(timeTags);
+            if (!dictionary.Any())
+                return null;
+
+            return dictionary.Last().Key;
         }
     }
 


### PR DESCRIPTION
Implement issue #1295

What's done in this PR:
- Add more test case for the utils.
- Add more test case for the note generator.
- Move some utils into .lrc encoder/decode because those method will not be used in the other place.