### PR TITLE
Switch the lrc parser

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcDecoderTest.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Formats
             TimeTagAssert.ArePropertyEqual(expected, actual);
         }
 
+        [Ignore("Time-tags with same time might be allowed.")]
         [TestCase("[00:04.00]か[00:04.00]ら[00:05.00]お[00:06.00]け[00:07.00]")]
         public void TestDecodeLyricWithDuplicatedTimeTag(string text)
         {

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using LyricMaker.Extensions;
-using LyricMaker.Parser;
-using osu.Framework.Graphics.Sprites;
+using LrcParser.Model;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
 using osu.Game.Rulesets.Karaoke.Objects;
+using Lyric = osu.Game.Rulesets.Karaoke.Objects.Lyric;
+using RubyTag = osu.Game.Rulesets.Karaoke.Objects.RubyTag;
+using TextIndex = osu.Framework.Graphics.Sprites.TextIndex;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
 {
@@ -28,67 +28,50 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
             output.HitObjects.Clear();
 
             string lyricText = stream.ReadToEnd();
-            var result = new LrcParser().Decode(lyricText);
+            var result = new LrcParser.Parser.Lrc.LrcParser().Decode(lyricText);
 
-            // Convert line
-            for (int i = 0; i < result.Lines.Length; i++)
+            foreach (var lrcLyric in result.Lyrics)
             {
-                // Empty line should not be imported
-                var line = result.Lines[i];
-                if (string.IsNullOrEmpty(line.Text))
-                    continue;
+                var lrcTimeTags = lrcLyric.TimeTags.Select(convertTimeTag).ToList();
+                var lrcRubies = lrcLyric.RubyTags.Select(convertRubyTag).ToArray();
 
-                try
+                double? startTime = lrcTimeTags.Select(x => x.Time).Min();
+                double? endTime = lrcTimeTags.Select(x => x.Time).Max();
+                double? duration = endTime - startTime;
+
+                var lyric = new Lyric
                 {
-                    // todo : check list ls sorted by time.
-                    var lrcTimeTag = line.TimeTags;
-                    var timeTags = line.TimeTags.Where(x => x.Check).ToDictionary(k =>
-                    {
-                        int index = (Array.IndexOf(lrcTimeTag, k) - 1) / 2;
-                        var state = (Array.IndexOf(lrcTimeTag, k) - 1) % 2 == 0 ? TextIndex.IndexState.Start : TextIndex.IndexState.End;
-                        return new TextIndex(index, state);
-                    }, v => (double)v.Time);
-
-                    double startTime = timeTags.FirstOrDefault(x => x.Value > 0).Value;
-                    double duration = timeTags.LastOrDefault(x => x.Value > 0).Value - startTime;
-
-                    var lyric = new Lyric
-                    {
-                        ID = output.HitObjects.Count, // id is star from zero.
-                        Order = output.HitObjects.Count + 1, // should create default order.
-                        Text = line.Text,
-                        // Start time and end time should be re-assigned
-                        StartTime = startTime,
-                        Duration = duration,
-                        TimeTags = ToTimeTagList(timeTags),
-                        RubyTags = result.QueryRubies(line.Text).Select(ruby => new RubyTag
-                        {
-                            Text = ruby.Ruby.Ruby,
-                            StartIndex = ruby.StartIndex,
-                            EndIndex = ruby.EndIndex
-                        }).ToArray()
-                    };
-                    lyric.InitialWorkingTime();
-                    output.HitObjects.Add(lyric);
-                }
-                catch (Exception ex)
-                {
-                    string message = $"Parsing lyric '{line.Text}' got error in line:{i}" +
-                                     "Please check time tag should be ordered and not duplicated." +
-                                     "Then re-import again.";
-                    throw new FormatException(message, ex);
-                }
+                    ID = output.HitObjects.Count, // id is star from zero.
+                    Order = output.HitObjects.Count + 1, // should create default order.
+                    Text = lrcLyric.Text,
+                    // Start time and end time should be re-assigned
+                    StartTime = startTime ?? 0,
+                    Duration = duration ?? 0,
+                    TimeTags = lrcTimeTags,
+                    RubyTags = lrcRubies
+                };
+                lyric.InitialWorkingTime();
+                output.HitObjects.Add(lyric);
             }
-        }
 
-        /// <summary>
-        /// Convert dictionary to list of time tags.
-        /// </summary>
-        /// <param name="dictionary">Dictionary.</param>
-        /// <returns>Time tags</returns>
-        internal static TimeTag[] ToTimeTagList(IReadOnlyDictionary<TextIndex, double> dictionary)
-        {
-            return dictionary.Select(d => new TimeTag(d.Key, d.Value)).ToArray();
+            static TimeTag convertTimeTag(KeyValuePair<LrcParser.Model.TextIndex, int?> timeTag)
+                => new(convertTextIndex(timeTag.Key), timeTag.Value);
+
+            static TextIndex convertTextIndex(LrcParser.Model.TextIndex textIndex)
+            {
+                int index = textIndex.Index;
+                var state = textIndex.State == IndexState.Start ? TextIndex.IndexState.Start : TextIndex.IndexState.End;
+
+                return new TextIndex(index, state);
+            }
+
+            static RubyTag convertRubyTag(LrcParser.Model.RubyTag rubyTag)
+                => new()
+                {
+                    Text = rubyTag.Text,
+                    StartIndex = rubyTag.StartIndex,
+                    EndIndex = rubyTag.EndIndex
+                };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/ILRepack.targets
+++ b/osu.Game.Rulesets.Karaoke/ILRepack.targets
@@ -4,11 +4,11 @@
         <ItemGroup>
             <InputAssemblies Include="$(OutputPath)\osu.Game.Rulesets.Karaoke.dll"/>
             <InputAssemblies Include="$(OutputPath)\LanguageDetection.dll"/>
+            <InputAssemblies Include="$(OutputPath)\LrcParser.dll"/>
             <InputAssemblies Include="$(OutputPath)\Octokit.dll"/>
             <InputAssemblies Include="$(OutputPath)\osu.Framework.KaraokeFont.dll"/>
             <InputAssemblies Include="$(OutputPath)\osu.Framework.Microphone.dll"/>
             <InputAssemblies Include="$(OutputPath)\NWaves.dll"/>
-            <InputAssemblies Include="$(OutputPath)\LyricMaker.dll"/>
             <InputAssemblies Include="$(OutputPath)\NicoKaraParser.dll"/>
             <InputAssemblies Include="$(OutputPath)\SixLabors.Fonts.dll"/>
             <InputAssemblies Include="$(OutputPath)\SixLabors.ImageSharp.Drawing.dll"/>

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
-    <PackageReference Include="LrcParser" Version="2022.527.3" />
+    <PackageReference Include="LrcParser" Version="2022.0528.0" />
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.522.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.522.0" />

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
+    <PackageReference Include="LrcParser" Version="2022.527.3" />
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.522.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.522.0" />
     <PackageReference Include="ppy.osu.Game" Version="2022.523.0" />
-    <PackageReference Include="LyricMaker" Version="1.1.1" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
     <PackageReference Include="NicoKaraParser" Version="1.1.0" />


### PR DESCRIPTION
It's time to switch to `LrcParser`.
It's a re-write package focus on encode or decode the `.lrc` format file.
More test case in this package so should be more stable.
And code quality is much more higher.

Repo:
- https://github.com/karaoke-dev/LrcParser

Nuget:
- https://www.nuget.org/packages/LrcParser