### PR TITLE
Refactor the test case for the generator.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BaseDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BaseDetectorTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator
+{
+    public abstract class BaseDetectorTest<TDetector, TObject, TConfig>
+        where TDetector : class, ILyricPropertyDetector<TObject> where TConfig : new()
+    {
+        protected static TConfig GeneratorConfig(params string[] properties)
+        {
+            var config = new TConfig();
+            if (properties == null)
+                return config;
+
+            foreach (string propertyName in properties)
+            {
+                if (propertyName == null)
+                    continue;
+
+                var theMethod = config.GetType().GetProperty(propertyName);
+                if (theMethod == null)
+                    throw new MissingMethodException("Config is not exist.");
+
+                theMethod.SetValue(config, true);
+            }
+
+            return config;
+        }
+
+        protected static void CheckCanDetect(string text, bool canDetect, TConfig config)
+        {
+            var lyric = new Lyric { Text = text };
+            CheckCanDetect(lyric, canDetect, config);
+        }
+
+        protected static void CheckCanDetect(Lyric lyric, bool canDetect, TConfig config)
+        {
+            if (Activator.CreateInstance(typeof(TDetector), config) is not TDetector detector)
+                throw new ArgumentNullException(nameof(detector));
+
+            bool actual = detector.CanDetect(lyric);
+            Assert.AreEqual(canDetect, actual);
+        }
+
+        protected void CheckDetectResult(string text, TObject expected, TConfig config)
+        {
+            var lyric = new Lyric { Text = text };
+            CheckDetectResult(lyric, expected, config);
+        }
+
+        protected void CheckDetectResult(Lyric lyric, TObject expected, TConfig config)
+        {
+            if (Activator.CreateInstance(typeof(TDetector), config) is not TDetector detector)
+                throw new ArgumentNullException(nameof(detector));
+
+            // create time tag and actually time tag.
+            var actual = detector.Detect(lyric);
+            AssertEqual(expected, actual);
+        }
+
+        protected abstract void AssertEqual(TObject expected, TObject actual);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BaseGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BaseGeneratorTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Generator.Types;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator
+{
+    public abstract class BaseGeneratorTest<TGenerator, TObject, TConfig>
+        where TGenerator : class, ILyricPropertyGenerator<TObject> where TConfig : new()
+    {
+        protected static TConfig GeneratorConfig(params string[] properties)
+        {
+            var config = new TConfig();
+            if (properties == null)
+                return config;
+
+            foreach (string propertyName in properties)
+            {
+                if (propertyName == null)
+                    continue;
+
+                var theMethod = config.GetType().GetProperty(propertyName);
+                if (theMethod == null)
+                    throw new MissingMethodException("Config is not exist.");
+
+                theMethod.SetValue(config, true);
+            }
+
+            return config;
+        }
+
+        protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
+        {
+            var lyric = new Lyric { Text = text };
+            CheckCanGenerate(lyric, canGenerate, config);
+        }
+
+        protected static void CheckCanGenerate(Lyric lyric, bool canGenerate, TConfig config)
+        {
+            if (Activator.CreateInstance(typeof(TGenerator), config) is not TGenerator generator)
+                throw new ArgumentNullException(nameof(generator));
+
+            bool actual = generator.CanGenerate(lyric);
+            Assert.AreEqual(canGenerate, actual);
+        }
+
+        protected void CheckGenerateResult(string text, TObject expected, TConfig config)
+        {
+            var lyric = new Lyric { Text = text };
+            CheckGenerateResult(lyric, expected, config);
+        }
+
+        protected void CheckGenerateResult(Lyric lyric, TObject expected, TConfig config)
+        {
+            if (Activator.CreateInstance(typeof(TGenerator), config) is not TGenerator generator)
+                throw new ArgumentNullException(nameof(generator));
+
+            // create time tag and actually time tag.
+            var actual = generator.Generate(lyric);
+            AssertEqual(expected, actual);
+        }
+
+        protected abstract void AssertEqual(TObject expected, TObject actual);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Languages/LanguageDetectorTest.cs
@@ -4,12 +4,11 @@
 using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Languages;
-using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
 {
     [TestFixture]
-    public class LanguageDetectorTest
+    public class LanguageDetectorTest : BaseDetectorTest<LanguageDetector, CultureInfo, LanguageDetectorConfig>
     {
         [TestCase("花火大会", true)]
         [TestCase("", false)] // will not able to detect the language if lyric is empty.
@@ -17,10 +16,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
         [TestCase(null, false)]
         public void TestCanDetect(string text, bool canDetect)
         {
-            var detector = new LanguageDetector(generateConfig());
-
-            bool actual = detector.GetInvalidMessage(new Lyric { Text = text }) == null;
-            Assert.AreEqual(canDetect, actual);
+            var config = GeneratorConfig();
+            CheckCanDetect(text, canDetect, config);
         }
 
         [TestCase("花火大会", "zh-CN")]
@@ -30,13 +27,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Languages
         [TestCase("はなび", "ja")]
         public void TestDetect(string text, string language)
         {
-            var detector = new LanguageDetector(generateConfig());
-
+            var config = GeneratorConfig();
             var expected = new CultureInfo(language);
-            var actual = detector.Detect(new Lyric { Text = text });
-            Assert.AreEqual(expected, actual);
+            CheckDetectResult(text, expected, config);
         }
 
-        private static LanguageDetectorConfig generateConfig() => new();
+        protected override void AssertEqual(CultureInfo expected, CultureInfo actual)
+        {
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Notes/NoteGeneratorTest.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
 {
     [TestFixture]
-    public class NoteGeneratorTest
+    public class NoteGeneratorTest : BaseGeneratorTest<NoteGenerator, Note[], NoteGeneratorConfig>
     {
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, true)]
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000" }, true)]
@@ -20,15 +20,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
         [TestCase(new string[] { }, false)]
         public void TestCanGenerate(string[] timeTags, bool canGenerate)
         {
-            var generator = new NoteGenerator(new NoteGeneratorConfig());
+            var config = GeneratorConfig();
             var lyric = new Lyric
             {
                 Text = "カラオケ",
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
-            bool actual = generator.GetInvalidMessage(lyric) == null;
 
-            Assert.AreEqual(canGenerate, actual);
+            CheckCanGenerate(lyric, canGenerate, config);
         }
 
         [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カ", "ラ", "オ", "ケ" })]
@@ -38,18 +37,29 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Notes
         [TestCase(new[] { "[0,start]:", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "ラ", "オ", "ケ" })]
         [TestCase(new[] { "[0,start]:1000" }, new string[] { })]
         [TestCase(new[] { "[0,start]:" }, new string[] { })]
-        public void TestGenerate(string[] timeTags, string[] expected)
+        public void TestGenerate(string[] timeTags, string[] expectedNotes)
         {
-            var generator = new NoteGenerator(new NoteGeneratorConfig());
+            var config = GeneratorConfig();
             var lyric = new Lyric
             {
                 Text = "カラオケ",
                 TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags),
             };
-            var notes = generator.Generate(lyric);
+            CheckGenerateResult(lyric, expectedNotes, config);
+        }
 
-            string[] actual = notes.Select(x => x.Text).ToArray();
-            Assert.AreEqual(expected, actual);
+        protected void CheckGenerateResult(Lyric lyric, string[] expectedNotes, NoteGeneratorConfig config)
+        {
+            var expected = expectedNotes.Select(x => new Note
+            {
+                Text = x
+            }).ToArray();
+            CheckGenerateResult(lyric, expected, config);
+        }
+
+        protected override void AssertEqual(Note[] expected, Note[] actual)
+        {
+            Assert.AreEqual(expected.Select(x => x.Text), actual.Select(x => x.Text));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/BaseRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/BaseRomajiTagGeneratorTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags
+{
+    public abstract class BaseRomajiTagGeneratorTest<TRomajiTagGenerator, TConfig> : BaseGeneratorTest<TRomajiTagGenerator, RomajiTag[], TConfig>
+        where TRomajiTagGenerator : RomajiTagGenerator<TConfig> where TConfig : RomajiTagGeneratorConfig, new()
+    {
+        protected void CheckGenerateResult(string text, string[] expectedRubies, TConfig config)
+        {
+            var expected = TestCaseTagHelper.ParseRomajiTags(expectedRubies);
+            CheckGenerateResult(text, expected, config);
+        }
+
+        protected override void AssertEqual(RomajiTag[] expected, RomajiTag[] actual)
+        {
+            TextTagAssert.ArePropertyEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -1,17 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RomajiTags.Ja;
-using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Tests.Asserts;
-using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
 {
-    public class JaRomajiTagGeneratorTest
+    public class JaRomajiTagGeneratorTest : BaseRomajiTagGeneratorTest<JaRomajiTagGenerator, JaRomajiTagGeneratorConfig>
     {
         [TestCase("花火大会", true)]
         [TestCase("", false)] // will not able to generate the romaji if lyric is empty.
@@ -19,8 +14,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
         [TestCase(null, false)]
         public void TestCanGenerate(string text, bool canGenerate)
         {
-            var config = generatorConfig(null);
-            runCanGenerateRomajiCheckTest(text, canGenerate, config);
+            var config = GeneratorConfig();
+            CheckCanGenerate(text, canGenerate, config);
         }
 
         [TestCase("花火大会", new[] { "[0,2]:hanabi", "[2,4]:taikai" })]
@@ -28,60 +23,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RomajiTags.Ja
         [TestCase("枯れた世界に輝く", new[] { "[0,3]:kareta", "[3,6]:sekaini", "[6,8]:kagayaku" })]
         public void TestGenerate(string text, string[] expectedRomajies)
         {
-            var config = generatorConfig(null);
-            runRomajiCheckTest(text, expectedRomajies, config);
+            var config = GeneratorConfig();
+            CheckGenerateResult(text, expectedRomajies, config);
         }
 
         [TestCase("花火大会", new[] { "[0,2]:HANABI", "[2,4]:TAIKAI" })]
         [TestCase("はなび", new[] { "[0,3]:HANABI" })]
         public void TestGenerateWithUppercase(string text, string[] expectedRomajies)
         {
-            var config = generatorConfig(nameof(JaRomajiTagGeneratorConfig.Uppercase));
-            runRomajiCheckTest(text, expectedRomajies, config);
+            var config = GeneratorConfig(nameof(JaRomajiTagGeneratorConfig.Uppercase));
+            CheckGenerateResult(text, expectedRomajies, config);
         }
-
-        #region test helper
-
-        private static void runCanGenerateRomajiCheckTest(string text, bool canGenerate, JaRomajiTagGeneratorConfig config)
-        {
-            var generator = new JaRomajiTagGenerator(config);
-            var lyric = new Lyric { Text = text };
-
-            bool actual = generator.GetInvalidMessage(lyric) == null;
-            Assert.AreEqual(canGenerate, actual);
-        }
-
-        private static void runRomajiCheckTest(string text, IEnumerable<string> expectedRomajies, JaRomajiTagGeneratorConfig config)
-        {
-            var generator = new JaRomajiTagGenerator(config);
-            var lyric = new Lyric { Text = text };
-
-            var expected = TestCaseTagHelper.ParseRomajiTags(expectedRomajies);
-            var actual = generator.Generate(lyric);
-            TextTagAssert.ArePropertyEqual(expected, actual);
-        }
-
-        private static JaRomajiTagGeneratorConfig generatorConfig(params string[] properties)
-        {
-            var config = new JaRomajiTagGeneratorConfig();
-            if (properties == null)
-                return config;
-
-            foreach (string propertyName in properties)
-            {
-                if (propertyName == null)
-                    continue;
-
-                var theMethod = config.GetType().GetProperty(propertyName);
-                if (theMethod == null)
-                    throw new MissingMethodException("Config is not exist.");
-
-                theMethod.SetValue(config, true);
-            }
-
-            return config;
-        }
-
-        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/BaseRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/BaseRubyTagGeneratorTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags
+{
+    public abstract class BaseRubyTagGeneratorTest<TRubyTagGenerator, TConfig> : BaseGeneratorTest<TRubyTagGenerator, RubyTag[], TConfig>
+        where TRubyTagGenerator : RubyTagGenerator<TConfig> where TConfig : RubyTagGeneratorConfig, new()
+    {
+        protected void CheckGenerateResult(string text, string[] expectedRubies, TConfig config)
+        {
+            var expected = TestCaseTagHelper.ParseRubyTags(expectedRubies);
+            CheckGenerateResult(text, expected, config);
+        }
+
+        protected override void AssertEqual(RubyTag[] expected, RubyTag[] actual)
+        {
+            TextTagAssert.ArePropertyEqual(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -1,18 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.RubyTags.Ja;
-using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Tests.Asserts;
-using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
 {
     [TestFixture]
-    public class JaRubyTagGeneratorTest
+    public class JaRubyTagGeneratorTest : BaseRubyTagGeneratorTest<JaRubyTagGenerator, JaRubyTagGeneratorConfig>
     {
         [TestCase("花火大会", true)]
         [TestCase("", false)] // will not able to generate the ruby if lyric is empty.
@@ -20,76 +15,32 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.RubyTags.Ja
         [TestCase(null, false)]
         public void TestCanGenerate(string text, bool canGenerate)
         {
-            var config = generatorConfig(null);
-            runCanGenerateRubyCheckTest(text, canGenerate, config);
+            var config = GeneratorConfig();
+            CheckCanGenerate(text, canGenerate, config);
         }
 
         [TestCase("花火大会", new[] { "[0,2]:はなび", "[2,4]:たいかい" })]
         [TestCase("はなび", new string[] { })]
         public void TestGenerate(string text, string[] expectedRubies)
         {
-            var config = generatorConfig(null);
-            runRubyCheckTest(text, expectedRubies, config);
+            var config = GeneratorConfig();
+            CheckGenerateResult(text, expectedRubies, config);
         }
 
         [TestCase("花火大会", new[] { "[0,2]:ハナビ", "[2,4]:タイカイ" })]
         [TestCase("ハナビ", new string[] { })]
         public void TestGenerateWithRubyAsKatakana(string text, string[] expectedRubies)
         {
-            var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.RubyAsKatakana));
-            runRubyCheckTest(text, expectedRubies, config);
+            var config = GeneratorConfig(nameof(JaRubyTagGeneratorConfig.RubyAsKatakana));
+            CheckGenerateResult(text, expectedRubies, config);
         }
 
         [TestCase("はなび", new[] { "[0,2]:はな", "[2,3]:び" })]
         [TestCase("ハナビ", new[] { "[0,3]:はなび" })]
         public void TestGenerateWithEnableDuplicatedRuby(string text, string[] expectedRubies)
         {
-            var config = generatorConfig(nameof(JaRubyTagGeneratorConfig.EnableDuplicatedRuby));
-            runRubyCheckTest(text, expectedRubies, config);
+            var config = GeneratorConfig(nameof(JaRubyTagGeneratorConfig.EnableDuplicatedRuby));
+            CheckGenerateResult(text, expectedRubies, config);
         }
-
-        #region test helper
-
-        private static void runCanGenerateRubyCheckTest(string text, bool canGenerate, JaRubyTagGeneratorConfig config)
-        {
-            var generator = new JaRubyTagGenerator(config);
-            var lyric = new Lyric { Text = text };
-
-            bool actual = generator.GetInvalidMessage(lyric) == null;
-            Assert.AreEqual(canGenerate, actual);
-        }
-
-        private static void runRubyCheckTest(string text, IEnumerable<string> expectedRubies, JaRubyTagGeneratorConfig config)
-        {
-            var generator = new JaRubyTagGenerator(config);
-            var lyric = new Lyric { Text = text };
-
-            var expected = TestCaseTagHelper.ParseRubyTags(expectedRubies);
-            var actual = generator.Generate(lyric);
-            TextTagAssert.ArePropertyEqual(expected, actual);
-        }
-
-        private static JaRubyTagGeneratorConfig generatorConfig(params string[] properties)
-        {
-            var config = new JaRubyTagGeneratorConfig();
-            if (properties == null)
-                return config;
-
-            foreach (string propertyName in properties)
-            {
-                if (propertyName == null)
-                    continue;
-
-                var theMethod = config.GetType().GetProperty(propertyName);
-                if (theMethod == null)
-                    throw new MissingMethodException("Config is not exist.");
-
-                theMethod.SetValue(config, true);
-            }
-
-            return config;
-        }
-
-        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.TimeTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -10,53 +8,24 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags
 {
-    public abstract class BaseTimeTagGeneratorTest<TTimeTagGenerator, TConfig>
+    public abstract class BaseTimeTagGeneratorTest<TTimeTagGenerator, TConfig> : BaseGeneratorTest<TTimeTagGenerator, TimeTag[], TConfig>
         where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, new()
     {
-        protected static void RunCanGenerateTimeTagCheckTest(string text, bool canGenerate, TConfig config)
+        protected void CheckGenerateResult(string text, string[] expectedTimeTags, TConfig config)
         {
-            var generator = Activator.CreateInstance(typeof(TTimeTagGenerator), config) as TTimeTagGenerator;
-            var lyric = new Lyric { Text = text };
-
-            bool? actual = generator?.GetInvalidMessage(lyric) == null;
-            Assert.AreEqual(canGenerate, actual);
-        }
-
-        protected static void RunTimeTagCheckTest(string text, string[] expectedTimeTags, TConfig config)
-        {
-            var lyric = new Lyric { Text = text };
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
-        }
-
-        protected static void RunTimeTagCheckTest(Lyric lyric, string[] expectedTimeTags, TConfig config)
-        {
-            var generator = Activator.CreateInstance(typeof(TTimeTagGenerator), config) as TTimeTagGenerator;
-
-            // create time tag and actually time tag.
             var expected = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
-            var actual = generator?.Generate(lyric);
-            TimeTagAssert.ArePropertyEqual(expected, actual);
+            CheckGenerateResult(text, expected, config);
         }
 
-        protected TConfig GeneratorConfig(params string[] properties)
+        protected void CheckGenerateResult(Lyric lyric, string[] expectedTimeTags, TConfig config)
         {
-            var config = new TConfig();
-            if (properties == null)
-                return config;
+            var expected = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
+            CheckGenerateResult(lyric, expected, config);
+        }
 
-            foreach (string propertyName in properties)
-            {
-                if (propertyName == null)
-                    continue;
-
-                var theMethod = config.GetType().GetProperty(propertyName);
-                if (theMethod == null)
-                    throw new MissingMethodException("Config is not exist.");
-
-                theMethod.SetValue(config, true);
-            }
-
-            return config;
+        protected override void AssertEqual(TimeTag[] expected, TimeTag[] actual)
+        {
+            TimeTagAssert.ArePropertyEqual(expected, actual);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         [TestCase(null, false)]
         public void TestCanGenerate(string text, bool canGenerate)
         {
-            var config = GeneratorConfig(null);
-            RunCanGenerateTimeTagCheckTest(text, canGenerate, config);
+            var config = GeneratorConfig();
+            CheckCanGenerate(text, canGenerate, config);
         }
 
         [TestCase("か", new[] { "[0,start]:" }, false)]
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckLineEndKeyUp) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase(" ", new string[] { }, false)]
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         public void TestGenerateWithCheckBlankLine(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckBlankLine) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("か     ", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:", "[5,start]:" }, false)]
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         public void TestGenerateWithCheckWhiteSpace(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("か ", new[] { "[0,start]:", "[1,start]:" }, false)]
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         {
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("a　b　c", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAlphabet) : null,
                 keyUp ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("0　1　2", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceDigit) : null,
                 keyUp ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("!　!　!", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false, false)]
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
             var config = GeneratorConfig(nameof(JaTimeTagGeneratorConfig.CheckWhiteSpace),
                 applyConfig ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceAsciiSymbol) : null,
                 keyUp ? nameof(JaTimeTagGeneratorConfig.CheckWhiteSpaceKeyUp) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("がんばって", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false)]
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         public void TestGenerateWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkん) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [TestCase("買って", new[] { "[0,start]:", "[2,start]:" }, false)]
@@ -106,13 +106,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
         public void TestGenerateWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
             var config = GeneratorConfig(applyConfig ? nameof(JaTimeTagGeneratorConfig.Checkっ) : null);
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
         [Test]
         public void TestGenerateWithRubyLyric()
         {
-            var config = GeneratorConfig(null);
+            var config = GeneratorConfig();
             var lyric = new Lyric
             {
                 Text = "明日いっしょに遊びましょう！",
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
                 }
             };
 
-            string[] actualTimeTags =
+            string[] expectedTimeTags =
             {
                 "[0,start]:",
                 "[0,start]:",
@@ -149,7 +149,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Ja
                 "[12,start]:",
                 "[13,start]:"
             };
-            RunTimeTagCheckTest(lyric, actualTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Zh
         [TestCase(null, false)]
         public void TestCanGenerate(string text, bool canGenerate)
         {
-            var config = GeneratorConfig(null);
-            RunCanGenerateTimeTagCheckTest(text, canGenerate, config);
+            var config = GeneratorConfig();
+            CheckCanGenerate(text, canGenerate, config);
         }
 
         [TestCase("測試一些歌詞", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[3,start]:", "[4,start]:", "[5,start]:", "[5,end]:" })]
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.TimeTags.Zh
         public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags)
         {
             var config = GeneratorConfig(nameof(ZhTimeTagGeneratorConfig.CheckLineEndKeyUp));
-            RunTimeTagCheckTest(lyric, expectedTimeTags, config);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
         }
     }
 }


### PR DESCRIPTION
Implement part of the #1335.
Because all generator/detector inherit the same interface, so it should be able to make the base class and merge the same testing tools.