### PR TITLE
Fix language detection might be wrong if select all lyrics at the same time.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
             if (!changingCache.IsValid)
                 throw new NotSupportedException("Cannot trigger the change while applying another change.");
 
+            if (beatmap.SelectedHitObjects.Count == 0)
+                throw new NotSupportedException($"Should contain at least one selected {nameof(THitObject)}");
+
             changingCache.Invalidate();
 
             try

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
@@ -13,10 +14,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
 {
     public abstract class HitObjectChangeHandler<THitObject> : Component where THitObject : HitObject
     {
+        private readonly Cached changingCache = new();
+
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
         protected IEnumerable<THitObject> HitObjects => beatmap.HitObjects.OfType<THitObject>();
+
+        protected HitObjectChangeHandler()
+        {
+            changingCache.Validate();
+        }
 
         protected void CheckExactlySelectedOneHitObject()
         {
@@ -24,11 +32,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
                 throw new InvalidOperationException($"Should be exactly one {nameof(THitObject)} being selected.");
         }
 
-        protected void PerformOnSelection(Action<THitObject> action) => beatmap.PerformOnSelection(h =>
+        protected void PerformOnSelection(Action<THitObject> action)
         {
-            if (h is THitObject tHitObject)
-                action.Invoke(tHitObject);
-        });
+            if (!changingCache.IsValid)
+                throw new NotSupportedException("Cannot trigger the change while applying another change.");
+
+            changingCache.Invalidate();
+
+            beatmap.PerformOnSelection(h =>
+            {
+                if (h is THitObject tHitObject)
+                    action.Invoke(tHitObject);
+            });
+
+            changingCache.Validate();
+        }
 
         protected void AddRange(IEnumerable<HitObject> hitObjects) => beatmap.AddRange(hitObjects);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -39,13 +39,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
 
             changingCache.Invalidate();
 
-            beatmap.PerformOnSelection(h =>
+            try
             {
-                if (h is THitObject tHitObject)
-                    action.Invoke(tHitObject);
-            });
-
-            changingCache.Validate();
+                beatmap.PerformOnSelection(h =>
+                {
+                    if (h is THitObject tHitObject)
+                        action.Invoke(tHitObject);
+                });
+            }
+            finally
+            {
+                changingCache.Validate();
+            }
         }
 
         protected void AddRange(IEnumerable<HitObject> hitObjects) => beatmap.AddRange(hitObjects);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -168,17 +168,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             bindableSelecting.BindValueChanged(e =>
             {
                 updateAddLyricState();
-            });
+                initializeApplySelectingArea();
+            }, true);
 
             bindableFontSize.BindValueChanged(e =>
             {
                 skin.FontSize = e.NewValue;
             });
-
-            lyricSelectionState.Selecting.BindValueChanged(_ =>
-            {
-                initializeApplySelectingArea();
-            }, true);
         }
 
         private void updateAddLyricState()
@@ -254,7 +250,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
         private void initializeApplySelectingArea()
         {
-            bool show = lyricSelectionState.Selecting.Value;
+            bool show = bindableSelecting.Value;
             lyricEditorGridContainer.RowDimensions = new[]
             {
                 new Dimension(),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/LanguageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Components/SubInfo/LanguageInfo.cs
@@ -11,8 +11,10 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
 {
@@ -27,15 +29,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Components.SubInfo
         }
 
         [BackgroundDependencyLoader]
-        private void load(ILyricLanguageChangeHandler lyricLanguageChangeHandler, OsuColour colours)
+        private void load(ILyricLanguageChangeHandler lyricLanguageChangeHandler, ILyricSelectionState lyricSelectionState, EditorBeatmap beatmap, OsuColour colours)
         {
             languageBindable.BindValueChanged(value =>
             {
-                // todo : how to mark lyric as selected.
                 var language = value.NewValue;
+                updateBadgeText(language);
+
+                if (lyricSelectionState.Selecting.Value)
+                    return;
+
+                // todo: it's a temp way for applying the lyric.
+                // because assign language does not have the caret algorithm, so cannot apply the selected hit object by changing the caret.
+                beatmap.SelectedHitObjects.Add(Lyric);
+
                 lyricLanguageChangeHandler.SetLanguage(language);
 
-                updateBadgeText(language);
+                beatmap.SelectedHitObjects.Remove(Lyric);
             });
             updateBadgeText(Lyric.Language);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricSelectionState.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (!selecting.Value)
                 return;
 
-            selecting.Value = false;
-
             // should sync selection to editor beatmap because auto-generate will be apply to those lyric that being selected.
             var selectedLyrics = bindableSelectedLyrics.ToArray();
             beatmap.SelectedHitObjects.Clear();
@@ -60,6 +58,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             // should clear the selection after finish.
             bindableSelectedLyrics.Clear();
+
+            // for able to check if still selecting, should make sure that every process step has been finished.
+            selecting.Value = false;
 
             // should add selected lyric back.
             lyricCaretState.SyncSelectedHitObjectWithCaret();


### PR DESCRIPTION
Closes issue #1326

What's done in this PR:
- refactor some logic in the lyric editor.
- change the selecting state after all lyric apply change.
- add some recursive check in the base change handler class.
- fix the behavior in the language selection badge.