### PR TITLE
Implement auto-change the time by reference lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
@@ -1,10 +1,13 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
 {
@@ -16,8 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
             PrepareHitObject(new Note
             {
                 Text = "カラオケ",
-                StartTime = 1000,
-                Duration = 1000,
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 1000, 1000)
             });
 
             TriggerHandlerChanged(c => c.Split());
@@ -29,6 +31,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
 
                 var firstNote = actualNotes[0];
                 var secondNote = actualNotes[1];
+
+                Assert.AreSame(firstNote.ReferenceLyric, secondNote.ReferenceLyric);
 
                 Assert.AreEqual("カラオケ", firstNote.Text);
                 Assert.AreEqual(1000, firstNote.StartTime);
@@ -43,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
         [Test]
         public void TestCombine()
         {
-            var lyric = new Lyric();
+            var lyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 1000, 1000);
 
             // note that lyric and notes should in the selection.
             PrepareHitObject(lyric);
@@ -53,17 +57,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
                 {
                     Text = "カラ",
                     RubyText = "から",
-                    StartTime = 1000,
-                    Duration = 500,
                     ReferenceLyric = lyric,
+                    ReferenceTimeTagIndex = 0
                 },
                 new Note
                 {
                     Text = "オケ",
                     RubyText = "おけ",
-                    StartTime = 1500,
-                    Duration = 500,
                     ReferenceLyric = lyric,
+                    ReferenceTimeTagIndex = 0
                 }
             });
 
@@ -158,16 +160,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
                 {
                     Text = "カラ",
                     RubyText = "から",
-                    StartTime = 1000,
-                    Duration = 500,
                     ReferenceLyric = lyric,
                 },
                 new Note
                 {
                     Text = "オケ",
                     RubyText = "おけ",
-                    StartTime = 1500,
-                    Duration = 500,
                     ReferenceLyric = lyric,
                 }
             }, false);

--- a/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseNoteHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseNoteHelper.cs
@@ -1,0 +1,25 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Helper
+{
+    public static class TestCaseNoteHelper
+    {
+        public static Lyric CreateLyricForNote(string text, double startTime, double duration)
+        {
+            return new Lyric
+            {
+                Text = text,
+                TimeTags = new List<TimeTag>
+                {
+                    new(new TextIndex(0), startTime),
+                    new(new TextIndex(text.Length - 1, TextIndex.IndexState.End), startTime + duration)
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects
 {
@@ -12,18 +13,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
         [TestCase]
         public void TestClone()
         {
-            var referenceLyric = new Lyric();
-
             var note = new Note
             {
                 Text = "ノート",
                 RubyText = "Note",
                 Display = true,
-                StartTime = 1000,
-                Duration = 500,
                 StartTimeOffset = 100,
                 EndTimeOffset = -100,
-                ReferenceLyric = referenceLyric
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("ノート", 1000, 1000),
+                ReferenceTimeTagIndex = 0,
             };
 
             var clonedNote = note.DeepClone();
@@ -42,13 +40,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
 
             // note time will not being copied because the time is based on the time-tag in the lyric.
             Assert.AreNotSame(clonedNote.StartTimeBindable, note.StartTimeBindable);
-            Assert.AreEqual(clonedNote.StartTime, 0);
+            Assert.AreEqual(clonedNote.StartTime, clonedNote.StartTime);
 
             // note time will not being copied because the time is based on the time-tag in the lyric.
-            Assert.AreEqual(clonedNote.Duration, 0);
+            Assert.AreEqual(clonedNote.Duration, clonedNote.Duration);
 
             // note time will not being copied because the time is based on the time-tag in the lyric.
-            Assert.AreEqual(clonedNote.EndTime, 0);
+            Assert.AreEqual(clonedNote.EndTime, clonedNote.EndTime);
 
             Assert.AreEqual(clonedNote.StartTimeOffset, note.StartTimeOffset);
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Replays/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Replays/TestSceneAutoGeneration.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Replays;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Tests.Visual;
 
@@ -23,11 +24,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Replays
             var beatmap = new KaraokeBeatmap();
             beatmap.HitObjects.Add(new Note
             {
-                Display = true,
-                StartTime = 1000,
-                Duration = 50,
                 Text = "karaoke!",
-                Tone = new Tone(0, true)
+                Display = true,
+                Tone = new Tone(0, true),
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 50)
             });
 
             var generated = new KaraokeAutoGenerator(beatmap).Generate();
@@ -49,11 +49,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Replays
             var beatmap = new KaraokeBeatmap();
             beatmap.HitObjects.Add(new Note
             {
-                Display = true,
-                StartTime = 1000,
-                Duration = 1000,
                 Text = "karaoke!",
-                Tone = new Tone(0, true)
+                Display = true,
+                Tone = new Tone(0, true),
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 1000)
             });
 
             var generated = new KaraokeAutoGenerator(beatmap).Generate();
@@ -75,19 +74,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Replays
             var beatmap = new KaraokeBeatmap();
             beatmap.HitObjects.Add(new Note
             {
-                Display = true,
-                StartTime = 1000,
-                Duration = 50,
                 Text = "kara",
-                Tone = new Tone(0, true)
+                Display = true,
+                Tone = new Tone(0, true),
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 50)
             });
             beatmap.HitObjects.Add(new Note
             {
-                Display = true,
-                StartTime = 1050,
-                Duration = 50,
                 Text = "oke!",
-                Tone = new Tone(1, true)
+                Display = true,
+                Tone = new Tone(1, true),
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1050, 50)
             });
 
             var generated = new KaraokeAutoGenerator(beatmap).Generate();

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeHitObjectTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeHitObjectTestScene.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.UI.Components;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK.Graphics;
 
@@ -45,11 +44,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
                         {
                             c.Add(CreateHitObject().With(h =>
                             {
-                                h.HitObject.StartTime = START_TIME;
-
-                                if (h.HitObject is IHasDuration hasDurationHitObject)
-                                    hasDurationHitObject.Duration = DURATION;
-
                                 h.AccentColour.Value = Color4.Orange;
                             }));
                         })

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
@@ -29,10 +30,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Skinning
         {
             var note = new Note
             {
-                StartTime = 100,
-                Duration = 800,
                 Text = "カラオケ",
-                ReferenceLyric = new Lyric()
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 100, 800),
             };
             note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.Replays;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.UI;
 using osu.Game.Rulesets.Karaoke.UI.Components;
 using osu.Game.Rulesets.Karaoke.UI.Position;
@@ -112,12 +113,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.UI
             {
                 var note = new Note
                 {
-                    StartTime = Time.Current + increaseTime,
-                    Duration = duration,
-                    Tone = new Tone { Scale = tone },
                     Text = "Here",
-                    ReferenceLyric = new Lyric(),
-                    Display = true
+                    Display = true,
+                    Tone = new Tone { Scale = tone },
+                    ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("Here", Time.Current + increaseTime, duration),
+                    ReferenceTimeTagIndex = 0
                 };
                 note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NoteUtilsTest.cs
@@ -3,28 +3,36 @@
 
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 {
     public class NoteUtilsTest
     {
-        [TestCase(new double[] { 1000, 3000 }, 0, 1, new double[] { 1000, 3000 })]
-        [TestCase(new double[] { 1000, 3000 }, 0, 0.5, new double[] { 1000, 1500 })]
-        [TestCase(new double[] { 1000, 3000 }, 0.5, 0.5, new double[] { 2500, 1500 })]
-        [TestCase(new double[] { 1000, 3000 }, 0.3, 0.4, new double[] { 1900, 1200 })]
-        [TestCase(new double[] { 1000, 3000 }, 0.3, 1, null)] // start + duration should not exceed 1
-        public void TestSliceNoteTime(double[] time, double startPercentage, double durationPercentage, double[]? expected)
+        [TestCase(0, 1, new double[] { 1000, 3000 })]
+        [TestCase(0, 0.5, new double[] { 1000, 1500 })]
+        [TestCase(0.5, 0.5, new double[] { 2500, 1500 })]
+        [TestCase(0.3, 0.4, new double[] { 1900, 1200 })]
+        [TestCase(0.3, 1, null)] // start + duration should not exceed 1
+        public void TestSliceNoteTime(double startPercentage, double durationPercentage, double[]? expected)
         {
+            var lyric = new Lyric
+            {
+                TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[1,start]:4000" }),
+            };
+
+            // start time will be 1000, and duration will be 3000.
             var note = new Note
             {
-                StartTime = time[0],
-                Duration = time[1],
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = 0
             };
 
             if (expected != null)
             {
                 var sliceNote = NoteUtils.SliceNote(note, startPercentage, durationPercentage);
+
                 Assert.AreEqual(expected[0], sliceNote.StartTime);
                 Assert.AreEqual(expected[1], sliceNote.Duration);
             }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
@@ -22,8 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         {
             var note = new Note
             {
-                StartTime = time[0],
-                Duration = time[1],
+                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", time[0], time[1]),
             };
 
             if (firstTime != null && secondTime != null)
@@ -46,20 +46,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         public void TestSplitNoteOtherProperty()
         {
             const double percentage = 0.3;
-            var lyric = new Lyric
-            {
-                Singers = new[] { 0 },
-            };
+
+            var lyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", 1000, 2000);
+            lyric.Singers = new[] { 0 };
 
             var note = new Note
             {
                 Text = "ka",
                 Display = false,
                 Tone = new Tone(-1, true),
-                StartTime = 1000,
-                Duration = 2000,
                 ReferenceLyric = lyric,
-                ReferenceTimeTagIndex = 1
+                ReferenceTimeTagIndex = 0
             };
 
             // create other property and make sure other class is applied value.
@@ -87,34 +84,31 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
             }
         }
 
-        [TestCase(new double[] { 1000, 1000 }, new double[] { 2000, 4000 }, new double[] { 1000, 5000 })]
-        [TestCase(new double[] { 1000, 2500 }, new double[] { 3500, 2500 }, new double[] { 1000, 5000 })]
+        [TestCase(new double[] { 1000, -1000 }, new double[] { 2000, -4000 }, new double[] { 1000, -1000 })]
         [TestCase(new double[] { 1000, 0 }, new double[] { 1000, 0 }, new double[] { 1000, 0 })] // it's ok to combine if duration is 0.
-        public void TestCombineNoteTime(double[] firstTime, double[] secondTime, double[] expected)
+        public void TestCombineNoteTime(double[] firstOffset, double[] secondOffset, double[] expectedOffset)
         {
-            const int reference_time_tag_index = 3;
-
-            var lyric = new Lyric();
+            var lyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", 1000, 5000);
 
             var firstNote = new Note
             {
-                StartTime = firstTime[0],
-                Duration = firstTime[1],
                 ReferenceLyric = lyric,
-                ReferenceTimeTagIndex = reference_time_tag_index,
+                StartTimeOffset = firstOffset[0],
+                EndTimeOffset = firstOffset[1],
+                ReferenceTimeTagIndex = 0,
             };
 
             var secondNote = new Note
             {
-                StartTime = secondTime[0],
-                Duration = secondTime[1],
                 ReferenceLyric = lyric,
-                ReferenceTimeTagIndex = reference_time_tag_index,
+                StartTimeOffset = secondOffset[0],
+                EndTimeOffset = secondOffset[1],
+                ReferenceTimeTagIndex = 0,
             };
 
             var combineNote = NotesUtils.CombineNote(firstNote, secondNote);
-            Assert.AreEqual(expected[0], combineNote.StartTime);
-            Assert.AreEqual(expected[1], combineNote.Duration);
+            Assert.AreEqual(expectedOffset[0], combineNote.StartTimeOffset);
+            Assert.AreEqual(expectedOffset[1], combineNote.EndTimeOffset);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Notes/NoteGenerator.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
                 if (timeTags.LastOrDefault().Key == timeTag.Key)
                     break;
 
-                (double time, var textIndex) = timeTag;
-                (double nextTime, var nextTextIndex) = timeTags.GetNext(timeTag);
+                (double _, var textIndex) = timeTag;
+                (double _, var nextTextIndex) = timeTags.GetNext(timeTag);
 
                 int startIndex = TextIndexUtils.ToStringIndex(textIndex);
                 int endIndex = TextIndexUtils.ToStringIndex(nextTextIndex);
@@ -65,8 +65,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Notes
                     {
                         Text = text,
                         RubyText = ruby,
-                        StartTime = time,
-                        Duration = nextTime - time,
                         ReferenceLyric = lyric,
                         ReferenceTimeTagIndex = timeTagIndex
                     });

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.IO.Serialization;
@@ -81,15 +82,22 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         public override double StartTime
         {
             get => base.StartTime;
-            set => base.StartTime = value;
+            set => throw new NotSupportedException($"The time will auto-sync via {nameof(ReferenceLyric)} and {nameof(ReferenceTimeTagIndex)}.");
         }
+
+        [JsonIgnore]
+        public readonly Bindable<double> DurationBindable = new BindableDouble();
 
         /// <summary>
         /// Duration.
         /// There's no need to save the time because it's calculated by the <see cref="TimeTag"/>
         /// </summary>
         [JsonIgnore]
-        public double Duration { get; set; }
+        public double Duration
+        {
+            get => DurationBindable.Value;
+            set => throw new NotSupportedException($"The time will auto-sync via {nameof(ReferenceLyric)} and {nameof(ReferenceTimeTagIndex)}.");
+        }
 
         /// <summary>
         /// End time.

--- a/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/NoteUtils.cs
@@ -21,9 +21,13 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         public static Note CopyByTime(Note originNote, double startTime, double duration)
         {
+            double fixedStartTime = originNote.StartTime - originNote.StartTimeOffset;
+            double fixedEndTime = originNote.EndTime - originNote.EndTimeOffset;
+            double endTime = startTime + duration;
+
             var note = originNote.DeepClone();
-            note.StartTime = startTime;
-            note.Duration = duration;
+            note.StartTimeOffset = startTime - fixedStartTime;
+            note.EndTimeOffset = endTime - fixedEndTime;
 
             return note;
         }


### PR DESCRIPTION
Last part of #1496.

What's done in this PR:
- will auto change the start time and duration if change the
  - Reference lyric.
  - Reference time-tag index.
  - Start offset time.
  - End offset time.
- Write the test case to check the behavior.
- Adjust the test case: should assign the lyric to the note instead of set time directly to the note.
- Adjust the test case: test the offset time instead of start time or duration.