### PR TITLE
Use current value instead of set value in the component.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
@@ -30,9 +30,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             Component.Value = GetFieldValue(item);
 
             // should change preview text box if selected ruby/romaji changed.
-            Component.OnCommit += (sender, value) =>
+            Component.OnCommit += (sender, edited) =>
             {
-                ApplyValue(item, value);
+                if (!edited)
+                    return;
+
+                ApplyValue(item, sender.Value);
             };
 
             // change style if focus.
@@ -82,7 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         {
             public Action<bool> Selected;
 
-            public Action<SwitchButton, bool> OnCommit;
+            public Action<ObjectFieldSwitchButton, bool> OnCommit;
 
             protected override bool OnHover(HoverEvent e)
             {
@@ -99,7 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             protected override void OnUserChange(bool value)
             {
                 base.OnUserChange(value);
-                OnCommit?.Invoke(this, value);
+                OnCommit?.Invoke(this, true);
             }
 
             private Color4 highLightColour;
@@ -116,6 +119,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 
             public bool Value
             {
+                get => Current.Value;
                 set => Current.Value = value;
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
@@ -26,8 +26,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         {
             this.item = item;
 
-            // apply current text from text-tag.
-            Component.Value = GetFieldValue(item);
+            // apply current value from the field in the item.
+            Current.Value = GetFieldValue(item);
 
             // should change preview text box if selected ruby/romaji changed.
             Component.OnCommit += (sender, edited) =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -26,8 +26,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         {
             Item = item;
 
-            // apply current text from text-tag.
-            Component.Text = GetFieldValue(item);
+            // apply current value from the field in the item.
+            Current.Value = GetFieldValue(item);
 
             // should change preview text box if selected ruby/romaji changed.
             OnCommit += (sender, edited) =>


### PR DESCRIPTION
What's changed in this PR:
- change event param meaning in the `ObjectFieldSwitchButton`.
- Use current value instead of set value in the component.