### PR TITLE
Fix time-tag anchor in the lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableTextIndex.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableTextIndex.cs
@@ -1,0 +1,30 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Components.Sprites
+{
+    public class DrawableTextIndex : RightTriangle
+    {
+        private TextIndex.IndexState state;
+
+        public TextIndex.IndexState State
+        {
+            get => state;
+            set
+            {
+                state = value;
+
+                RightAngleDirection = state switch
+                {
+                    TextIndex.IndexState.Start => TriangleRightAngleDirection.BottomLeft,
+                    TextIndex.IndexState.End => TriangleRightAngleDirection.BottomRight,
+                    _ => throw new ArgumentOutOfRangeException(nameof(value))
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
@@ -16,11 +16,11 @@ using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 
             private Drawable[] createContent(Lyric lyric, TimeTag timeTag, TimeTagInvalid invalid) => new Drawable[]
             {
-                new RightTriangle
+                new DrawableTextIndex
                 {
                     Origin = Anchor.Centre,
                     Size = new Vector2(10),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagEditCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagEditCaret.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
             InternalChild = drawableTimeTag = new RightTriangle
             {
                 Name = "Time tag triangle",
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.Centre,
                 Size = new Vector2(triangle_width),
                 Alpha = preview ? 0.5f : 1
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagEditCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagEditCaret.cs
@@ -3,10 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
@@ -21,16 +20,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
         [Resolved]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
 
-        private readonly RightTriangle drawableTimeTag;
+        private readonly DrawableTextIndex drawableTextIndex;
 
         public DrawableTimeTagEditCaret(bool preview)
             : base(preview)
         {
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = drawableTimeTag = new RightTriangle
+            InternalChild = drawableTextIndex = new DrawableTextIndex
             {
-                Name = "Time tag triangle",
+                Name = "Text index",
                 Size = new Vector2(triangle_width),
                 Alpha = preview ? 0.5f : 1
             };
@@ -38,9 +37,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
 
         protected override void Apply(TimeTagIndexCaretPosition caret)
         {
-            Position = karaokeSpriteText.GetTextIndexPosition(caret.Index);
-            drawableTimeTag.Scale = new Vector2(caret.Index.State == TextIndex.IndexState.Start ? 1 : -1, 1);
-            drawableTimeTag.Colour = colours.GetEditTimeTagCaretColour();
+            var textIndex = caret.Index;
+            Position = karaokeSpriteText.GetTextIndexPosition(textIndex);
+
+            drawableTextIndex.State = textIndex.State;
+            drawableTextIndex.Colour = colours.GetEditTimeTagCaretColour();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagRecordCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagRecordCaret.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
             InternalChild = drawableTimeTag = new RightTriangle
             {
                 Name = "Time tag triangle",
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.Centre,
                 Size = new Vector2(triangle_width),
                 Alpha = preview ? 0.5f : 1
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagRecordCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Carets/DrawableTimeTagRecordCaret.cs
@@ -3,10 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
@@ -21,16 +20,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
         [Resolved]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
 
-        private readonly RightTriangle drawableTimeTag;
+        private readonly DrawableTextIndex drawableTextIndex;
 
         public DrawableTimeTagRecordCaret(bool preview)
             : base(preview)
         {
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = drawableTimeTag = new RightTriangle
+            InternalChild = drawableTextIndex = new DrawableTextIndex
             {
-                Name = "Time tag triangle",
+                Name = "Text index",
                 Size = new Vector2(triangle_width),
                 Alpha = preview ? 0.5f : 1
             };
@@ -39,10 +38,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Carets
         protected override void Apply(TimeTagCaretPosition caret)
         {
             var timeTag = caret.TimeTag;
+            var textIndex = timeTag.Index;
             this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), Preview ? 0 : 100, Easing.OutCubic);
 
-            drawableTimeTag.Scale = new Vector2(timeTag.Index.State == TextIndex.IndexState.Start ? 1 : -1, 1);
-            drawableTimeTag.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
+            drawableTextIndex.State = textIndex.State;
+            drawableTextIndex.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
@@ -25,16 +25,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Parts
 
         public DrawableTimeTag(TimeTag timeTag)
         {
+            AutoSizeAxes = Axes.Both;
+
             this.timeTag = timeTag;
-
-            Size = new Vector2(triangle_width);
-
             var index = timeTag.Index;
+
             InternalChild = new RightTriangle
             {
                 Name = "Time tag triangle",
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.Centre,
                 Size = new Vector2(triangle_width),
                 Scale = new Vector2(index.State == TextIndex.IndexState.Start ? 1 : -1, 1)
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/Parts/DrawableTimeTag.cs
@@ -5,10 +5,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
@@ -28,13 +27,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.Parts
             AutoSizeAxes = Axes.Both;
 
             this.timeTag = timeTag;
-            var index = timeTag.Index;
+            var state = timeTag.Index.State;
 
-            InternalChild = new RightTriangle
+            InternalChild = new DrawableTextIndex
             {
-                Name = "Time tag triangle",
+                Name = "Text index",
                 Size = new Vector2(triangle_width),
-                Scale = new Vector2(index.State == TextIndex.IndexState.Start ? 1 : -1, 1)
+                State = state
             };
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -17,7 +17,6 @@ using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
@@ -122,7 +121,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
 
             private readonly Bindable<double?> bindableTime;
 
-            private readonly TimeTagPiece timeTagPiece;
+            private readonly TextIndexPiece textIndexPiece;
 
             private readonly Lyric lyric;
             private readonly TimeTag timeTag;
@@ -131,7 +130,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
             {
                 this.lyric = lyric;
                 this.timeTag = timeTag;
-                bool start = timeTag.Index.State == TextIndex.IndexState.Start;
+
+                var state = timeTag.Index.State;
+                bool start = state == TextIndex.IndexState.Start;
 
                 Anchor = Anchor.CentreLeft;
                 Origin = start ? Anchor.CentreLeft : Anchor.CentreRight;
@@ -141,13 +142,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                 bindableTime = timeTag.TimeBindable.GetBoundCopy();
                 InternalChildren = new Drawable[]
                 {
-                    timeTagPiece = new TimeTagPiece
+                    textIndexPiece = new TextIndexPiece
                     {
                         Name = "Time tag triangle",
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
-                        Scale = new Vector2(start ? 1 : -1, 1)
+                        State = state
                     },
                     new OsuSpriteText
                     {
@@ -161,8 +162,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
             [BackgroundDependencyLoader]
             private void load(EditorClock clock, OsuColour colours, RecordingTimeTagEditor timeline)
             {
-                timeTagPiece.Clock = clock;
-                timeTagPiece.Colour = colours.GetTimeTagColour(timeTag);
+                textIndexPiece.Clock = clock;
+                textIndexPiece.Colour = colours.GetTimeTagColour(timeTag);
 
                 bindableTime.BindValueChanged(e =>
                 {
@@ -181,12 +182,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                         X = (float)previewTime;
 
                         // make tickle effect.
-                        timeTagPiece.ClearTransforms();
+                        textIndexPiece.ClearTransforms();
 
-                        using (timeTagPiece.BeginAbsoluteSequence(previewTime))
+                        using (textIndexPiece.BeginAbsoluteSequence(previewTime))
                         {
-                            timeTagPiece.Colour = colours.GetTimeTagColour(timeTag);
-                            timeTagPiece.FlashColour(colours.RedDark, 750, Easing.OutQuint);
+                            textIndexPiece.Colour = colours.GetTimeTagColour(timeTag);
+                            textIndexPiece.FlashColour(colours.RedDark, 750, Easing.OutQuint);
                         }
                     });
                 }, true);
@@ -213,7 +214,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                 };
         }
 
-        private class TimeTagPiece : RightTriangle
+        private class TextIndexPiece : DrawableTextIndex
         {
             public override bool RemoveCompletedTransforms => false;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
@@ -57,6 +58,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
 
             private readonly Lyric lyric;
 
+            private readonly DrawableTextIndex drawableTextIndex;
+
             public CurrentRecordingTimeTagVisualization(Lyric lyric)
             {
                 this.lyric = lyric;
@@ -65,7 +68,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                 RelativePositionAxes = Axes.X;
                 Size = new Vector2(RecordingTimeTagEditor.TIMELINE_HEIGHT / 2);
 
-                InternalChild = new RightTriangle
+                InternalChild = drawableTextIndex = new DrawableTextIndex
                 {
                     Name = "Time tag triangle",
                     Anchor = Anchor.Centre,
@@ -90,11 +93,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.RecordingTimeTags
                     }
 
                     var timeTag = timeTagCaretPosition.TimeTag;
-                    bool start = timeTag.Index.State == TextIndex.IndexState.Start;
+                    var state = timeTag.Index.State;
 
-                    Origin = start ? Anchor.BottomLeft : Anchor.BottomRight;
-                    InternalChild.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
-                    InternalChild.Scale = new Vector2(start ? 1 : -1, 1);
+                    Origin = state == TextIndex.IndexState.Start ? Anchor.BottomLeft : Anchor.BottomRight;
+                    drawableTextIndex.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
+                    drawableTextIndex.State = state;
 
                     if (timeTag.Time.HasValue)
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -15,7 +15,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
-using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
@@ -155,46 +155,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
         public class TimeTagPiece : CompositeDrawable
         {
-            private readonly Box box;
-
-            private readonly RightTriangle triangle;
-
             public TimeTagPiece(TimeTag timeTag)
             {
                 RelativeSizeAxes = Axes.Y;
                 Width = 10;
+
+                var state = timeTag.Index.State;
                 InternalChildren = new Drawable[]
                 {
-                    box = new Box
+                    new Box
                     {
                         RelativeSizeAxes = Axes.Y,
                         Width = 1.5f,
+                        Anchor = state == TextIndex.IndexState.Start ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = state == TextIndex.IndexState.Start ? Anchor.CentreLeft : Anchor.CentreRight
                     },
-                    triangle = new RightTriangle
+                    new DrawableTextIndex
                     {
                         Size = new Vector2(10),
                         Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.BottomCentre
+                        Origin = Anchor.BottomCentre,
+                        State = state
                     }
                 };
-
-                switch (timeTag.Index.State)
-                {
-                    case TextIndex.IndexState.Start:
-                        triangle.Scale = new Vector2(1);
-                        box.Anchor = Anchor.CentreLeft;
-                        box.Origin = Anchor.CentreLeft;
-                        break;
-
-                    case TextIndex.IndexState.End:
-                        triangle.Scale = new Vector2(-1, 1);
-                        box.Anchor = Anchor.CentreRight;
-                        box.Origin = Anchor.CentreRight;
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(timeTag.Index.State));
-                }
             }
 
             public override bool RemoveCompletedTransforms => false;
@@ -202,27 +185,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 
         public class TimeTagWithNoTimePiece : CompositeDrawable
         {
-            private readonly RightTriangle triangle;
-
             public TimeTagWithNoTimePiece(TimeTag timeTag)
             {
                 AutoSizeAxes = Axes.Y;
                 Width = 10;
+
+                var state = timeTag.Index.State;
                 InternalChildren = new Drawable[]
                 {
-                    triangle = new RightTriangle
+                    new DrawableTextIndex
                     {
                         Size = new Vector2(10),
                         Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.BottomCentre
+                        Origin = Anchor.BottomCentre,
+                        State = state
                     }
-                };
-
-                triangle.Scale = timeTag.Index.State switch
-                {
-                    TextIndex.IndexState.Start => new Vector2(1),
-                    TextIndex.IndexState.End => new Vector2(-1, 1),
-                    _ => triangle.Scale
                 };
             }
         }


### PR DESCRIPTION
Closes issue #1308

Before:
![image](https://user-images.githubusercontent.com/9100368/168198380-9de6e68c-500f-4de6-9ba6-38a360e241cc.png)

After
![image](https://user-images.githubusercontent.com/9100368/168329213-1b44e08d-ce9f-42fc-882d-afee7ae52b70.png)

What's done in this PR:
- Remove the anchor and origin in the right triangle drawable due to there's no need to add this shit.
- Implement `DrawableTextIndex` for handle the style for the time-tag.
- Apply `DrawableTextIndex` in everywhere.
- Replace with the drawable text index in the time-tag recording field.