### PR TITLE
Fix crash in the adjust time-tag mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneLyricEditorScreen.cs
@@ -2,16 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor
 {
@@ -46,22 +51,90 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
             Dependencies.Cache(new KaraokeRulesetEditGeneratorConfigManager());
         }
 
-        [TestCase(LyricEditorMode.View)]
-        [TestCase(LyricEditorMode.Manage)]
-        [TestCase(LyricEditorMode.Typing)]
-        [TestCase(LyricEditorMode.Language)]
-        [TestCase(LyricEditorMode.EditRuby)]
-        [TestCase(LyricEditorMode.EditRomaji)]
-        [TestCase(LyricEditorMode.EditTimeTag)]
-        [TestCase(LyricEditorMode.EditNote)]
-        [TestCase(LyricEditorMode.Singer)]
-        public void TestSwitchMode(LyricEditorMode mode)
+        [Test]
+        public void TestViewMode()
+        {
+            switchToMode(LyricEditorMode.View);
+        }
+
+        [Test]
+        public void TestManageMode()
+        {
+            switchToMode(LyricEditorMode.Manage);
+        }
+
+        [Test]
+        public void TestTypingMode()
+        {
+            switchToMode(LyricEditorMode.Typing);
+        }
+
+        [Test]
+        public void TestLanguageMode()
+        {
+            switchToMode(LyricEditorMode.Language);
+            clickEditModeButtons<LanguageEditMode>();
+        }
+
+        [Test]
+        public void TestEditRubyMode()
+        {
+            switchToMode(LyricEditorMode.EditRuby);
+            clickEditModeButtons<TextTagEditMode>();
+        }
+
+        [Test]
+        public void TestEditRomajiMode()
+        {
+            switchToMode(LyricEditorMode.EditRomaji);
+            clickEditModeButtons<TextTagEditMode>();
+        }
+
+        [Test]
+        public void TestEditTimeTagMode()
+        {
+            switchToMode(LyricEditorMode.EditTimeTag);
+            clickEditModeButtons<TimeTagEditMode>();
+        }
+
+        [Test]
+        public void TestEditNoteMode()
+        {
+            switchToMode(LyricEditorMode.EditNote);
+            clickEditModeButtons<NoteEditMode>();
+        }
+
+        [Test]
+        public void TestSingerMode()
+        {
+            switchToMode(LyricEditorMode.Singer);
+        }
+
+        private void switchToMode(LyricEditorMode mode)
         {
             AddStep($"switch to mode {Enum.GetName(typeof(LyricEditorMode), mode)}", () =>
             {
                 bindableLyricEditorMode.Value = mode;
             });
             AddWaitStep("wait for switch to new mode", 5);
+        }
+
+        private void clickEditModeButtons<T>() where T : Enum
+        {
+            foreach (var editMode in EnumUtils.GetValues<T>())
+            {
+                clickTargetEditModeButton(editMode);
+            }
+        }
+
+        private void clickTargetEditModeButton<T>(T editMode) where T : Enum
+        {
+            AddStep("Click the button", () =>
+            {
+                var editModeSection = this.ChildrenOfType<EditModeSection<T>>().Single();
+                editModeSection.UpdateEditMode(editMode);
+            });
+            AddWaitStep("wait for switch to new edit mode.", 1);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             });
         }
 
-        protected virtual void UpdateEditMode(T mode)
+        internal virtual void UpdateEditMode(T mode)
         {
             // should cancel the selection after change to the new edit mode.
             lyricSelectionState?.EndSelecting(LyricEditorSelectingAction.Cancel);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Languages/LanguageEditModeSection.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Languages
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
 
-        protected override void UpdateEditMode(LanguageEditMode mode)
+        internal override void UpdateEditMode(LanguageEditMode mode)
         {
             languageModeState.ChangeEditMode(mode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditModeSection.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
 
-        protected override void UpdateEditMode(NoteEditMode mode)
+        internal override void UpdateEditMode(NoteEditMode mode)
         {
             editNoteModeState.ChangeEditMode(mode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditModeSection.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                 }
             };
 
-        protected override void UpdateEditMode(TextTagEditMode mode)
+        internal override void UpdateEditMode(TextTagEditMode mode)
         {
             editRomajiModeState.ChangeEditMode(mode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditModeSection.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
                 }
             };
 
-        protected override void UpdateEditMode(TextTagEditMode mode)
+        internal override void UpdateEditMode(TextTagEditMode mode)
         {
             editRubyModeState.ChangeEditMode(mode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditSection.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
         {
             lyricCaretState.BindableCaretPosition.BindValueChanged(e =>
             {
-                Lyric = e.NewValue.Lyric;
+                Lyric = e.NewValue?.Lyric;
 
                 if (e.OldValue?.Lyric != null)
                 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagEditModeSection.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
             };
         }
 
-        protected override void UpdateEditMode(TimeTagEditMode mode)
+        internal override void UpdateEditMode(TimeTagEditMode mode)
         {
             timeTagModeState.ChangeEditMode(mode);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Extends/TimeTags/TimeTagEditor.cs
@@ -18,7 +18,6 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Extends.TimeTags
 {
-    [Cached(typeof(IPositionSnapProvider))]
     [Cached]
     public class TimeTagEditor : TimeTagEditorScrollContainer, IPositionSnapProvider
     {

--- a/osu.Game.Rulesets.Karaoke/Utils/EnumUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/EnumUtils.cs
@@ -9,13 +9,13 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 {
     public static class EnumUtils
     {
-        public static T[] GetValues<T>() where T : struct
+        public static T[] GetValues<T>() where T : Enum
             => (T[])Enum.GetValues(typeof(T));
 
-        public static T GetPreviousValue<T>(T v) where T : struct
+        public static T GetPreviousValue<T>(T v) where T : Enum
             => GetValues<T>().Concat(new[] { default(T) }).Reverse().SkipWhile(e => !EqualityComparer<T>.Default.Equals(v, e)).Skip(1).First();
 
-        public static T GetNextValue<T>(T v) where T : struct
+        public static T GetNextValue<T>(T v) where T : Enum
             => GetValues<T>().Concat(new[] { default(T) }).SkipWhile(e => !EqualityComparer<T>.Default.Equals(v, e)).Skip(1).First();
     }
 }


### PR DESCRIPTION
Closes issue #1309

What's done in this PR:
- Fix crash in the adjust time-tag mode by removing the duplicated injection.
- Adjust the enum utils for better object type.
- Refactor the lyric editor test case for able to switch to mode's edit mode.