### PR TITLE
Switch the draw node by changing the alpha version.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="LanguageDetection.karaoke-dev" Version="1.3.3-alpha" />
     <PackageReference Include="LrcParser" Version="2022.529.1" />
     <PackageReference Include="Octokit" Version="2.0.0" />
-    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.806.0" />
+    <PackageReference Include="osu.Framework.KaraokeFont" Version="2022.806.1-alpha" />
     <PackageReference Include="osu.Framework.Microphone" Version="2022.806.0" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.809.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Test issue https://github.com/karaoke-dev/osu-framework-font/pull/247.
Seems there's no GC issue, happy.