### PR TITLE
Should not able to select if there's no auto-generator for the current language.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
         {
             var detector = new LanguageDetector(generateConfig());
 
-            bool actual = detector.CanDetect(new Lyric { Text = text });
+            bool actual = detector.GetInvalidMessage(new Lyric { Text = text }) == null;
             Assert.AreEqual(canDetect, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
     {
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, true)]
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000" }, true)]
+        [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:" }, false)] // all time-tag should with time.
         [TestCase(new[] { "[0,start]:1000", "[1,start]:" }, false)] // should have at least two time-tags with time.
         [TestCase(new[] { "[0,start]:1000" }, false)]
         [TestCase(new string[] { }, false)]
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
                 Text = "カラオケ",
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
-            bool actual = generator.CanGenerate(lyric);
+            bool actual = generator.GetInvalidMessage(lyric) == null;
 
             Assert.AreEqual(canGenerate, actual);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
             var generator = new JaRomajiTagGenerator(config);
             var lyric = new Lyric { Text = text };
 
-            bool actual = generator.CanGenerate(lyric);
+            bool actual = generator.GetInvalidMessage(lyric) == null;
             Assert.AreEqual(canGenerate, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
             var generator = new JaRubyTagGenerator(config);
             var lyric = new Lyric { Text = text };
 
-            bool actual = generator.CanGenerate(lyric);
+            bool actual = generator.GetInvalidMessage(lyric) == null;
             Assert.AreEqual(canGenerate, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
             var generator = Activator.CreateInstance(typeof(TTimeTagGenerator), config) as TTimeTagGenerator;
             var lyric = new Lyric { Text = text };
 
-            bool? actual = generator?.CanGenerate(lyric);
+            bool? actual = generator?.GetInvalidMessage(lyric) == null;
             Assert.AreEqual(canGenerate, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorSelector.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -35,8 +36,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 
         protected abstract KaraokeRulesetEditGeneratorSetting GetGeneratorConfigSetting(CultureInfo info);
 
-        public bool CanGenerate(Lyric lyric)
-            => Generator.Any(g => EqualityComparer<CultureInfo>.Default.Equals(g.Key, lyric.Language) && g.Value.Value.CanGenerate(lyric));
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            if (lyric.Language == null)
+                return "Oops, language is missing.";
+
+            var generator = Generator.FirstOrDefault(g => EqualityComparer<CultureInfo>.Default.Equals(g.Key, lyric.Language));
+            if (generator.Key == null)
+                return "Sorry, the language of lyric is not supported yet.";
+
+            return generator.Value.Value.GetInvalidMessage(lyric);
+        }
 
         public abstract TProperty Generate(Lyric lyric);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Languages/LanguageDetector.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -27,8 +28,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Languages
             }
         }
 
-        public bool CanDetect(Lyric lyric)
-            => !string.IsNullOrWhiteSpace(lyric.Text);
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            if (string.IsNullOrWhiteSpace(lyric.Text))
+                return "Lyric should not be empty.";
+
+            return null;
+        }
 
         public CultureInfo Detect(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -19,8 +20,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
             Config = config;
         }
 
-        public bool CanGenerate(Lyric lyric)
-            => lyric.TimeTags.Count(x => x.Time != null) >= 2;
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            var timeTags = lyric.TimeTags;
+
+            if (lyric.TimeTags.Count < 2)
+                return "Sorry, lyric must have at least two time-tags.";
+
+            if (timeTags.Any(x => x.Time == null))
+                return "All time-tag should have the time.";
+
+            return null;
+        }
 
         public Note[] Generate(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RomajiTags/RomajiTagGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -15,8 +16,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags
             Config = config;
         }
 
-        public bool CanGenerate(Lyric lyric)
-            => !string.IsNullOrWhiteSpace(lyric.Text);
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            if (string.IsNullOrWhiteSpace(lyric.Text))
+                return "Lyric should not be empty.";
+
+            return null;
+        }
 
         public abstract RomajiTag[] Generate(Lyric lyric);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/RubyTags/RubyTagGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -15,8 +16,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags
             Config = config;
         }
 
-        public bool CanGenerate(Lyric lyric)
-            => !string.IsNullOrWhiteSpace(lyric.Text);
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            if (string.IsNullOrWhiteSpace(lyric.Text))
+                return "Lyric should not be empty.";
+
+            return null;
+        }
 
         public abstract RubyTag[] Generate(Lyric lyric);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/TimeTags/TimeTagGenerator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -18,8 +19,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags
             Config = config;
         }
 
-        public bool CanGenerate(Lyric lyric)
-            => !string.IsNullOrEmpty(lyric.Text);
+        public LocalisableString? GetInvalidMessage(Lyric lyric)
+        {
+            if (string.IsNullOrEmpty(lyric.Text))
+                return "Lyric should not be empty.";
+
+            return null;
+        }
 
         public virtual TimeTag[] Generate(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyDetector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
@@ -16,7 +17,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
         /// </summary>
         /// <param name="lyric"></param>
         /// <returns></returns>
-        bool CanDetect(Lyric lyric);
+        bool CanDetect(Lyric lyric) => GetInvalidMessage(lyric) == null;
+
+        /// <summary>
+        /// Will get the invalid message if lyric property is not able to be detected.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        LocalisableString? GetInvalidMessage(Lyric lyric);
 
         /// <summary>
         /// Detect the property from the lyric.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Types/ILyricPropertyGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
@@ -16,7 +17,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Types
         /// </summary>
         /// <param name="lyric"></param>
         /// <returns></returns>
-        bool CanGenerate(Lyric lyric);
+        bool CanGenerate(Lyric lyric) => GetInvalidMessage(lyric) == null;
+
+        /// <summary>
+        /// Will get the invalid message if lyric property is not able to be generated.
+        /// </summary>
+        /// <param name="lyric"></param>
+        /// <returns></returns>
+        LocalisableString? GetInvalidMessage(Lyric lyric);
 
         /// <summary>
         /// Generate the property from the lyric.


### PR DESCRIPTION
<img width="400" alt="image" src="https://user-images.githubusercontent.com/9100368/171834702-4a80ce0f-cf21-4715-9613-8eecc392553b.png">
Implement most feature part of the #1335

What's done in this PR:
- Implement new interface for able to return the invalid message in the detector or the generator.
- Use the message directly in the generator or the detector.