### PR TITLE
Fix `Children cannot be cleared on a disposed drawable.` exception in the import lyric screen.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/TopNavigation.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/TopNavigation.cs
@@ -151,6 +151,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric
 
         protected virtual void CompleteClicked() => Screen.Complete();
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            editorBeatmap.TransactionEnded -= TriggerStateChange;
+        }
+
         public class NavigationTextContainer : CustomizableTextContainer
         {
             protected void AddLinkFactory(string name, string text, Action action)


### PR DESCRIPTION
Closes issue #1348