### PR TITLE
Implement lyric translate json convertor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TranslatesConvertorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TranslatesConvertorTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
+{
+    public class TranslatesConvertorTest : BaseSingleConverterTest<TranslatesConvertor>
+    {
+        protected override JsonConverter[] CreateExtraConverts()
+            => new JsonConverter[]
+            {
+                new CultureInfoConverter(),
+            };
+
+        [Test]
+        public void TestSerialize()
+        {
+            var translates = new Dictionary<CultureInfo, string>
+            {
+                { new CultureInfo("en-US"), "karaoke" },
+                { new CultureInfo("Ja-jp"), "カラオケ" }
+            };
+
+            const string expected = "[{\"key\":1033,\"value\":\"karaoke\"},{\"key\":1041,\"value\":\"カラオケ\"}]";
+            string actual = JsonConvert.SerializeObject(translates, CreateSettings());
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestDeserialize()
+        {
+            const string json = "[{\"key\":1033,\"value\":\"karaoke\"},{\"key\":1041,\"value\":\"カラオケ\"}]";
+
+            var expected = new Dictionary<CultureInfo, string>
+            {
+                { new CultureInfo("en-US"), "karaoke" },
+                { new CultureInfo("Ja-jp"), "カラオケ" }
+            };
+
+            var actual = JsonConvert.DeserializeObject<Dictionary<CultureInfo, string>>(json, CreateSettings()) ?? throw new InvalidCastException();
+            CollectionAssert.AreEquivalent(expected, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TranslatesConvertorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/TranslatesConvertorTest.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
 
             var actual = JsonConvert.DeserializeObject<Dictionary<CultureInfo, string>>(json, CreateSettings()) ?? throw new InvalidCastException();
             CollectionAssert.AreEquivalent(expected, actual);
+
+            var actualWithInterface = JsonConvert.DeserializeObject<IDictionary<CultureInfo, string>>(json, CreateSettings()) ?? throw new InvalidCastException();
+            CollectionAssert.AreEquivalent(expected, actualWithInterface);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/KaraokeJsonSerializableExtensionsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/KaraokeJsonSerializableExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization
         {
             var lyric = new Lyric();
 
-            const string expeccted = @"{""time_preempt"":600.0,""time_fade_in"":400.0,""start_time_bindable"":0.0,""samples_bindable"":[],""sample_control_point"":{""sample_bank_bindable"":""normal"",""sample_volume_bindable"":100,""sample_bank"":""normal"",""sample_volume"":100},""difficulty_control_point"":{""slider_velocity_bindable"":1.0,""slider_velocity"":1.0},""text"":"""",""time_tags"":[],""ruby_tags"":[],""romaji_tags"":[],""singers"":[],""translates"":{},""samples"":[],""auxiliary_samples"":[]}";
+            const string expeccted = @"{""time_preempt"":600.0,""time_fade_in"":400.0,""start_time_bindable"":0.0,""samples_bindable"":[],""sample_control_point"":{""sample_bank_bindable"":""normal"",""sample_volume_bindable"":100,""sample_bank"":""normal"",""sample_volume"":100},""difficulty_control_point"":{""slider_velocity_bindable"":1.0,""slider_velocity"":1.0},""text"":"""",""time_tags"":[],""ruby_tags"":[],""romaji_tags"":[],""singers"":[],""translates"":[],""samples"":[],""auxiliary_samples"":[]}";
 
             string actual = JsonConvert.SerializeObject(lyric, createSettings());
             Assert.AreEqual(expeccted, actual);
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization
         [Test]
         public void TestDeserializeLyric()
         {
-            const string json = @"{""time_preempt"":600.0,""time_fade_in"":400.0,""start_time_bindable"":0.0,""samples_bindable"":[],""sample_control_point"":{""sample_bank_bindable"":""normal"",""sample_volume_bindable"":100,""sample_bank"":""normal"",""sample_volume"":100},""difficulty_control_point"":{""slider_velocity_bindable"":1.0,""slider_velocity"":1.0},""text"":"""",""time_tags"":[],""ruby_tags"":[],""romaji_tags"":[],""singers"":[],""translates"":{},""samples"":[],""auxiliary_samples"":[]}";
+            const string json = @"{""time_preempt"":600.0,""time_fade_in"":400.0,""start_time_bindable"":0.0,""samples_bindable"":[],""sample_control_point"":{""sample_bank_bindable"":""normal"",""sample_volume_bindable"":100,""sample_bank"":""normal"",""sample_volume"":100},""difficulty_control_point"":{""slider_velocity_bindable"":1.0,""slider_velocity"":1.0},""text"":"""",""time_tags"":[],""ruby_tags"":[],""romaji_tags"":[],""singers"":[],""translates"":[],""samples"":[],""auxiliary_samples"":[]}";
 
             Lyric expected = new Lyric();
             Lyric actual = JsonConvert.DeserializeObject<Lyric>(json, createSettings())!;

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/DictionaryConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/DictionaryConverter.cs
@@ -1,0 +1,45 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public abstract class DictionaryConverter<TKey, TValue> : JsonConverter<IDictionary<TKey, TValue>>
+    {
+        public sealed override IDictionary<TKey, TValue> ReadJson(JsonReader reader, Type objectType, IDictionary<TKey, TValue>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var obj = JArray.Load(reader);
+            return obj.OfType<JObject>().ToDictionary(
+                x => deserializeKey((JProperty)x.First!),
+                x => deserializeValue((JProperty)x.Last!)
+            );
+
+            TKey deserializeKey(JProperty token)
+                => serializer.Deserialize<TKey>(token.Value.CreateReader())!;
+
+            TValue deserializeValue(JProperty token)
+                => serializer.Deserialize<TValue>(token.Value.CreateReader())!;
+        }
+
+        public override void WriteJson(JsonWriter writer, IDictionary<TKey, TValue>? value, JsonSerializer serializer)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            writer.WriteStartArray();
+
+            foreach (var keyValuePair in value)
+            {
+                var jObject = JObject.FromObject(keyValuePair, serializer);
+                jObject.WriteTo(writer);
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TranslatesConvertor.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/TranslatesConvertor.cs
@@ -1,0 +1,11 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
+{
+    public class TranslatesConvertor : DictionaryConverter<CultureInfo, string>
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/KaraokeJsonSerializableExtensions.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/KaraokeJsonSerializableExtensions.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.IO.Serialization
             globalSetting.Converters.Add(new TimeTagConverter());
             globalSetting.Converters.Add(new TimeTagsConverter());
             globalSetting.Converters.Add(new ToneConverter());
+            globalSetting.Converters.Add(new TranslatesConvertor());
 
             return globalSetting;
         }


### PR DESCRIPTION
Closes issue #1492.
The final solution for now is writing the json serializer with key-value format to fix that issue:

The format should be like this one:
```
[
  { 
    "key":1033, // for better safety, not use the LCID as the key.
    "value":"karaoke"
  },
  {
    "key":1041,
    "value":"カラオケ"
  }
]
```