### PR TITLE
Prepare sync the reference lyric

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/RomajiTagTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/RomajiTagTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects
+{
+    public class RomajiTagTest
+    {
+        [TestCase]
+        public void TestClone()
+        {
+            var romajiTag = new RomajiTag
+            {
+                Text = "romaji",
+                StartIndex = 1,
+                EndIndex = 2
+            };
+
+            var clonedRomajiTag = romajiTag.DeepClone();
+
+            Assert.AreNotSame(clonedRomajiTag.TextBindable, romajiTag.TextBindable);
+            Assert.AreEqual(clonedRomajiTag.Text, romajiTag.Text);
+
+            Assert.AreNotSame(clonedRomajiTag.StartIndexBindable, romajiTag.StartIndexBindable);
+            Assert.AreEqual(clonedRomajiTag.StartIndex, romajiTag.StartIndex);
+
+            Assert.AreNotSame(clonedRomajiTag.EndIndexBindable, romajiTag.EndIndexBindable);
+            Assert.AreEqual(clonedRomajiTag.EndIndex, romajiTag.EndIndex);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/RubyTagTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/RubyTagTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects
+{
+    public class RubyTagTest
+    {
+        [TestCase]
+        public void TestClone()
+        {
+            var rubyTag = new RubyTag
+            {
+                Text = "ruby",
+                StartIndex = 1,
+                EndIndex = 2
+            };
+
+            var clonedRubyTag = rubyTag.DeepClone();
+
+            Assert.AreNotSame(clonedRubyTag.TextBindable, rubyTag.TextBindable);
+            Assert.AreEqual(clonedRubyTag.Text, rubyTag.Text);
+
+            Assert.AreNotSame(clonedRubyTag.StartIndexBindable, rubyTag.StartIndexBindable);
+            Assert.AreEqual(clonedRubyTag.StartIndex, rubyTag.StartIndex);
+
+            Assert.AreNotSame(clonedRubyTag.EndIndexBindable, rubyTag.EndIndexBindable);
+            Assert.AreEqual(clonedRubyTag.EndIndex, rubyTag.EndIndex);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/TimeTagTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/TimeTagTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects
+{
+    public class TimeTagTest
+    {
+        [TestCase]
+        public void TestClone()
+        {
+            var timeTag = new TimeTag(new TextIndex(1, TextIndex.IndexState.End), 1000);
+
+            var clonedTimeTag = timeTag.DeepClone();
+
+            Assert.AreEqual(clonedTimeTag.Index, timeTag.Index);
+
+            Assert.AreNotSame(clonedTimeTag.TimeBindable, timeTag.TimeBindable);
+            Assert.AreEqual(clonedTimeTag.Time, timeTag.Time);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Globalization;
-using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -24,7 +22,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class Lyric : KaraokeHitObject, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey, IDeepCloneable<Lyric>
+    public partial class Lyric : KaraokeHitObject, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey, IDeepCloneable<Lyric>
     {
         /// <summary>
         /// Primary key.
@@ -229,62 +227,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public Lyric()
         {
-            TimeTagsBindable.CollectionChanged += (_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var c in args.NewItems.Cast<TimeTag>())
-                            c.Changed += invalidate;
-                        break;
-
-                    case NotifyCollectionChangedAction.Reset:
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var c in args.OldItems.Cast<TimeTag>())
-                            c.Changed -= invalidate;
-                        break;
-                }
-
-                void invalidate() => TimeTagsVersion.Value++;
-            };
-
-            RubyTagsBindable.CollectionChanged += (_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var c in args.NewItems.Cast<RubyTag>())
-                            c.Changed += invalidate;
-                        break;
-
-                    case NotifyCollectionChangedAction.Reset:
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var c in args.OldItems.Cast<RubyTag>())
-                            c.Changed -= invalidate;
-                        break;
-                }
-
-                void invalidate() => RubyTagsVersion.Value++;
-            };
-
-            RomajiTagsBindable.CollectionChanged += (_, args) =>
-            {
-                switch (args.Action)
-                {
-                    case NotifyCollectionChangedAction.Add:
-                        foreach (var c in args.NewItems.Cast<RomajiTag>())
-                            c.Changed += invalidate;
-                        break;
-
-                    case NotifyCollectionChangedAction.Reset:
-                    case NotifyCollectionChangedAction.Remove:
-                        foreach (var c in args.OldItems.Cast<RomajiTag>())
-                            c.Changed -= invalidate;
-                        break;
-                }
-
-                void invalidate() => RomajiTagsVersion.Value++;
-            };
+            initInternalBindingEvent();
         }
 
         public override Judgement CreateJudgement() => new KaraokeLyricJudgement();

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -214,6 +214,9 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         }
 
         [JsonIgnore]
+        public readonly Bindable<int> ReferenceLyricConfigVersion = new();
+
+        [JsonIgnore]
         public readonly Bindable<IReferenceLyricPropertyConfig?> ReferenceLyricConfigBindable = new();
 
         /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Objects
+{
+    public partial class Lyric
+    {
+        private void initInternalBindingEvent()
+        {
+            TimeTagsBindable.CollectionChanged += (_, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var c in args.NewItems.Cast<TimeTag>())
+                            c.Changed += invalidate;
+                        break;
+
+                    case NotifyCollectionChangedAction.Reset:
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var c in args.OldItems.Cast<TimeTag>())
+                            c.Changed -= invalidate;
+                        break;
+                }
+
+                void invalidate() => TimeTagsVersion.Value++;
+            };
+
+            RubyTagsBindable.CollectionChanged += (_, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var c in args.NewItems.Cast<RubyTag>())
+                            c.Changed += invalidate;
+                        break;
+
+                    case NotifyCollectionChangedAction.Reset:
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var c in args.OldItems.Cast<RubyTag>())
+                            c.Changed -= invalidate;
+                        break;
+                }
+
+                void invalidate() => RubyTagsVersion.Value++;
+            };
+
+            RomajiTagsBindable.CollectionChanged += (_, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var c in args.NewItems.Cast<RomajiTag>())
+                            c.Changed += invalidate;
+                        break;
+
+                    case NotifyCollectionChangedAction.Reset:
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var c in args.OldItems.Cast<RomajiTag>())
+                            c.Changed -= invalidate;
+                        break;
+                }
+
+                void invalidate() => RomajiTagsVersion.Value++;
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
@@ -66,6 +66,21 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
                 void invalidate() => RomajiTagsVersion.Value++;
             };
+
+            ReferenceLyricConfigBindable.ValueChanged += e =>
+            {
+                if (e.OldValue != null)
+                {
+                    e.OldValue.Changed -= invalidate;
+                }
+
+                if (e.NewValue != null)
+                {
+                    e.NewValue.Changed += invalidate;
+                }
+
+                void invalidate() => ReferenceLyricConfigVersion.Value++;
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Properties/IReferenceLyricPropertyConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Properties/IReferenceLyricPropertyConfig.cs
@@ -1,10 +1,14 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Rulesets.Karaoke.Objects.Properties
 {
     public interface IReferenceLyricPropertyConfig
     {
         double OffsetTime { get; set; }
+
+        public event Action? Changed;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Properties/ReferenceLyricConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Properties/ReferenceLyricConfig.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 
@@ -8,6 +9,13 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Properties
 {
     public class ReferenceLyricConfig : IReferenceLyricPropertyConfig
     {
+        public event Action? Changed;
+
+        public ReferenceLyricConfig()
+        {
+            OffsetTimeBindable.ValueChanged += _ => Changed?.Invoke();
+        }
+
         [JsonIgnore]
         public readonly Bindable<double> OffsetTimeBindable = new BindableDouble();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Properties/SyncLyricConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Properties/SyncLyricConfig.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 using osu.Framework.Bindables;
@@ -9,6 +10,15 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Properties
 {
     public class SyncLyricConfig : IReferenceLyricPropertyConfig
     {
+        public event Action? Changed;
+
+        public SyncLyricConfig()
+        {
+            OffsetTimeBindable.ValueChanged += _ => Changed?.Invoke();
+            SyncSingerPropertyBindable.ValueChanged += _ => Changed?.Invoke();
+            SyncTimeTagPropertyBindable.ValueChanged += _ => Changed?.Invoke();
+        }
+
         [JsonIgnore]
         public readonly Bindable<double> OffsetTimeBindable = new BindableDouble();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RomajiTag.cs
@@ -5,10 +5,11 @@ using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class RomajiTag : ITextTag
+    public class RomajiTag : ITextTag, IDeepCloneable<RomajiTag>
     {
         /// <summary>
         /// Invoked when any property of this <see cref="RomajiTag"/> is changed.
@@ -57,5 +58,13 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             get => EndIndexBindable.Value;
             set => EndIndexBindable.Value = value;
         }
+
+        public RomajiTag DeepClone()
+            => new()
+            {
+                Text = Text,
+                StartIndex = StartIndex,
+                EndIndex = EndIndex,
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/RubyTag.cs
@@ -5,10 +5,11 @@ using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class RubyTag : ITextTag
+    public class RubyTag : ITextTag, IDeepCloneable<RubyTag>
     {
         /// <summary>
         /// Invoked when any property of this <see cref="RubyTag"/> is changed.
@@ -57,5 +58,13 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             get => EndIndexBindable.Value;
             set => EndIndexBindable.Value = value;
         }
+
+        public RubyTag DeepClone()
+            => new()
+            {
+                Text = Text,
+                StartIndex = StartIndex,
+                EndIndex = EndIndex,
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/TimeTag.cs
@@ -5,10 +5,11 @@ using System;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class TimeTag
+    public class TimeTag : IDeepCloneable<TimeTag>
     {
         /// <summary>
         /// Invoked when any property of this <see cref="RubyTag"/> is changed.
@@ -39,6 +40,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         {
             get => TimeBindable.Value;
             set => TimeBindable.Value = value;
+        }
+
+        public TimeTag DeepClone()
+        {
+            return new TimeTag(Index, Time);
         }
     }
 }


### PR DESCRIPTION
Prepare of issue #1467

What's done in this PR:
- make some property become cloneable because they will be copied from other lyric.
- should be able to get change event from the reference lyric config.
- add the config version and the number will be larger if config changed.