### PR TITLE
Fix preview note playfield crash in the config page.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay
                 StartTime = startTime,
                 Duration = 1000,
                 Text = "Note",
+                ParentLyric = new Lyric(),
                 HitWindows = new KaraokeNoteHitWindows(),
             });
 


### PR DESCRIPTION
Due to missing parent lyric, which needed in the drawable note.