### PR TITLE
Fix will cause crash if switch from translate screen to singer screen.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeEditorScreen.cs
@@ -23,9 +23,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         {
             base.PopIn();
 
-            // for prevent accidentally change the property in the hit object that is not expected,
-            // should clear all selected hit object if user change to the different tab.
-            beatmap.SelectedHitObjects.Clear();
+            // should wait until current change handler done.
+            // not a good way but ok for now.
+            ScheduleAfterChildren(() =>
+            {
+                // for prevent accidentally change the property in the hit object that is not expected,
+                // should clear all selected hit object if user change to the different tab.
+                beatmap.SelectedHitObjects.Clear();
+            });
         }
     }
 }


### PR DESCRIPTION
Closes issue #1436.

Some of the change handler step might be a little bit late(e.g: submit the text from the textbox)
So make clear selected hit objects step a little bit late.