### PR TITLE
Rename from manage lyric into split lyric in the texting mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
 {
     public class EditLyricNavigation : TopNavigation<EditLyricStepScreen>
     {
-        private const string cutting_mode = "CUTTING_MODE";
         private const string typing_mode = "TYPING_MODE";
+        private const string split_mode = "SPLIT_MODE";
 
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
 
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
             switch (value)
             {
                 case NavigationState.Initial:
-                    return $"Does something looks weird? Try switching [{cutting_mode}] or [{typing_mode}] to edit your lyric.";
+                    return $"Does something looks weird? Try switching [{typing_mode}] or [{split_mode}] to edit your lyric.";
 
                 case NavigationState.Working:
                 case NavigationState.Done:
@@ -55,8 +55,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
 
                     return mode switch
                     {
-                        TextingEditMode.Manage => $"Cool! Try switching to [{typing_mode}] if you want to edit lyric.",
-                        TextingEditMode.Typing => $"Cool! Try switching to [{cutting_mode}] if you want to cut or combine lyric.",
+                        TextingEditMode.Typing => $"Cool! Try switching to [{split_mode}] if you want to cut or combine lyric.",
+                        TextingEditMode.Split => $"Cool! Try switching to [{typing_mode}] if you want to edit lyric.",
                         _ => throw new InvalidEnumArgumentException(nameof(mode))
                     };
 
@@ -75,8 +75,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
         {
             public EditLyricTextFlowContainer(EditLyricStepScreen screen)
             {
-                AddLinkFactory(cutting_mode, "cutting mode", () => screen.SwitchToEditModeState(TextingEditMode.Manage));
                 AddLinkFactory(typing_mode, "typing mode", () => screen.SwitchToEditModeState(TextingEditMode.Typing));
+                AddLinkFactory(split_mode, "split mode", () => screen.SwitchToEditModeState(TextingEditMode.Split));
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingDeleteSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingDeleteSubsection.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 {
-    public class ManageDeleteSubsection : SelectLyricButton
+    public class TextingDeleteSubsection : SelectLyricButton
     {
         [Resolved]
         private ILyricsChangeHandler lyricsChangeHandler { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingEditModeSection.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
                     TextingEditMode.Typing, new EditModeSelectionItem("Typing", "Edit the lyric text.")
                 },
                 {
-                    TextingEditMode.Manage, new EditModeSelectionItem("Manage", "Create/delete or split/combine the lyric.")
+                    TextingEditMode.Split, new EditModeSelectionItem("Split", "Create/delete or split/combine the lyric.")
                 }
             };
 
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
             return mode switch
             {
                 TextingEditMode.Typing => active ? colours.Blue : colours.BlueDarker,
-                TextingEditMode.Manage => active ? colours.Yellow : colours.YellowDarker,
+                TextingEditMode.Split => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode))
             };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingEditModeSpecialAction.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingEditModeSpecialAction.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 {
-    public enum ManageEditModeSpecialAction
+    public enum TextingEditModeSpecialAction
     {
         Copy,
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
                         };
                         break;
 
-                    case TextingEditMode.Manage:
+                    case TextingEditMode.Split:
                         Children = new Drawable[]
                         {
                             new TextingEditModeSection(),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -25,9 +23,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
                 switch (e.NewValue)
                 {
                     case TextingEditMode.Typing:
-                        Children = new[]
+                        Children = new Drawable[]
                         {
                             new TextingEditModeSection(),
+                            new TextingSwitchSpecialActionSection()
                         };
                         break;
 
@@ -35,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
                         Children = new Drawable[]
                         {
                             new TextingEditModeSection(),
-                            new ManageSwitchSpecialActionSection()
+                            new TextingSwitchSpecialActionSection()
                         };
                         break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingSwitchSpecialActionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingSwitchSpecialActionSection.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 {
-    public class ManageSwitchSpecialActionSection : SpecialActionSection<ManageEditModeSpecialAction>
+    public class TextingSwitchSpecialActionSection : SpecialActionSection<TextingEditModeSpecialAction>
     {
         protected override string SwitchActionTitle => "Special actions";
 
@@ -21,21 +19,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
             BindTo(textingModeState);
         }
 
-        protected override void UpdateActionArea(ManageEditModeSpecialAction action)
+        protected override void UpdateActionArea(TextingEditModeSpecialAction action)
         {
-            RemoveAll(x => x is ManageDeleteSubsection);
+            RemoveAll(x => x is TextingDeleteSubsection);
 
             switch (action)
             {
-                case ManageEditModeSpecialAction.Copy:
+                case TextingEditModeSpecialAction.Copy:
                     // todo: implement
                     break;
 
-                case ManageEditModeSpecialAction.Delete:
-                    Add(new ManageDeleteSubsection());
+                case TextingEditModeSpecialAction.Delete:
+                    Add(new TextingDeleteSubsection());
                     break;
 
-                case ManageEditModeSpecialAction.Move:
+                case TextingEditModeSpecialAction.Move:
                     // todo: implement
                     break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
@@ -150,13 +150,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.Texting:
                     switch (textingModeState.EditMode)
                     {
-                        case TextingEditMode.Manage:
-                            lyricsChangeHandler.Remove();
-                            return true;
-
                         case TextingEditMode.Typing:
                             // cut, copy or paste event should be handled in the caret.
                             return false;
+
+                        case TextingEditMode.Split:
+                            lyricsChangeHandler.Remove();
+                            return true;
 
                         default:
                             throw new ArgumentOutOfRangeException();
@@ -217,14 +217,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.Texting:
                     switch (textingModeState.EditMode)
                     {
-                        case TextingEditMode.Manage:
-                            saveObjectToTheClipboardContent(lyric);
-                            copyObjectToClipboard(lyric.Text);
-                            return true;
-
                         case TextingEditMode.Typing:
                             // cut, copy or paste event should be handled in the caret.
                             return false;
+
+                        case TextingEditMode.Split:
+                            saveObjectToTheClipboardContent(lyric);
+                            copyObjectToClipboard(lyric.Text);
+                            return true;
 
                         default:
                             throw new ArgumentOutOfRangeException();
@@ -289,17 +289,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                 case LyricEditorMode.Texting:
                     switch (textingModeState.EditMode)
                     {
-                        case TextingEditMode.Manage:
+                        case TextingEditMode.Typing:
+                            // cut, copy or paste event should be handled in the caret.
+                            return false;
+
+                        case TextingEditMode.Split:
                             var pasteLyric = getObjectFromClipboardContent<Lyric>();
                             if (pasteLyric == null)
                                 return false;
 
                             lyricsChangeHandler.AddBelowToSelection(pasteLyric);
                             return true;
-
-                        case TextingEditMode.Typing:
-                            // cut, copy or paste event should be handled in the caret.
-                            return false;
 
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 return textingEditMode switch
                 {
                     TextingEditMode.Typing => new TypingCaretPositionAlgorithm(lyrics),
-                    TextingEditMode.Manage => new CuttingCaretPositionAlgorithm(lyrics),
+                    TextingEditMode.Split => new CuttingCaretPositionAlgorithm(lyrics),
                     _ => throw new InvalidOperationException(nameof(textingEditMode))
                 };
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ITextingModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ITextingModeState.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public interface ITextingModeState : IHasEditModeState<TextingEditMode>, IHasSpecialAction<ManageEditModeSpecialAction>
+    public interface ITextingModeState : IHasEditModeState<TextingEditMode>, IHasSpecialAction<TextingEditModeSpecialAction>
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingEditMode.cs
@@ -7,6 +7,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
     {
         Typing,
 
-        Manage
+        Split
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingModeState.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
         public void ChangeEditMode(TextingEditMode mode)
             => bindableEditMode.Value = mode;
 
-        public Bindable<ManageEditModeSpecialAction> BindableSpecialAction { get; } = new();
+        public Bindable<TextingEditModeSpecialAction> BindableSpecialAction { get; } = new();
     }
 }


### PR DESCRIPTION
Closes issue #1472

![image](https://user-images.githubusercontent.com/9100368/180898655-c732f38a-dca8-44e8-9f78-dd5b841ec08e.png)
This is how it looks like.