### PR TITLE
Update lrc parser to the latest

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Difficulty/KaraokeDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Difficulty/KaraokeDifficultyCalculatorTest.cs
@@ -21,8 +21,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Difficulty
 
         protected override string ResourceAssembly => "osu.Game.Rulesets.Karaoke.Tests";
 
-        [TestCase(1.7028276483104616d, 936, "karaoke-file-samples")]
-        [TestCase(1.6935488434919981d, 924, "karaoke-file-samples-without-note")]
+        [TestCase(1.7535600395779332d, 936, "karaoke-file-samples")]
+        [TestCase(1.6991673944010039d, 924, "karaoke-file-samples-without-note")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
-    <PackageReference Include="LrcParser" Version="2022.528.1" />
+    <PackageReference Include="LrcParser" Version="2022.529.1" />
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.522.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.522.0" />

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.18" />
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
-    <PackageReference Include="LrcParser" Version="2022.0528.0" />
+    <PackageReference Include="LrcParser" Version="2022.528.1" />
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.522.0" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.522.0" />


### PR DESCRIPTION
What's done in this PR:
- Update .lrc parser to the latest.
- Closes #1338.