### PR TITLE
Make lyric selection state strategy clear.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (selecting.Value)
                 throw new NotSupportedException("Selecting already started.");
 
-            bindableSelectedLyrics.Clear();
             selecting.Value = true;
         }
 
@@ -49,9 +48,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             selecting.Value = false;
 
-            if (beatmap == null)
-                return;
-
             // should sync selection to editor beatmap because auto-generate will be apply to those lyric that being selected.
             var selectedLyrics = bindableSelectedLyrics.ToArray();
             beatmap.SelectedHitObjects.Clear();
@@ -61,6 +57,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             // after being applied, should clear the selection.
             beatmap.SelectedHitObjects.Clear();
+
+            // should clear the selection after finish.
+            bindableSelectedLyrics.Clear();
 
             // should add selected lyric back.
             lyricCaretState.SyncSelectedHitObjectWithCaret();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -35,13 +35,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void StartSelecting()
         {
+            if (selecting.Value)
+                throw new NotSupportedException("Selecting already started.");
+
             bindableSelectedLyrics.Clear();
             selecting.Value = true;
         }
 
         public void EndSelecting(LyricEditorSelectingAction action)
         {
-            if (selecting.Value == false)
+            if (!selecting.Value)
                 return;
 
             selecting.Value = false;
@@ -65,6 +68,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void Select(Lyric lyric)
         {
+            if (!selecting.Value)
+                throw new NotSupportedException("Should not add the lyric if not in the selecting state.");
+
             if (bindableSelectedLyrics.Contains(lyric))
                 return;
 
@@ -76,11 +82,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void UnSelect(Lyric lyric)
         {
+            if (!selecting.Value)
+                throw new NotSupportedException("Should not remove the lyric if not in the selecting state.");
+
             bindableSelectedLyrics.Remove(lyric);
         }
 
         public void SelectAll()
         {
+            if (!selecting.Value)
+                throw new NotSupportedException("Should not select the lyric if not in the selecting state.");
+
             var lyrics = beatmap.HitObjects.OfType<Lyric>();
 
             foreach (var lyric in lyrics)
@@ -91,11 +103,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void UnSelectAll()
         {
+            if (!selecting.Value)
+                throw new NotSupportedException("Should not clear the selected lyric if not in the selecting state.");
+
             bindableSelectedLyrics.Clear();
         }
 
         public void UpdateDisableLyricList(IDictionary<Lyric, string> disableLyrics)
         {
+            if (selecting.Value)
+                throw new NotSupportedException("Should not update the disable lyric list while selecting.");
+
             bindableDisableSelectingLyric.Clear();
 
             if (disableLyrics == null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -68,6 +68,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (bindableSelectedLyrics.Contains(lyric))
                 return;
 
+            if (bindableDisableSelectingLyric.ContainsKey(lyric))
+                return;
+
             bindableSelectedLyrics.Add(lyric);
         }
 
@@ -78,8 +81,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public void SelectAll()
         {
-            var disableSelectingLyrics = bindableDisableSelectingLyric.Keys;
-            var lyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => !disableSelectingLyrics.Contains(x));
+            var lyrics = beatmap.HitObjects.OfType<Lyric>();
 
             foreach (var lyric in lyrics)
             {


### PR DESCRIPTION
Figured out while implementing the #1326

What's done in this PR:
- make sure should check the disable lyrics while adding the lyric to the selected list.
- make a check that not add or remove the selecting list if not selecting.
- should clear all selection after end selecting.