### PR TITLE
Prevent reload the section while switch the typing/split mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 {
@@ -14,40 +11,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 
         public override float ExtendWidth => 300;
 
-        private readonly IBindable<TextingEditMode> bindableMode = new Bindable<TextingEditMode>();
-
         public TextingExtend()
         {
-            bindableMode.BindValueChanged(e =>
+            Children = new Drawable[]
             {
-                switch (e.NewValue)
-                {
-                    case TextingEditMode.Typing:
-                        Children = new Drawable[]
-                        {
-                            new TextingEditModeSection(),
-                            new TextingSwitchSpecialActionSection()
-                        };
-                        break;
-
-                    case TextingEditMode.Split:
-                        Children = new Drawable[]
-                        {
-                            new TextingEditModeSection(),
-                            new TextingSwitchSpecialActionSection()
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(ITextingModeState textingModeState)
-        {
-            bindableMode.BindTo(textingModeState.BindableEditMode);
+                new TextingEditModeSection(),
+                new TextingSwitchSpecialActionSection()
+            };
         }
     }
 }


### PR DESCRIPTION
There's no need to apply that stupid mode change event.