### PR TITLE
Implement the singer avatar for able to load the image.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Beatmaps/IKaraokeBeatmapResourcesProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/IKaraokeBeatmapResourcesProvider.cs
@@ -1,0 +1,13 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Textures;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps
+{
+    public interface IKaraokeBeatmapResourcesProvider
+    {
+        Texture GetSingerAvatar(ISinger singer);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapResourcesProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapResourcesProvider.cs
@@ -1,0 +1,51 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Reflection;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps
+{
+    public class KaraokeBeatmapResourcesProvider : Component, IKaraokeBeatmapResourcesProvider
+    {
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> working { get; set; }
+
+        public Texture GetSingerAvatar(ISinger singer)
+        {
+            var provider = getBeatmapResourceProvider();
+            if (provider == null)
+                return null;
+
+            if (singer is not Singer s)
+                return null;
+
+            var beatmapSetInfo = working.Value.BeatmapSetInfo;
+            if (beatmapSetInfo == null)
+                return null;
+
+            string path = beatmapSetInfo.GetPathForFile($"assets/singers/{s.AvatarFile}");
+            return provider.LargeTextureStore.Get(path);
+        }
+
+        private IBeatmapResourceProvider getBeatmapResourceProvider()
+        {
+            // todo : use better way to get the resource provider.
+            var prop = typeof(BeatmapManager).GetField("workingBeatmapCache", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (prop == null)
+                throw new NullReferenceException();
+
+            return prop.GetValue(beatmapManager) as WorkingBeatmapCache;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Singer.cs
@@ -33,12 +33,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas
         }
 
         [JsonIgnore]
-        public readonly Bindable<string> AvatarBindable = new();
+        public readonly Bindable<string> AvatarFileBindable = new();
 
-        public string Avatar
+        public string AvatarFile
         {
-            get => AvatarBindable.Value;
-            set => AvatarBindable.Value = value;
+            get => AvatarFileBindable.Value;
+            set => AvatarFileBindable.Value = value;
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/ISingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/ISingersChangeHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.IO;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 
@@ -12,6 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
         BindableList<Singer> Singers { get; }
 
         void ChangeOrder(Singer singer, int newIndex);
+
+        bool ChangeSingerAvatar(Singer singer, FileInfo fileInfo);
 
         void Add(Singer singer);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Singers/SingersChangeHandler.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Utils;
@@ -13,6 +16,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
 {
     public class SingersChangeHandler : BeatmapPropertyChangeHandler<Singer>, ISingersChangeHandler
     {
+        [Resolved(canBeNull: true)]
+        private BeatmapManager beatmapManager { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private IBindable<WorkingBeatmap> working { get; set; }
+
         public BindableList<Singer> Singers => Items;
 
         protected override List<Singer> GetItemsFromBeatmap(KaraokeBeatmap beatmap)
@@ -29,6 +38,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers
                     // todo : not really sure should call update?
                 });
             });
+        }
+
+        public bool ChangeSingerAvatar(Singer singer, FileInfo fileInfo)
+        {
+            if (beatmapManager == null || working == null)
+                return false;
+
+            if (!fileInfo.Exists)
+                throw new FileNotFoundException();
+
+            // note: follow the same logic in the ResourcesSection.ChangeBackgroundImage
+            var set = working.Value.BeatmapSetInfo;
+
+            // todo: we might re-format the new file name, like give it a hash name for prevent duplicated file name with other singer.
+            string newFileName = fileInfo.Name;
+
+            using (var stream = fileInfo.OpenRead())
+            {
+                // in the future we probably want to check if this is being used elsewhere (other difficulties?)
+                var oldFile = set.Files.FirstOrDefault(f => f.Filename == singer.AvatarFile);
+                if (oldFile != null)
+                    beatmapManager.DeleteFile(set, oldFile);
+
+                beatmapManager.AddFile(set, stream, $"assets/singers/{newFileName}");
+            }
+
+            // Write-back the file name.
+            singer.AvatarFile = newFileName;
+
+            return true;
         }
 
         protected override void OnItemAdded(Singer item)

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditor.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
@@ -41,6 +42,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached]
         private readonly FontManager fontManager;
 
+        [Cached(typeof(IKaraokeBeatmapResourcesProvider))]
+        private KaraokeBeatmapResourcesProvider karaokeBeatmapResourcesProvider;
+
         [Cached(typeof(ILyricsProvider))]
         private readonly LyricsProvider lyricsProvider;
 
@@ -65,6 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 
             // Duplicated registration because selection handler need to use it.
             AddInternal(fontManager = new FontManager());
+            AddInternal(karaokeBeatmapResourcesProvider = new KaraokeBeatmapResourcesProvider());
 
             AddInternal(exportLyricManager = new ExportLyricManager());
             AddInternal(lyricsProvider = new LyricsProvider());

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeHitObjectComposer.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
@@ -44,6 +45,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         [Cached]
         private readonly FontManager fontManager;
 
+        [Cached(typeof(IKaraokeBeatmapResourcesProvider))]
+        private KaraokeBeatmapResourcesProvider karaokeBeatmapResourcesProvider;
+
         [Cached(typeof(ILyricRubyTagsChangeHandler))]
         private readonly LyricRubyTagsChangeHandler lyricRubyTagsChangeHandler;
 
@@ -76,6 +80,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 
             // Duplicated registration because selection handler need to use it.
             AddInternal(fontManager = new FontManager());
+            AddInternal(karaokeBeatmapResourcesProvider = new KaraokeBeatmapResourcesProvider());
 
             AddInternal(lyricRubyTagsChangeHandler = new LyricRubyTagsChangeHandler());
             AddInternal(lyricRomajiTagsChangeHandler = new LyricRomajiTagsChangeHandler());

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
                 {
                     Label = "Avatar",
                     Description = "Select image to set avatar.",
-                    Current = singer.AvatarBindable,
+                    Current = singer.AvatarFileBindable,
                 },
                 new LabelledHueSelector
                 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Detail/AvatarSection.cs
@@ -15,14 +15,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Detail
         {
             Children = new Drawable[]
             {
-                // todo: because cannot open the popover inside the popover.
-                // so might change the avatar only if click the avatar image in the singer editor.
-                new LabelledImageSelector
-                {
-                    Label = "Avatar",
-                    Description = "Select image to set avatar.",
-                    Current = singer.AvatarFileBindable,
-                },
                 new LabelledHueSelector
                 {
                     Label = "Colour",

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerAvatar.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/Components/SingerAvatar.cs
@@ -1,0 +1,115 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
+using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components
+{
+    public class SingerAvatar : CompositeDrawable, ICanAcceptFiles, IHasPopover
+    {
+        private readonly string[] handledExtensions = { ".jpg", ".jpeg", ".png" };
+
+        public IEnumerable<string> HandledExtensions => handledExtensions;
+
+        private readonly Bindable<FileInfo> currentFile = new();
+
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
+        [Resolved]
+        private ISingersChangeHandler singersChangeHandler { get; set; }
+
+        private readonly Singer singer;
+
+        public SingerAvatar(Singer singer)
+        {
+            this.singer = singer;
+
+            InternalChildren = new[]
+            {
+                new DrawableSingerAvatar
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Singer = singer
+                }
+            };
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            this.ShowPopover();
+            return true;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            game.RegisterImportHandler(this);
+            currentFile.BindValueChanged(onFileSelected);
+        }
+
+        private void onFileSelected(ValueChangedEvent<FileInfo> file)
+        {
+            if (file.NewValue == null)
+                return;
+
+            this.HidePopover();
+
+            singersChangeHandler.ChangeSingerAvatar(singer, file.NewValue);
+        }
+
+        Task ICanAcceptFiles.Import(params string[] paths)
+        {
+            Schedule(() => currentFile.Value = new FileInfo(paths.First()));
+            return Task.CompletedTask;
+        }
+
+        Task ICanAcceptFiles.Import(params ImportTask[] tasks) => throw new NotImplementedException();
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (game.IsNotNull())
+                game.UnregisterImportHandler(this);
+        }
+
+        public Popover GetPopover() => new FileChooserPopover(handledExtensions, currentFile);
+
+        private class FileChooserPopover : OsuPopover
+        {
+            public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo> currentFile)
+            {
+                Child = new Container
+                {
+                    Size = new Vector2(600, 400),
+                    Child = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CurrentFile = { BindTarget = currentFile }
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/SingerLyricPlacementRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/SingerLyricPlacementRow.cs
@@ -52,7 +52,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
 
             private readonly IBindable<int> bindableOrder = new Bindable<int>();
             private readonly IBindable<float> bindableHue = new Bindable<float>();
-            private readonly IBindable<string> bindableAvatar = new Bindable<string>();
             private readonly IBindable<string> bindableSingerName = new Bindable<string>();
             private readonly IBindable<string> bindableEnglishName = new Bindable<string>();
 
@@ -64,12 +63,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
 
                 bindableOrder.BindTo(singer.OrderBindable);
                 bindableHue.BindTo(singer.HueBindable);
-                bindableAvatar.BindTo(singer.AvatarBindable);
                 bindableSingerName.BindTo(singer.NameBindable);
                 bindableEnglishName.BindTo(singer.EnglishNameBindable);
 
                 Box background;
-                DrawableSingerAvatar avatar;
                 OsuSpriteText singerName;
                 OsuSpriteText singerEnglishName;
 
@@ -98,10 +95,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
                             {
                                 new Drawable[]
                                 {
-                                    avatar = new DrawableSingerAvatar
+                                    new DrawableSingerAvatar
                                     {
                                         Name = "Avatar",
                                         Size = new Vector2(avatar_size),
+                                        Singer = singer,
                                     },
                                     new FillFlowContainer
                                     {
@@ -144,12 +142,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
                 {
                     // background
                     background.Colour = SingerUtils.GetBackgroundColour(singer);
-                }, true);
-
-                bindableAvatar.BindValueChanged(_ =>
-                {
-                    // avatar
-                    avatar.Singer = singer;
                 }, true);
 
                 bindableSingerName.BindValueChanged(_ =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/SingerLyricPlacementRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/SingerLyricPlacementRow.cs
@@ -19,7 +19,6 @@ using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
 using osu.Game.Rulesets.Karaoke.Edit.Singers.Detail;
 using osu.Game.Rulesets.Karaoke.Edit.Singers.Rows.Components;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
-using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK;
 
@@ -95,11 +94,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
                             {
                                 new Drawable[]
                                 {
-                                    new DrawableSingerAvatar
+                                    new SingerAvatar(singer)
                                     {
                                         Name = "Avatar",
                                         Size = new Vector2(avatar_size),
-                                        Singer = singer,
                                     },
                                     new FillFlowContainer
                                     {

--- a/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Cursor/SingerToolTip.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
         private const int main_text_size = 24;
         private const int sub_text_size = 12;
 
-        private readonly IBindable<string> bindableAvatar = new Bindable<string>();
         private readonly IBindable<string> bindableName = new Bindable<string>();
         private readonly IBindable<string> bindableRomajiName = new Bindable<string>();
         private readonly IBindable<string> bindableEnglishName = new Bindable<string>();
@@ -118,7 +117,6 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
                 }
             };
 
-            bindableAvatar.BindValueChanged(_ => avatar.Singer = lastSinger, true);
             bindableName.BindValueChanged(e => singerName.Text = e.NewValue, true);
             bindableRomajiName.BindValueChanged(e => singerRomajiName.Text = string.IsNullOrEmpty(e.NewValue) ? "" : $"({e.NewValue})", true);
             bindableEnglishName.BindValueChanged(e => singerEnglishName.Text = e.NewValue, true);
@@ -132,19 +130,19 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Cursor
             if (singer == lastSinger)
                 return;
 
+            avatar.Singer = singer;
+
             lastSinger = singer;
 
             // todo: other type of singer(e.g: sub-singer) might display different info.
             if (singer is not Singer s)
                 return;
 
-            bindableAvatar.UnbindBindings();
             bindableName.UnbindBindings();
             bindableRomajiName.UnbindBindings();
             bindableEnglishName.UnbindBindings();
             bindableDescription.UnbindBindings();
 
-            bindableAvatar.BindTo(s.AvatarBindable);
             bindableName.BindTo(s.NameBindable);
             bindableRomajiName.BindTo(s.RomajiNameBindable);
             bindableEnglishName.BindTo(s.EnglishNameBindable);

--- a/osu.Game.Rulesets.Karaoke/UI/DrawableKaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/DrawableKaraokeRuleset.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Rulesets.Karaoke.UI
         [Cached]
         private readonly FontManager fontManager;
 
+        [Cached(typeof(IKaraokeBeatmapResourcesProvider))]
+        private KaraokeBeatmapResourcesProvider karaokeBeatmapResourcesProvider;
+
         protected virtual bool DisplayNotePlayfield => Beatmap.IsScorable();
 
         public DrawableKaraokeRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
@@ -45,6 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.UI
         {
             AddInternal(positionCalculator = new NotePositionInfo());
             AddInternal(fontManager = new FontManager());
+            AddInternal(karaokeBeatmapResourcesProvider = new KaraokeBeatmapResourcesProvider());
         }
 
         protected override Playfield CreatePlayfield() => new KaraokePlayfield();


### PR DESCRIPTION
Closes issue of #1377

What's done in this PR:
- Remove un-need bindable properties because avatar will change the image automatically if avatar changed.
- Remove the `Avatar` to the `AvatarFile` because the property is used to record the upload file name.
- Able to upload the image in the singer change handler.
- Implement singer avatar for able to upload the image by drag or clicking the avatar icon.
- Implement karaoke resource provider for able to get resource from the karaoke beatmap.
- Should be able to re-load the image after update the avatar.