### PR TITLE
Upgrade the font package

### DIFF
--- a/osu.Game.Rulesets.Karaoke/IO/Stores/TtfGlyphStore.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Stores/TtfGlyphStore.cs
@@ -116,13 +116,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Stores
         public int GetKerning(char left, char right)
         {
             // todo: implement.
-            var rightGlyphMetrics = fontMetrics?.GetGlyphMetrics(new CodePoint(right), ColorFontSupport.None).FirstOrDefault();
-
-            if (rightGlyphMetrics == null)
-                return 0;
-
-            float kerning = rightGlyphMetrics.LeftSideBearing;
-            return (int)kerning;
+            return 0;
         }
 
         Task<CharacterGlyph> IResourceStore<CharacterGlyph>.GetAsync(string name, CancellationToken cancellationToken) =>

--- a/osu.Game.Rulesets.Karaoke/IO/Stores/TtfGlyphStore.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Stores/TtfGlyphStore.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Stores
 {
     public class TtfGlyphStore : IResourceStore<TextureUpload>, IGlyphStore
     {
-        private const int dpi = 80;
+        private const float dpi = 72f;
 
         protected readonly string AssetName;
 
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Stores
             float xOffset = bounds.Left * dpi;
             float yOffset = bounds.Top * dpi;
 
-            int advanceWidth2 = glyphMetrics.AdvanceWidth * dpi / glyphMetrics.UnitsPerEm;
+            float advanceWidth2 = glyphMetrics.AdvanceWidth * dpi / glyphMetrics.UnitsPerEm;
             return new CharacterGlyph(character, xOffset, yOffset, advanceWidth2, Baseline.Value, this);
         }
 

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="ppy.osu.Game" Version="2022.509.0" />
     <PackageReference Include="LyricMaker" Version="1.1.1" />
     <PackageReference Include="NicoKaraParser" Version="1.1.0" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
     <!--install because it might cause "Could not load file or assembly" error, might be removed eventually-->
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="WanaKanaSharp" Version="0.2.0" />


### PR DESCRIPTION
Upgrade those packages and apply the api change in the package:
```
<PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
```

Closes issue #1322 and implement part of #1317

And notice that this package does not cover fix the test case broken issue in the `TtfGlyphStoreTest`.