### PR TITLE
Implement `IDeepCloneable<T>` for some hit-object for better copy experience.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
 
                 var combinedNote = actualNotes.First();
                 Assert.AreEqual("カラ", combinedNote.Text);
-                Assert.AreEqual(null, combinedNote.RubyText);
+                Assert.AreEqual("から", combinedNote.RubyText);
                 Assert.AreEqual(1000, combinedNote.StartTime);
                 Assert.AreEqual(1000, combinedNote.Duration);
             });

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Tests.Asserts;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects
+{
+    public class LyricTest
+    {
+        [TestCase]
+        public void TestClone()
+        {
+            var referencedLyric = new Lyric();
+
+            var lyric = new Lyric
+            {
+                ID = 1,
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }),
+                RubyTags = TestCaseTagHelper.ParseRubyTags(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }),
+                RomajiTags = TestCaseTagHelper.ParseRomajiTags(new[] { "[0,2]:ka", "[2,4]:ra", "[4,5]:o", "[5,7]:ke" }),
+                StartTime = 1000,
+                Duration = 4000,
+                Singers = new[] { 1, 2 },
+                Translates = new Dictionary<CultureInfo, string>
+                {
+                    { new CultureInfo("en-US"), "karaoke" }
+                },
+                Language = new CultureInfo("ja-JP"),
+                Order = 1,
+                Lock = LockState.None,
+                ReferenceLyric = referencedLyric
+            };
+
+            var clonedLyric = lyric.DeepClone();
+
+            Assert.AreEqual(clonedLyric.ID, lyric.ID);
+
+            Assert.AreNotSame(clonedLyric.TextBindable, lyric.TextBindable);
+            Assert.AreEqual(clonedLyric.Text, lyric.Text);
+
+            Assert.AreNotSame(clonedLyric.TimeTagsVersion, lyric.TimeTagsVersion);
+            Assert.AreNotSame(clonedLyric.TimeTagsBindable, lyric.TimeTagsBindable);
+            TimeTagAssert.ArePropertyEqual(clonedLyric.TimeTags, lyric.TimeTags);
+
+            Assert.AreNotSame(clonedLyric.RubyTagsVersion, lyric.RubyTagsVersion);
+            Assert.AreNotSame(clonedLyric.RubyTagsBindable, lyric.RubyTagsBindable);
+            TextTagAssert.ArePropertyEqual(clonedLyric.RubyTags, lyric.RubyTags);
+
+            Assert.AreNotSame(clonedLyric.RomajiTagsVersion, lyric.RomajiTagsVersion);
+            Assert.AreNotSame(clonedLyric.RomajiTagsBindable, lyric.RomajiTagsBindable);
+            TextTagAssert.ArePropertyEqual(clonedLyric.RomajiTags, lyric.RomajiTags);
+
+            Assert.AreNotSame(clonedLyric.StartTimeBindable, lyric.StartTimeBindable);
+            Assert.AreEqual(clonedLyric.StartTime, lyric.StartTime);
+
+            Assert.AreEqual(clonedLyric.Duration, lyric.Duration);
+
+            Assert.AreNotSame(clonedLyric.SingersBindable, lyric.SingersBindable);
+            CollectionAssert.AreEquivalent(clonedLyric.Singers, lyric.Singers);
+
+            Assert.AreNotSame(clonedLyric.TranslateTextBindable, lyric.TranslateTextBindable);
+            CollectionAssert.AreEquivalent(clonedLyric.Translates, lyric.Translates);
+
+            Assert.AreNotSame(clonedLyric.LanguageBindable, lyric.LanguageBindable);
+            Assert.AreEqual(clonedLyric.Language, lyric.Language);
+
+            Assert.AreNotSame(clonedLyric.OrderBindable, lyric.OrderBindable);
+            Assert.AreEqual(clonedLyric.Order, lyric.Order);
+
+            Assert.AreNotSame(clonedLyric.LockBindable, lyric.LockBindable);
+            Assert.AreEqual(clonedLyric.Lock, lyric.Lock);
+
+            Assert.AreNotSame(clonedLyric.ReferenceLyricBindable, lyric.ReferenceLyricBindable);
+            Assert.AreSame(clonedLyric.ReferenceLyric, lyric.ReferenceLyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
@@ -11,9 +11,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
         [TestCase]
         public void TestClone()
         {
+            var parentLyric = new Lyric();
+
             var note = new Note
             {
-                Text = "lyric",
+                Text = "ノート",
+                RubyText = "Note",
+                Display = true,
+                StartTime = 1000,
+                Duration = 500,
+                ParentLyric = parentLyric
             };
 
             var clonedNote = note.DeepClone();
@@ -29,6 +36,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
 
             Assert.AreNotSame(clonedNote.ToneBindable, note.ToneBindable);
             Assert.AreEqual(clonedNote.Tone, note.Tone);
+
+            Assert.AreNotSame(clonedNote.StartTimeBindable, note.StartTimeBindable);
+            Assert.AreEqual(clonedNote.StartTime, note.StartTime);
 
             Assert.AreEqual(clonedNote.Duration, note.Duration);
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects
+{
+    public class NoteTest
+    {
+        [TestCase]
+        public void TestClone()
+        {
+            var note = new Note
+            {
+                Text = "lyric",
+            };
+
+            var clonedNote = note.DeepClone();
+
+            Assert.AreNotSame(clonedNote.TextBindable, note.TextBindable);
+            Assert.AreEqual(clonedNote.Text, note.Text);
+
+            Assert.AreNotSame(clonedNote.RubyTextBindable, note.RubyTextBindable);
+            Assert.AreEqual(clonedNote.RubyText, note.RubyText);
+
+            Assert.AreNotSame(clonedNote.DisplayBindable, note.DisplayBindable);
+            Assert.AreEqual(clonedNote.Display, note.Display);
+
+            Assert.AreNotSame(clonedNote.ToneBindable, note.ToneBindable);
+            Assert.AreEqual(clonedNote.Tone, note.Tone);
+
+            Assert.AreEqual(clonedNote.Duration, note.Duration);
+
+            Assert.AreEqual(clonedNote.StartIndex, note.StartIndex);
+
+            Assert.AreEqual(clonedNote.EndIndex, note.EndIndex);
+
+            Assert.AreSame(clonedNote.ParentLyric, note.ParentLyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Extensions;
+using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Judgements;
@@ -18,10 +19,11 @@ using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class Lyric : KaraokeHitObject, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey
+    public class Lyric : KaraokeHitObject, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey, IDeepCloneable<Lyric>
     {
         /// <summary>
         /// Primary key.
@@ -291,5 +293,18 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         }
 
         protected override HitWindows CreateHitWindows() => new KaraokeLyricHitWindows();
+
+        public Lyric DeepClone()
+        {
+            string serializeString = this.Serialize();
+            var lyric = serializeString.Deserialize<Lyric>();
+
+            // IDK why got the different value of `CultureInfo` if placing it as key of the dictionary.
+            // So make a copy in here.
+            lyric.Translates = Translates;
+            lyric.ReferenceLyric = ReferenceLyric;
+
+            return lyric;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -10,9 +10,9 @@ using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Extensions;
-using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.IO.Serialization;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Scoring;
@@ -296,12 +296,9 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public Lyric DeepClone()
         {
-            string serializeString = this.Serialize();
-            var lyric = serializeString.Deserialize<Lyric>();
+            string serializeString = JsonConvert.SerializeObject(this, KaraokeJsonSerializableExtensions.CreateGlobalSettings());
+            var lyric = JsonConvert.DeserializeObject<Lyric>(serializeString, KaraokeJsonSerializableExtensions.CreateGlobalSettings())!;
 
-            // IDK why got the different value of `CultureInfo` if placing it as key of the dictionary.
-            // So make a copy in here.
-            lyric.Translates = Translates;
             lyric.ReferenceLyric = ReferenceLyric;
 
             return lyric;

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Judgements;
@@ -75,7 +76,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         /// <summary>
         /// Duration
         /// </summary>
-        [JsonIgnore]
         public double Duration { get; set; }
 
         /// <summary>
@@ -114,19 +114,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public Note DeepClone()
         {
-            // (Note)MemberwiseClone();
+            string serializeString = this.Serialize();
+            var note = serializeString.Deserialize<Note>();
+            note.ParentLyric = ParentLyric;
 
-            return new()
-            {
-                Text = Text,
-                RubyText = RubyText,
-                Display = Display,
-                Tone = Tone,
-                Duration = Duration,
-                StartIndex = StartIndex,
-                EndIndex = EndIndex,
-                ParentLyric = ParentLyric
-            };
+            return note;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -10,10 +10,11 @@ using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Scoring;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class Note : KaraokeHitObject, IHasDuration, IHasText
+    public class Note : KaraokeHitObject, IHasDuration, IHasText, IDeepCloneable<Note>
     {
         [JsonIgnore]
         public readonly Bindable<string> TextBindable = new();
@@ -110,5 +111,22 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         public override Judgement CreateJudgement() => new KaraokeNoteJudgement();
 
         protected override HitWindows CreateHitWindows() => new KaraokeNoteHitWindows();
+
+        public Note DeepClone()
+        {
+            // (Note)MemberwiseClone();
+
+            return new()
+            {
+                Text = Text,
+                RubyText = RubyText,
+                Display = Display,
+                Tone = Tone,
+                Duration = Duration,
+                StartIndex = StartIndex,
+                EndIndex = EndIndex,
+                ParentLyric = ParentLyric
+            };
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricsUtils.cs
@@ -60,28 +60,20 @@ namespace osu.Game.Rulesets.Karaoke.Utils
                 }
             }
 
-            var firstLyric = new Lyric
-            {
-                Text = lyric.Text[..splitIndex],
-                TimeTags = firstTimeTag.ToArray(),
-                RubyTags = lyric.RubyTags.Where(x => x.StartIndex < splitIndex && x.EndIndex <= splitIndex).ToArray(),
-                RomajiTags = lyric.RomajiTags.Where(x => x.StartIndex < splitIndex && x.EndIndex <= splitIndex).ToArray(),
-                // todo : should implement time and duration
-                Singers = lyric.Singers,
-                Language = lyric.Language,
-            };
+            // todo : should implement time and duration
+            var firstLyric = lyric.DeepClone();
+            firstLyric.Text = lyric.Text[..splitIndex];
+            firstLyric.TimeTags = firstTimeTag.ToArray();
+            firstLyric.RubyTags = lyric.RubyTags.Where(x => x.StartIndex < splitIndex && x.EndIndex <= splitIndex).ToArray();
+            firstLyric.RomajiTags = lyric.RomajiTags.Where(x => x.StartIndex < splitIndex && x.EndIndex <= splitIndex).ToArray();
 
+            // todo : should implement time and duration
             string secondLyricText = lyric.Text[splitIndex..];
-            var secondLyric = new Lyric
-            {
-                Text = secondLyricText,
-                TimeTags = shiftingTimeTag(secondTimeTag.ToArray(), -splitIndex),
-                RubyTags = shiftingTextTag(lyric.RubyTags.Where(x => x.StartIndex >= splitIndex && x.EndIndex > splitIndex).ToArray(), secondLyricText, -splitIndex),
-                RomajiTags = shiftingTextTag(lyric.RomajiTags.Where(x => x.StartIndex >= splitIndex && x.EndIndex > splitIndex).ToArray(), secondLyricText, -splitIndex),
-                // todo : should implement time and duration
-                Singers = lyric.Singers,
-                Language = lyric.Language,
-            };
+            var secondLyric = lyric.DeepClone();
+            secondLyric.Text = secondLyricText;
+            secondLyric.TimeTags = shiftingTimeTag(secondTimeTag.ToArray(), -splitIndex);
+            secondLyric.RubyTags = shiftingTextTag(lyric.RubyTags.Where(x => x.StartIndex >= splitIndex && x.EndIndex > splitIndex).ToArray(), secondLyricText, -splitIndex);
+            secondLyric.RomajiTags = shiftingTextTag(lyric.RomajiTags.Where(x => x.StartIndex >= splitIndex && x.EndIndex > splitIndex).ToArray(), secondLyricText, -splitIndex);
 
             return new Tuple<Lyric, Lyric>(firstLyric, secondLyric);
         }

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -19,18 +19,14 @@ namespace osu.Game.Rulesets.Karaoke.Utils
             return CopyByTime(note, startTime, duration);
         }
 
-        public static Note CopyByTime(Note originNote, double startTime, double duration) =>
-            new()
-            {
-                StartTime = startTime,
-                Duration = duration,
-                StartIndex = originNote.StartIndex,
-                EndIndex = originNote.EndIndex,
-                Text = originNote.Text,
-                Display = originNote.Display,
-                Tone = originNote.Tone,
-                ParentLyric = originNote.ParentLyric
-            };
+        public static Note CopyByTime(Note originNote, double startTime, double duration)
+        {
+            var note = originNote.DeepClone();
+            note.StartTime = startTime;
+            note.Duration = duration;
+
+            return note;
+        }
 
         /// <summary>
         /// Get the display text while gameplay or in editor.


### PR DESCRIPTION
It's the final way for the issue #1482.

And note that there's several reason for choosing the json serializer as solution for copy the properties:
1. Follow the way how `PerformCopy()` in the `ComposeScreen.cs` did.
2. Easy way for make sure that all properties has been copied.
3. Easy to make sure that all properties has new instance.