### PR TITLE
Prevent some property change in the change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -73,6 +73,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
             });
         }
 
+        protected void TriggerHandlerChangedWithException<T>(Action<TChangeHandler> c) where T : Exception
+        {
+            TriggerHandlerChanged(ch =>
+            {
+                Assert.Catch<T>(() => c(ch));
+            });
+        }
+
         protected void AssertEditorBeatmap(Action<EditorBeatmap> assert)
         {
             AddStep("Is result matched", () =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricLanguageChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricLanguageChangeHandlerTest.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricLanguageChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricLanguageChangeHandler, Lyric>
+    public class LyricLanguageChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricLanguageChangeHandler>
     {
         [Test]
         public void TestSetLanguageToJapanese()
@@ -38,6 +38,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             {
                 Assert.IsNull(h.Language);
             });
+        }
+
+        [Test]
+        public void TestSetLanguageWithReferenceLyric()
+        {
+            PrepareLyricWithSyncConfig(new Lyric());
+            TriggerHandlerChangedWithChangeForbiddenException(c => c.SetLanguage(new CultureInfo("ja")));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
+{
+    public abstract class LyricPropertyChangeHandlerTest<TChangeHandler> : BaseHitObjectChangeHandlerTest<TChangeHandler, Lyric>
+        where TChangeHandler : LyricPropertyChangeHandler, new()
+    {
+        protected void PrepareLyricWithSyncConfig(Lyric hitObject, bool selected = true)
+        {
+            // allow to pre-assign the config.
+            hitObject.ReferenceLyric = new Lyric();
+            hitObject.ReferenceLyricConfig ??= new SyncLyricConfig();
+
+            PrepareHitObjects(new[] { hitObject }, selected);
+        }
+
+        protected void TriggerHandlerChangedWithChangeForbiddenException(Action<TChangeHandler> c)
+        {
+            TriggerHandlerChangedWithException<LyricPropertyChangeHandler.ChangeForbiddenException>(c);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricReferenceChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricReferenceChangeHandler, Lyric>
+    public class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricReferenceChangeHandler>
     {
         [Test]
         public void TestUpdateReferenceLyric()
@@ -107,6 +107,24 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
                 Assert.AreEqual(100, config.OffsetTime);
                 Assert.AreEqual(false, config.SyncSingerProperty);
             });
+        }
+
+        [Test]
+        public void TestWithReferenceLyric()
+        {
+            var lyric = new Lyric
+            {
+                Text = "Referenced lyric"
+            };
+
+            PrepareHitObject(lyric, false);
+            PrepareLyricWithSyncConfig(new Lyric());
+
+            // should not block the reference language change.
+            TriggerHandlerChanged(c => c.UpdateReferenceLyric(lyric));
+            TriggerHandlerChanged(c => c.SwitchToReferenceLyricConfig());
+            TriggerHandlerChanged(c => c.SwitchToSyncLyricConfig());
+            TriggerHandlerChanged(c => c.AdjustLyricConfig<SyncLyricConfig>(syncLyricConfig => syncLyricConfig.OffsetTime = 1000));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandlerTest.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricRomajiTagsChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricRomajiTagsChangeHandler, Lyric>
+    public class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricRomajiTagsChangeHandler>
     {
         [Test]
         public void TestAdd()
@@ -208,6 +208,23 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             {
                 Assert.AreEqual("karaoke", targetTag.Text);
             });
+        }
+
+        [Test]
+        public void TestWithReferenceLyric()
+        {
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                Text = "風",
+                Language = new CultureInfo(17)
+            });
+
+            TriggerHandlerChangedWithChangeForbiddenException(c => c.Add(new RomajiTag
+            {
+                StartIndex = 0,
+                EndIndex = 1,
+                Text = "kaze",
+            }));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandlerTest.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricRubyTagsChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricRubyTagsChangeHandler, Lyric>
+    public class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricRubyTagsChangeHandler>
     {
         [Test]
         public void TestAdd()
@@ -208,6 +208,23 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             {
                 Assert.AreEqual("からおけ", targetTag.Text);
             });
+        }
+
+        [Test]
+        public void TestWithReferenceLyric()
+        {
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                Text = "風",
+                Language = new CultureInfo(17)
+            });
+
+            TriggerHandlerChangedWithChangeForbiddenException(c => c.Add(new RubyTag
+            {
+                StartIndex = 0,
+                EndIndex = 1,
+                Text = "かぜ",
+            }));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricSingerChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricSingerChangeHandlerTest.cs
@@ -6,10 +6,11 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricSingerChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricSingerChangeHandler, Lyric>
+    public class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricSingerChangeHandler>
     {
         [Test]
         public void TestAdd()
@@ -140,6 +141,32 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             {
                 Assert.IsEmpty(h.Singers);
             });
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestWithReferenceLyric(bool syncSinger)
+        {
+            var singer = new Singer(1)
+            {
+                Name = "Singer1",
+            };
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                ReferenceLyricConfig = new SyncLyricConfig
+                {
+                    SyncSingerProperty = syncSinger
+                }
+            });
+
+            if (syncSinger)
+            {
+                TriggerHandlerChangedWithChangeForbiddenException(c => c.Add(singer));
+            }
+            else
+            {
+                TriggerHandlerChanged(c => c.Add(singer));
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTextChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTextChangeHandlerTest.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricTextChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricTextChangeHandler, Lyric>
+    public class LyricTextChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricTextChangeHandler>
     {
         [Test]
         public void TestInsertText()
@@ -52,6 +52,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             TriggerHandlerChanged(c => c.DeleteLyricText(1));
 
             AssertHitObjects(Assert.IsEmpty);
+        }
+
+        [Test]
+        public void TestWithReferenceLyric()
+        {
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                Text = "カラ"
+            });
+
+            TriggerHandlerChangedWithChangeForbiddenException(c => c.InsertText(2, "オケ"));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
@@ -8,11 +8,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricTimeTagsChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricTimeTagsChangeHandler, Lyric>
+    public class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricTimeTagsChangeHandler>
     {
         [Test]
         public void TestSetTimeTagTime()
@@ -413,6 +414,34 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
                     c.Shifting(targetTimeTag, direction, type);
                 });
             });
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestWithReferenceLyric(bool syncTimeTag)
+        {
+            var timeTag = new TimeTag(new TextIndex(), 1000);
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = new[]
+                {
+                    timeTag
+                },
+                ReferenceLyricConfig = new SyncLyricConfig
+                {
+                    SyncTimeTagProperty = syncTimeTag
+                }
+            });
+
+            if (syncTimeTag)
+            {
+                TriggerHandlerChangedWithChangeForbiddenException(c => c.SetTimeTagTime(timeTag, 2000));
+            }
+            else
+            {
+                TriggerHandlerChanged(c => c.SetTimeTagTime(timeTag, 2000));
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTranslateChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTranslateChangeHandlerTest.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
-    public class LyricTranslateChangeHandlerTest : BaseHitObjectChangeHandlerTest<LyricTranslateChangeHandler, Lyric>
+    public class LyricTranslateChangeHandlerTest : LyricPropertyChangeHandlerTest<LyricTranslateChangeHandler>
     {
         [Test]
         public void TestUpdateTranslateWithNewLanguage()
@@ -87,6 +87,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
             {
                 Assert.IsEmpty(h.Translates);
             });
+        }
+
+        [Test]
+        public void TestWithReferenceLyric()
+        {
+            PrepareLyricWithSyncConfig(new Lyric
+            {
+                Text = "カラオケ",
+            });
+
+            TriggerHandlerChangedWithChangeForbiddenException(c => c.UpdateTranslate(new CultureInfo(17), "からおけ"));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
                 throw new InvalidOperationException($"Should be exactly one {nameof(THitObject)} being selected.");
         }
 
-        protected void PerformOnSelection(Action<THitObject> action)
+        protected virtual void PerformOnSelection(Action<THitObject> action)
         {
             if (!changingCache.IsValid)
                 throw new NotSupportedException("Cannot trigger the change while applying another change.");

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricLanguageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricLanguageChangeHandler.cs
@@ -3,11 +3,10 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricLanguageChangeHandler : HitObjectChangeHandler<Lyric>, ILyricLanguageChangeHandler
+    public class LyricLanguageChangeHandler : LyricPropertyChangeHandler, ILyricLanguageChangeHandler
     {
         public void SetLanguage(CultureInfo? language)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
@@ -2,22 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
     public abstract class LyricPropertyChangeHandler : HitObjectChangeHandler<Lyric>
     {
+        [Resolved, AllowNull]
+        private EditorBeatmap beatmap { get; set; }
+
         protected sealed override void PerformOnSelection(Action<Lyric> action)
         {
-            base.PerformOnSelection(lyric =>
-            {
-                if (!AllowToEditIfHasReferenceLyric(lyric.ReferenceLyricConfig))
-                    throw new ChangeForbiddenException();
+            // note: should not check lyric in the perform on selection because it will let change handler in lazer broken.
+            if (beatmap.SelectedHitObjects.OfType<Lyric>().Any(lyric => !AllowToEditIfHasReferenceLyric(lyric.ReferenceLyricConfig)))
+                throw new ChangeForbiddenException();
 
-                action.Invoke(lyric);
-            });
+            base.PerformOnSelection(action);
         }
 
         protected virtual bool AllowToEditIfHasReferenceLyric(IReferenceLyricPropertyConfig? config)

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
+{
+    public abstract class LyricPropertyChangeHandler : HitObjectChangeHandler<Lyric>
+    {
+        protected sealed override void PerformOnSelection(Action<Lyric> action)
+        {
+            base.PerformOnSelection(lyric =>
+            {
+                if (!AllowToEditIfHasReferenceLyric(lyric.ReferenceLyricConfig))
+                    throw new ChangeForbiddenException();
+
+                action.Invoke(lyric);
+            });
+        }
+
+        protected virtual bool AllowToEditIfHasReferenceLyric(IReferenceLyricPropertyConfig? config)
+        {
+            if (config == null)
+                return true;
+
+            return config switch
+            {
+                SyncLyricConfig => false,
+                ReferenceLyricConfig => true,
+                _ => throw new ArgumentOutOfRangeException(nameof(config), config, "unknown config.")
+            };
+        }
+
+        public class ChangeForbiddenException : Exception
+        {
+            public ChangeForbiddenException()
+                : base("Should not change the property because this property is referenced by other lyric.")
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricReferenceChangeHandler : HitObjectChangeHandler<Lyric>, ILyricReferenceChangeHandler
+    public class LyricReferenceChangeHandler : LyricPropertyChangeHandler, ILyricReferenceChangeHandler
     {
         public void UpdateReferenceLyric(Lyric? referenceLyric)
         {
@@ -68,6 +68,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
                 action.Invoke(config);
             });
+        }
+
+        protected override bool AllowToEditIfHasReferenceLyric(IReferenceLyricPropertyConfig? config)
+        {
+            // should always able to adjust the reference lyric.
+            return true;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
@@ -4,11 +4,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
-using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricSingerChangeHandler : HitObjectChangeHandler<Lyric>, ILyricSingerChangeHandler
+    public class LyricSingerChangeHandler : LyricPropertyChangeHandler, ILyricSingerChangeHandler
     {
         public void Add(Singer singer)
         {
@@ -56,6 +56,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             {
                 lyric.Singers.Clear();
             });
+        }
+
+        protected override bool AllowToEditIfHasReferenceLyric(IReferenceLyricPropertyConfig? config)
+        {
+            if (config is SyncLyricConfig syncLyricConfig && !syncLyricConfig.SyncSingerProperty)
+                return true;
+
+            return base.AllowToEditIfHasReferenceLyric(config);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextChangeHandler.cs
@@ -2,12 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricTextChangeHandler : HitObjectChangeHandler<Lyric>, ILyricTextChangeHandler
+    public class LyricTextChangeHandler : LyricPropertyChangeHandler, ILyricTextChangeHandler
     {
         public void InsertText(int index, string text)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTextTagsChangeHandler.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public abstract class LyricTextTagsChangeHandler<TTextTag> : HitObjectChangeHandler<Lyric>, ILyricTextTagsChangeHandler<TTextTag> where TTextTag : class, ITextTag, new()
+    public abstract class LyricTextTagsChangeHandler<TTextTag> : LyricPropertyChangeHandler, ILyricTextTagsChangeHandler<TTextTag> where TTextTag : class, ITextTag, new()
     {
         public void Add(TTextTag textTag)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
@@ -6,11 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Properties;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricTimeTagsChangeHandler : HitObjectChangeHandler<Lyric>, ILyricTimeTagsChangeHandler
+    public class LyricTimeTagsChangeHandler : LyricPropertyChangeHandler, ILyricTimeTagsChangeHandler
     {
         public void SetTimeTagTime(TimeTag timeTag, double time)
         {
@@ -222,6 +223,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                         throw new InvalidOperationException();
                 }
             }
+        }
+
+        protected override bool AllowToEditIfHasReferenceLyric(IReferenceLyricPropertyConfig? config)
+        {
+            if (config is SyncLyricConfig syncLyricConfig && !syncLyricConfig.SyncTimeTagProperty)
+                return true;
+
+            return base.AllowToEditIfHasReferenceLyric(config);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTranslateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTranslateChangeHandler.cs
@@ -3,11 +3,10 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public class LyricTranslateChangeHandler : HitObjectChangeHandler<Lyric>, ILyricTranslateChangeHandler
+    public class LyricTranslateChangeHandler : LyricPropertyChangeHandler, ILyricTranslateChangeHandler
     {
         public void UpdateTranslate(CultureInfo cultureInfo, string translate)
         {


### PR DESCRIPTION
Seems there's no issue for it, so maybe this is resolve the part of #1444
Should not let user able to adjust the property if the property is sync from another lyric.
The better way might block in the change handler.

What's done in this PR:
- Implement the base lyric property related change handler for inherit. this base handler will check if lyric is allow to be modified.
- Apply the base change handler.
- Write some test case for them.