### PR TITLE
Define the common interface for the lyric property generator.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
@@ -11,6 +11,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
     [TestFixture]
     public class LanguageDetectorTest
     {
+        [TestCase("花火大会", true)]
+        [TestCase("", false)] // will not able to detect the language if lyric is empty.
+        [TestCase("   ", false)]
+        [TestCase(null, false)]
+        public void TestCanDetect(string text, bool canDetect)
+        {
+            var detector = new LanguageDetector(generateConfig());
+
+            bool actual = detector.CanDetect(new Lyric { Text = text });
+            Assert.AreEqual(canDetect, actual);
+        }
+
         [TestCase("花火大会", "zh-CN")]
         [TestCase("花火大會", "zh-TW")]
         [TestCase("Testing", "en")]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
@@ -16,12 +16,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
         [TestCase("Testing", "en")]
         [TestCase("ハナビ", "ja")]
         [TestCase("はなび", "ja")]
-        public void TestDetectLanguage(string text, string language)
+        public void TestDetect(string text, string language)
         {
             var detector = new LanguageDetector(generateConfig());
 
             var expected = new CultureInfo(language);
-            var actual = detector.DetectLanguage(new Lyric { Text = text });
+            var actual = detector.Detect(new Lyric { Text = text });
             Assert.AreEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
         [TestCase(new[] { "[0,start]:", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "ラ", "オ", "ケ" })]
         [TestCase(new[] { "[0,start]:1000" }, new string[] { })]
         [TestCase(new[] { "[0,start]:" }, new string[] { })]
-        public void TestCreateNotes(string[] timeTags, string[] expected)
+        public void TestGenerate(string[] timeTags, string[] expected)
         {
             var generator = new NoteGenerator(new NoteGeneratorConfig());
             var lyric = new Lyric
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
                 Text = "カラオケ",
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
-            var notes = generator.CreateNotes(lyric);
+            var notes = generator.Generate(lyric);
 
             string[] actual = notes.Select(x => x.Text).ToArray();
             Assert.AreEqual(expected, actual);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
@@ -12,6 +12,24 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
     [TestFixture]
     public class NoteGeneratorTest
     {
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, true)]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000" }, true)]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:" }, false)] // should have at least two time-tags with time.
+        [TestCase(new[] { "[0,start]:1000" }, false)]
+        [TestCase(new string[] { }, false)]
+        public void TestCanGenerate(string[] timeTags, bool canGenerate)
+        {
+            var generator = new NoteGenerator(new NoteGeneratorConfig());
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
+            };
+            bool actual = generator.CanGenerate(lyric);
+
+            Assert.AreEqual(canGenerate, actual);
+        }
+
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カ", "ラ", "オ", "ケ" })]
         [TestCase(new[] { "[3,end]:1000", "[3,start]:2000", "[2,start]:3000", "[1,start]:4000", "[0,start]:5000" }, new string[] { })]
         [TestCase(new[] { "[0,start]:1000", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カラ", "オ", "ケ" })] // will combine the note if time is duplicated.

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
         [TestCase("花火大会", new[] { "[0,2]:hanabi", "[2,4]:taikai" })]
         [TestCase("はなび", new[] { "[0,3]:hanabi" })]
         [TestCase("枯れた世界に輝く", new[] { "[0,3]:kareta", "[3,6]:sekaini", "[6,8]:kagayaku" })]
-        public void TestCreateRomajiTags(string text, string[] expectedRomajies)
+        public void TestGenerate(string text, string[] expectedRomajies)
         {
             var config = generatorConfig(null);
             runRomajiCheckTest(text, expectedRomajies, config);
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
 
         [TestCase("花火大会", new[] { "[0,2]:HANABI", "[2,4]:TAIKAI" })]
         [TestCase("はなび", new[] { "[0,3]:HANABI" })]
-        public void TestCreateRomajiTagsWithUppercase(string text, string[] expectedRomajies)
+        public void TestGenerateWithUppercase(string text, string[] expectedRomajies)
         {
             var config = generatorConfig(nameof(JaRomajiTagGeneratorConfig.Uppercase));
             runRomajiCheckTest(text, expectedRomajies, config);
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
             var lyric = new Lyric { Text = text };
 
             var expected = TestCaseTagHelper.ParseRomajiTags(expectedRomajies);
-            var actual = generator.CreateRomajiTags(lyric);
+            var actual = generator.Generate(lyric);
             TextTagAssert.ArePropertyEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -13,6 +13,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
 {
     public class JaRomajiTagGeneratorTest
     {
+        [TestCase("花火大会", true)]
+        [TestCase("", false)] // will not able to generate the romaji if lyric is empty.
+        [TestCase("   ", false)]
+        [TestCase(null, false)]
+        public void TestCanGenerate(string text, bool canGenerate)
+        {
+            var config = generatorConfig(null);
+            runCanGenerateRomajiCheckTest(text, canGenerate, config);
+        }
+
         [TestCase("花火大会", new[] { "[0,2]:hanabi", "[2,4]:taikai" })]
         [TestCase("はなび", new[] { "[0,3]:hanabi" })]
         [TestCase("枯れた世界に輝く", new[] { "[0,3]:kareta", "[3,6]:sekaini", "[6,8]:kagayaku" })]
@@ -31,6 +41,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
         }
 
         #region test helper
+
+        private static void runCanGenerateRomajiCheckTest(string text, bool canGenerate, JaRomajiTagGeneratorConfig config)
+        {
+            var generator = new JaRomajiTagGenerator(config);
+            var lyric = new Lyric { Text = text };
+
+            bool actual = generator.CanGenerate(lyric);
+            Assert.AreEqual(canGenerate, actual);
+        }
 
         private static void runRomajiCheckTest(string text, IEnumerable<string> expectedRomajies, JaRomajiTagGeneratorConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/RomajiTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/RomajiTagGeneratorSelectorTest.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags
         [TestCase(17, "花火大会", new[] { "[0,2]:hanabi", "[2,4]:taikai" })] // Japanese
         [TestCase(1041, "はなび", new[] { "[0,3]:hanabi" })] // Japanese
         [TestCase(1028, "はなび", null)] // Chinese(should not supported)
-        public void TestCreateRomajiTag(int lcid, string text, string[] expectedRomajies)
+        public void TestGenerate(int lcid, string text, string[] expectedRomajies)
         {
             var selector = CreateSelector();
             var lyric = new Lyric
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags
             };
 
             var expected = TestCaseTagHelper.ParseRomajiTags(expectedRomajies);
-            var actual = selector.GenerateRomajiTags(lyric);
+            var actual = selector.Generate(lyric);
             TextTagAssert.ArePropertyEqual(expected, actual);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
     {
         [TestCase("花火大会", new[] { "[0,2]:はなび", "[2,4]:たいかい" })]
         [TestCase("はなび", new string[] { })]
-        public void TestCreateRubyTags(string text, string[] expectedRubies)
+        public void TestGenerate(string text, string[] expectedRubies)
         {
             var config = generatorConfig(null);
             runRubyCheckTest(text, expectedRubies, config);
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
 
         [TestCase("花火大会", new[] { "[0,2]:ハナビ", "[2,4]:タイカイ" })]
         [TestCase("ハナビ", new string[] { })]
-        public void TestCreateRubyTagsWithRubyAsKatakana(string text, string[] expectedRubies)
+        public void TestGenerateWithRubyAsKatakana(string text, string[] expectedRubies)
         {
             var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.RubyAsKatakana));
             runRubyCheckTest(text, expectedRubies, config);
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
 
         [TestCase("はなび", new[] { "[0,2]:はな", "[2,3]:び" })]
         [TestCase("ハナビ", new[] { "[0,3]:はなび" })]
-        public void TestCreateRubyTagsWithEnableDuplicatedRuby(string text, string[] expectedRubies)
+        public void TestGenerateWithEnableDuplicatedRuby(string text, string[] expectedRubies)
         {
             var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.EnableDuplicatedRuby));
             runRubyCheckTest(text, expectedRubies, config);
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
             var lyric = new Lyric { Text = text };
 
             var expected = TestCaseTagHelper.ParseRubyTags(expectedRubies);
-            var actual = generator.CreateRubyTags(lyric);
+            var actual = generator.Generate(lyric);
             TextTagAssert.ArePropertyEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -14,6 +14,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
     [TestFixture]
     public class JaRubyTagGeneratorTest
     {
+        [TestCase("花火大会", true)]
+        [TestCase("", false)] // will not able to generate the ruby if lyric is empty.
+        [TestCase("   ", false)]
+        [TestCase(null, false)]
+        public void TestCanGenerate(string text, bool canGenerate)
+        {
+            var config = generatorConfig(null);
+            runCanGenerateRubyCheckTest(text, canGenerate, config);
+        }
+
         [TestCase("花火大会", new[] { "[0,2]:はなび", "[2,4]:たいかい" })]
         [TestCase("はなび", new string[] { })]
         public void TestGenerate(string text, string[] expectedRubies)
@@ -39,6 +49,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
         }
 
         #region test helper
+
+        private static void runCanGenerateRubyCheckTest(string text, bool canGenerate, JaRubyTagGeneratorConfig config)
+        {
+            var generator = new JaRubyTagGenerator(config);
+            var lyric = new Lyric { Text = text };
+
+            bool actual = generator.CanGenerate(lyric);
+            Assert.AreEqual(canGenerate, actual);
+        }
 
         private static void runRubyCheckTest(string text, IEnumerable<string> expectedRubies, JaRubyTagGeneratorConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/RubyTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/RubyTagGeneratorSelectorTest.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags
         [TestCase(17, "花火大会", new[] { "[0,2]:はなび", "[2,4]:たいかい" })] // Japanese
         [TestCase(1041, "はなび", new string[] { })] // Japanese
         [TestCase(1028, "はなび", null)] // Chinese(should not supported)
-        public void TestCreateRubyTag(int lcid, string text, string[] expectedRubies)
+        public void TestGenerate(int lcid, string text, string[] expectedRubies)
         {
             var selector = CreateSelector();
             var lyric = new Lyric
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags
             };
 
             var expected = TestCaseTagHelper.ParseRubyTags(expectedRubies);
-            var actual = selector.GenerateRubyTags(lyric);
+            var actual = selector.Generate(lyric);
             TextTagAssert.ArePropertyEqual(expected, actual);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -12,13 +13,22 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
     public abstract class BaseTimeTagGeneratorTest<TTimeTagGenerator, TConfig>
         where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, new()
     {
-        protected void RunTimeTagCheckTest(string text, string[] expectedTimeTags, TConfig config)
+        protected static void RunCanGenerateTimeTagCheckTest(string text, bool canGenerate, TConfig config)
+        {
+            var generator = Activator.CreateInstance(typeof(TTimeTagGenerator), config) as TTimeTagGenerator;
+            var lyric = new Lyric { Text = text };
+
+            bool? actual = generator?.CanGenerate(lyric);
+            Assert.AreEqual(canGenerate, actual);
+        }
+
+        protected static void RunTimeTagCheckTest(string text, string[] expectedTimeTags, TConfig config)
         {
             var lyric = new Lyric { Text = text };
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
         }
 
-        protected void RunTimeTagCheckTest(Lyric lyric, string[] expectedTimeTags, TConfig config)
+        protected static void RunTimeTagCheckTest(Lyric lyric, string[] expectedTimeTags, TConfig config)
         {
             var generator = Activator.CreateInstance(typeof(TTimeTagGenerator), config) as TTimeTagGenerator;
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
 
             // create time tag and actually time tag.
             var expected = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
-            var actual = generator?.CreateTimeTags(lyric);
+            var actual = generator?.Generate(lyric);
             TimeTagAssert.ArePropertyEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
     {
         [TestCase("か", new[] { "[0,start]:" }, false)]
         [TestCase("か", new[] { "[0,start]:", "[0,end]:" }, true)]
-        public void TestLyricWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckLineEndKeyUp) : null);
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
 
         [TestCase(" ", new string[] { }, false)]
         [TestCase(" ", new[] { "[0,start]:" }, true)]
-        public void TestLyricWithCheckBlankLine(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckBlankLine(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckBlankLine) : null);
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
 
         [TestCase("か     ", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:", "[5,start]:" }, false)]
         [TestCase("か     ", new[] { "[0,start]:", "[1,start]:" }, true)]
-        public void TestLyricWithCheckWhiteSpace(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckWhiteSpace(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace) : null);
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
 
         [TestCase("か ", new[] { "[0,start]:", "[1,start]:" }, false)]
         [TestCase("か ", new[] { "[0,start]:", "[0,end]:" }, true)]
-        public void TestLyricWithCheckWhiteSpaceKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckWhiteSpaceKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         [TestCase("Ａ　Ｂ　Ｃ", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
         [TestCase("Ａ　Ｂ　Ｃ", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:" }, true, false)]
         [TestCase("Ａ　Ｂ　Ｃ", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
-        public void TestLyricWithCheckWhiteSpaceAlphabet(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
+        public void TestGenerateWithCheckWhiteSpaceAlphabet(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
         {
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAlphabet) : null,
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         [TestCase("０　１　２", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
         [TestCase("０　１　２", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:" }, true, false)]
         [TestCase("０　１　２", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
-        public void TestLyricWithCheckWhiteSpaceDigit(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
+        public void TestGenerateWithCheckWhiteSpaceDigit(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
         {
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceDigit) : null,
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         [TestCase("!　!　!", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
         [TestCase("!　!　!", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:" }, true, false)]
         [TestCase("!　!　!", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
-        public void TestLyricWitCheckWhiteSpaceAsciiSymbol(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
+        public void TestGenerateWitCheckWhiteSpaceAsciiSymbol(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
         {
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAsciiSymbol) : null,
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
 
         [TestCase("がんばって", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false)]
         [TestCase("がんばって", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[4,start]:" }, true)]
-        public void TestLyricWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkん) : null);
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
@@ -92,14 +92,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
 
         [TestCase("買って", new[] { "[0,start]:", "[2,start]:" }, false)]
         [TestCase("買って", new[] { "[0,start]:", "[1,start]:", "[2,start]:" }, true)]
-        public void TestLyricWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
+        public void TestGenerateWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkっ) : null);
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);
         }
 
         [Test]
-        public void TestTagWithRubyLyric()
+        public void TestGenerateWithRubyLyric()
         {
             var config = GeneratorConfig(null);
             var lyric = new Lyric

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -10,6 +10,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
     [TestFixture]
     public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerator, JaTimeTagGeneratorConfig>
     {
+        [TestCase("花火大会", true)]
+        [TestCase("！", true)]
+        [TestCase("   ", true)]
+        [TestCase("", false)] // will not able to generate the romaji if lyric is empty.
+        [TestCase(null, false)]
+        public void TestCanGenerate(string text, bool canGenerate)
+        {
+            var config = GeneratorConfig(null);
+            RunCanGenerateTimeTagCheckTest(text, canGenerate, config);
+        }
+
         [TestCase("か", new[] { "[0,start]:" }, false)]
         [TestCase("か", new[] { "[0,start]:", "[0,end]:" }, true)]
         public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/TimeTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/TimeTagGeneratorSelectorTest.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
         [TestCase(1041, "か", new[] { "[0,start]:", "[0,end]:" })] // Japanese
         [TestCase(1028, "喵", new[] { "[0,start]:" })] // Chinese
         [TestCase(3081, "hello", null)] // English
-        public void TestCreateTimeTag(int lcid, string text, string[] expectedTimeTags)
+        public void TestGenerate(int lcid, string text, string[] expectedTimeTags)
         {
             var selector = CreateSelector();
             var lyric = new Lyric
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
             };
 
             var expected = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
-            var actual = selector.GenerateTimeTags(lyric);
+            var actual = selector.Generate(lyric);
             TimeTagAssert.ArePropertyEqual(expected, actual);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Zh
         [TestCase("測試一些歌詞", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:", "[5,start]:", "[5,end]:" })]
         [TestCase("拉拉拉~~~", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[5,end]:" })]
         [TestCase("拉~拉~拉~", new[] { "[0,start]:", "[2,start]:", "[4,start]:", "[5,end]:" })]
-        public void TestLyricWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags)
+        public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags)
         {
             var config = GeneratorConfig(nameof(ZhTimeTagGeneratorConfig.CheckLineEndKeyUp));
             RunTimeTagCheckTest(lyric, expectedTimeTags, config);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
@@ -9,6 +9,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Zh
     [TestFixture]
     public class ZhTimeTagGeneratorTest : BaseTimeTagGeneratorTest<ZhTimeTagGenerator, ZhTimeTagGeneratorConfig>
     {
+        [TestCase("拉拉拉~~~", true)]
+        [TestCase("~~~", true)]
+        [TestCase("   ", true)]
+        [TestCase("", false)] // will not able to generate the romaji if lyric is empty.
+        [TestCase(null, false)]
+        public void TestCanGenerate(string text, bool canGenerate)
+        {
+            var config = GeneratorConfig(null);
+            RunCanGenerateTimeTagCheckTest(text, canGenerate, config);
+        }
+
         [TestCase("測試一些歌詞", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:", "[5,start]:", "[5,end]:" })]
         [TestCase("拉拉拉~~~", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[5,end]:" })]
         [TestCase("拉~拉~拉~", new[] { "[0,start]:", "[2,start]:", "[4,start]:", "[5,end]:" })]

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -106,12 +106,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                 // Create default note if not exist
                 if (string.IsNullOrEmpty(line))
                 {
-                    beatmap.HitObjects.AddRange(noteGenerator.CreateNotes(lyric));
+                    beatmap.HitObjects.AddRange(noteGenerator.Generate(lyric));
                     continue;
                 }
 
                 string[] notes = line.Split(',');
-                var defaultNotes = noteGenerator.CreateNotes(lyric).ToList();
+                var defaultNotes = noteGenerator.Generate(lyric).ToList();
                 int minNoteNumber = Math.Min(notes.Length, defaultNotes.Count);
 
                 // Process each note

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricLanguageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricLanguageChangeHandler.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
             PerformOnSelection(lyric =>
             {
-                var detectedLanguage = detector.DetectLanguage(lyric);
+                var detectedLanguage = detector.Detect(lyric);
                 lyric.Language = detectedLanguage;
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandler.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                var romajiTags = selector.GenerateRomajiTags(lyric);
+                var romajiTags = selector.Generate(lyric);
                 lyric.RomajiTags = romajiTags ?? Array.Empty<RomajiTag>();
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandler.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                var rubyTags = selector.GenerateRubyTags(lyric);
+                var rubyTags = selector.Generate(lyric);
                 lyric.RubyTags = rubyTags ?? Array.Empty<RubyTag>();
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         {
             PerformOnSelection(lyric =>
             {
-                var timeTags = selector.GenerateTimeTags(lyric);
+                var timeTags = selector.Generate(lyric);
                 lyric.TimeTags = timeTags ?? Array.Empty<TimeTag>();
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotesChangeHandler.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
                 var matchedNotes = HitObjects.Where(x => x.ParentLyric == lyric).ToArray();
                 RemoveRange(matchedNotes);
 
-                var notes = generator.CreateNotes(lyric);
+                var notes = generator.Generate(lyric);
                 AddRange(notes);
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
@@ -6,13 +6,14 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 {
-    public abstract class GeneratorSelector<TBaseGenerator, TBaseConfig> where TBaseGenerator : class
+    public abstract class GeneratorSelector<TProperty, TBaseConfig>
     {
-        protected Dictionary<CultureInfo, Lazy<TBaseGenerator>> Generator { get; } = new();
+        protected Dictionary<CultureInfo, Lazy<ILyricPropertyGenerator<TProperty>>> Generator { get; } = new();
 
         private readonly KaraokeRulesetEditGeneratorConfigManager generatorConfigManager;
 
@@ -21,13 +22,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator
             this.generatorConfigManager = generatorConfigManager;
         }
 
-        protected void RegisterGenerator<TGenerator, TConfig>(CultureInfo info) where TGenerator : TBaseGenerator where TConfig : TBaseConfig, new()
+        protected void RegisterGenerator<TGenerator, TConfig>(CultureInfo info) where TGenerator : ILyricPropertyGenerator<TProperty> where TConfig : TBaseConfig, new()
         {
-            Generator.Add(info, new Lazy<TBaseGenerator>(() =>
+            Generator.Add(info, new Lazy<ILyricPropertyGenerator<TProperty>>(() =>
             {
                 var generatorSetting = GetGeneratorConfigSetting(info);
                 var config = generatorConfigManager.Get<TConfig>(generatorSetting);
-                var generator = Activator.CreateInstance(typeof(TGenerator), config) as TBaseGenerator;
+                var generator = Activator.CreateInstance(typeof(TGenerator), config) as ILyricPropertyGenerator<TProperty>;
                 return generator;
             }));
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 {
-    public abstract class GeneratorSelector<TProperty, TBaseConfig>
+    public abstract class GeneratorSelector<TProperty, TBaseConfig> : ILyricPropertyGenerator<TProperty>
     {
         protected Dictionary<CultureInfo, Lazy<ILyricPropertyGenerator<TProperty>>> Generator { get; } = new();
 
@@ -37,5 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 
         public bool CanGenerate(Lyric lyric)
             => Generator.Keys.Any(k => EqualityComparer<CultureInfo>.Default.Equals(k, lyric.Language));
+
+        public abstract TProperty Generate(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator
         protected abstract KaraokeRulesetEditGeneratorSetting GetGeneratorConfigSetting(CultureInfo info);
 
         public bool CanGenerate(Lyric lyric)
-            => Generator.Keys.Any(k => EqualityComparer<CultureInfo>.Default.Equals(k, lyric.Language));
+            => Generator.Any(g => EqualityComparer<CultureInfo>.Default.Equals(g.Key, lyric.Language) && g.Value.Value.CanGenerate(lyric));
 
         public abstract TProperty Generate(Lyric lyric);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
             }
         }
 
-        public CultureInfo DetectLanguage(Lyric lyric)
+        public CultureInfo Detect(Lyric lyric)
         {
             var result = detector.DetectAll(lyric.Text);
             string languageCode = result.FirstOrDefault()?.Language;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -4,11 +4,12 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
 {
-    public class LanguageDetector
+    public class LanguageDetector : ILyricPropertyDetector<CultureInfo>
     {
         private readonly LanguageDetection.LanguageDetector detector = new();
 
@@ -25,6 +26,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
                 detector.AddAllLanguages();
             }
         }
+
+        public bool CanDetect(Lyric lyric)
+            => !string.IsNullOrWhiteSpace(lyric.Text);
 
         public CultureInfo Detect(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
             Config = config;
         }
 
-        public Note[] CreateNotes(Lyric lyric)
+        public Note[] Generate(Lyric lyric)
         {
             var timeTags = TimeTagsUtils.ToTimeBasedDictionary(lyric.TimeTags);
             var notes = new List<Note>();

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
@@ -4,12 +4,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
 {
-    public class NoteGenerator
+    public class NoteGenerator : ILyricPropertyGenerator<Note[]>
     {
         protected NoteGeneratorConfig Config { get; }
 
@@ -17,6 +18,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
         {
             Config = config;
         }
+
+        public bool CanGenerate(Lyric lyric)
+            => lyric.TimeTags.Count(x => x.Time != null) >= 2;
 
         public Note[] Generate(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/Ja/JaRomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/Ja/JaRomajiTagGenerator.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags.Ja
             });
         }
 
-        public override RomajiTag[] CreateRomajiTags(Lyric lyric)
+        public override RomajiTag[] Generate(Lyric lyric)
         {
             string text = lyric.Text;
             var processingTags = new List<RomajiTagGeneratorParameter>();

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
@@ -15,8 +16,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
         }
     }
 
-    public abstract class RomajiTagGenerator
+    public abstract class RomajiTagGenerator : ILyricPropertyGenerator<RomajiTag[]>
     {
+        public bool CanGenerate(Lyric lyric)
+            => !string.IsNullOrWhiteSpace(lyric.Text);
+
         public abstract RomajiTag[] Generate(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
 {
-    public abstract class RomajiTagGenerator<T> : RomajiTagGenerator where T : RomajiTagGeneratorConfig
+    public abstract class RomajiTagGenerator<T> : ILyricPropertyGenerator<RomajiTag[]> where T : RomajiTagGeneratorConfig
     {
         protected T Config { get; }
 
@@ -14,10 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
         {
             Config = config;
         }
-    }
 
-    public abstract class RomajiTagGenerator : ILyricPropertyGenerator<RomajiTag[]>
-    {
         public bool CanGenerate(Lyric lyric)
             => !string.IsNullOrWhiteSpace(lyric.Text);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
 
     public abstract class RomajiTagGenerator
     {
-        public abstract RomajiTag[] CreateRomajiTags(Lyric lyric);
+        public abstract RomajiTag[] Generate(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
 {
-    public class RomajiTagGeneratorSelector : GeneratorSelector<RomajiTagGenerator, RomajiTagGeneratorConfig>
+    public class RomajiTagGeneratorSelector : GeneratorSelector<RomajiTag[], RomajiTagGeneratorConfig>
     {
         public RomajiTagGeneratorSelector(KaraokeRulesetEditGeneratorConfigManager generatorConfigManager)
             : base(generatorConfigManager)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
             RegisterGenerator<JaRomajiTagGenerator, JaRomajiTagGeneratorConfig>(new CultureInfo(1041));
         }
 
-        public RomajiTag[] Generate(Lyric lyric)
+        public override RomajiTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGeneratorSelector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
             RegisterGenerator<JaRomajiTagGenerator, JaRomajiTagGeneratorConfig>(new CultureInfo(1041));
         }
 
-        public RomajiTag[] GenerateRomajiTags(Lyric lyric)
+        public RomajiTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
             if (!Generator.TryGetValue(lyric.Language, out var generator))
                 return null;
 
-            return generator.Value.CreateRomajiTags(lyric);
+            return generator.Value.Generate(lyric);
         }
 
         protected override KaraokeRulesetEditGeneratorSetting GetGeneratorConfigSetting(CultureInfo info)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/Ja/JaRubyTagGenerator.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja
             });
         }
 
-        public override RubyTag[] CreateRubyTags(Lyric lyric)
+        public override RubyTag[] Generate(Lyric lyric)
         {
             string text = lyric.Text;
             var tags = new List<RubyTag>();

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
 
     public abstract class RubyTagGenerator
     {
-        public abstract RubyTag[] CreateRubyTags(Lyric lyric);
+        public abstract RubyTag[] Generate(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
 {
-    public abstract class RubyTagGenerator<T> : RubyTagGenerator where T : RubyTagGeneratorConfig
+    public abstract class RubyTagGenerator<T> : ILyricPropertyGenerator<RubyTag[]> where T : RubyTagGeneratorConfig
     {
         protected T Config { get; }
 
@@ -14,10 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
         {
             Config = config;
         }
-    }
 
-    public abstract class RubyTagGenerator : ILyricPropertyGenerator<RubyTag[]>
-    {
         public bool CanGenerate(Lyric lyric)
             => !string.IsNullOrWhiteSpace(lyric.Text);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
@@ -15,8 +16,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
         }
     }
 
-    public abstract class RubyTagGenerator
+    public abstract class RubyTagGenerator : ILyricPropertyGenerator<RubyTag[]>
     {
+        public bool CanGenerate(Lyric lyric)
+            => !string.IsNullOrWhiteSpace(lyric.Text);
+
         public abstract RubyTag[] Generate(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
 {
-    public class RubyTagGeneratorSelector : GeneratorSelector<RubyTagGenerator, RubyTagGeneratorConfig>
+    public class RubyTagGeneratorSelector : GeneratorSelector<RubyTag[], RubyTagGeneratorConfig>
     {
         public RubyTagGeneratorSelector(KaraokeRulesetEditGeneratorConfigManager generatorConfigManager)
             : base(generatorConfigManager)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
             RegisterGenerator<JaRubyTagGenerator, JaRubyTagGeneratorConfig>(new CultureInfo(1041));
         }
 
-        public RubyTag[] Generate(Lyric lyric)
+        public override RubyTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGeneratorSelector.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
             RegisterGenerator<JaRubyTagGenerator, JaRubyTagGeneratorConfig>(new CultureInfo(1041));
         }
 
-        public RubyTag[] GenerateRubyTags(Lyric lyric)
+        public RubyTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
             if (!Generator.TryGetValue(lyric.Language, out var generator))
                 return null;
 
-            return generator.Value.CreateRubyTags(lyric);
+            return generator.Value.Generate(lyric);
         }
 
         protected override KaraokeRulesetEditGeneratorSetting GetGeneratorConfigSetting(CultureInfo info)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
@@ -9,19 +9,14 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
 {
-    public abstract class TimeTagGenerator<T> : TimeTagGenerator where T : TimeTagGeneratorConfig
+    public abstract class TimeTagGenerator<T> : ILyricPropertyGenerator<TimeTag[]> where T : TimeTagGeneratorConfig
     {
-        protected new T Config => base.Config as T;
+        protected T Config { get; }
 
         protected TimeTagGenerator(T config)
         {
-            base.Config = config;
+            Config = config;
         }
-    }
-
-    public abstract class TimeTagGenerator : ILyricPropertyGenerator<TimeTag[]>
-    {
-        protected TimeTagGeneratorConfig Config { get; set; }
 
         public bool CanGenerate(Lyric lyric)
             => !string.IsNullOrEmpty(lyric.Text);

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
     {
         protected TimeTagGeneratorConfig Config { get; set; }
 
-        public virtual TimeTag[] CreateTimeTags(Lyric lyric)
+        public virtual TimeTag[] Generate(Lyric lyric)
         {
             var timeTags = new List<TimeTag>();
             string text = lyric.Text;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
@@ -18,9 +19,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
         }
     }
 
-    public abstract class TimeTagGenerator
+    public abstract class TimeTagGenerator : ILyricPropertyGenerator<TimeTag[]>
     {
         protected TimeTagGeneratorConfig Config { get; set; }
+
+        public bool CanGenerate(Lyric lyric)
+            => !string.IsNullOrEmpty(lyric.Text);
 
         public virtual TimeTag[] Generate(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
             RegisterGenerator<ZhTimeTagGenerator, ZhTimeTagGeneratorConfig>(new CultureInfo(1028));
         }
 
-        public TimeTag[] Generate(Lyric lyric)
+        public override TimeTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
             RegisterGenerator<ZhTimeTagGenerator, ZhTimeTagGeneratorConfig>(new CultureInfo(1028));
         }
 
-        public TimeTag[] GenerateTimeTags(Lyric lyric)
+        public TimeTag[] Generate(Lyric lyric)
         {
             if (lyric.Language == null)
                 return null;
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
             if (!Generator.TryGetValue(lyric.Language, out var generator))
                 return null;
 
-            return generator.Value.CreateTimeTags(lyric);
+            return generator.Value.Generate(lyric);
         }
 
         protected override KaraokeRulesetEditGeneratorSetting GetGeneratorConfigSetting(CultureInfo info) =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGeneratorSelector.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
 {
-    public class TimeTagGeneratorSelector : GeneratorSelector<TimeTagGenerator, TimeTagGeneratorConfig>
+    public class TimeTagGeneratorSelector : GeneratorSelector<TimeTag[], TimeTagGeneratorConfig>
     {
         public TimeTagGeneratorSelector(KaraokeRulesetEditGeneratorConfigManager generatorConfigManager)
             : base(generatorConfigManager)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyDetector.cs
@@ -1,0 +1,28 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
+{
+    /// <summary>
+    /// Base interface of the detector.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ILyricPropertyDetector<out T>
+    {
+        /// <summary>
+        /// Determined if detect property from lyric is supported.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        bool CanDetect(Lyric lyric);
+
+        /// <summary>
+        /// Detect the property from the lyric.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        T Detect(Lyric lyric);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyGenerator.cs
@@ -1,0 +1,28 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
+{
+    /// <summary>
+    /// Base interface of the auto-generator.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ILyricPropertyGenerator<out T>
+    {
+        /// <summary>
+        /// Determined if generate property from lyric is supported.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        bool CanGenerate(Lyric lyric);
+
+        /// <summary>
+        /// Generate the property from the lyric.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        T Generate(Lyric lyric);
+    }
+}


### PR DESCRIPTION
It's the preparation of the #1335

What's done in this PR:
- generate the common interface.
- Should able to check if lyric property is able to be detected or generated in the detector or the generator.
- Apply the interface in the generator.
- Apply the interface in the selector.
- Should check if lyric property is able to be generated in the selected generator.