### PR TITLE
Improve the `HitObjectWritableUtils`.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
 {
@@ -17,7 +18,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
         [Test]
         public void TestIsWriteLyricPropertyLocked()
         {
+            // standard.
             test(new Lyric());
+
+            // test lock state.
+            foreach (var lockState in EnumUtils.GetValues<LockState>())
+            {
+                test(new Lyric
+                {
+                    Lock = lockState
+                });
+            }
+
+            // reference lyric.
+            test(new Lyric
+            {
+                ReferenceLyricConfig = new ReferenceLyricConfig(),
+            });
+
+            test(new Lyric
+            {
+                ReferenceLyricConfig = new SyncLyricConfig(),
+            });
 
             void test(Lyric lyric)
                 => testEveryWritablePropertyInObject<Lyric, Lyric>(lyric, (l, propertyName) => HitObjectWritableUtils.IsWriteLyricPropertyLocked(l, propertyName));
@@ -26,6 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
         [Test]
         public void TestGetLyricPropertyLockedReason()
         {
+            // standard.
             test(new Lyric());
 
             void test(Lyric lyric)
@@ -33,30 +56,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
         }
 
         [Test]
-        public void TestIsWriteLyricPropertyLockedByState()
-        {
-            test(LockState.None);
-            test(LockState.Partial);
-            test(LockState.Full);
-
-            void test(LockState lockState)
-                => testEveryWritablePropertyInObject<Lyric, LockState>(lockState, (l, propertyName) => HitObjectWritableUtils.IsWriteLyricPropertyLockedByState(l, propertyName));
-        }
-
-        [Test]
-        public void TestIsWriteLyricPropertyLockedByConfig()
-        {
-            test(new SyncLyricConfig());
-            test(new ReferenceLyricConfig());
-            test(null);
-
-            void test(IReferenceLyricPropertyConfig? config)
-                => testEveryWritablePropertyInObject<Lyric, IReferenceLyricPropertyConfig?>(config, (c, propertyName) => HitObjectWritableUtils.IsWriteLyricPropertyLockedByConfig(c, propertyName));
-        }
-
-        [Test]
         public void TestIsWriteNotePropertyLocked()
         {
+            // standard.
             test(new Note());
 
             void test(Note note)
@@ -66,19 +68,17 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
         [Test]
         public void TestGetNotePropertyLockedReason()
         {
+            // standard.
             test(new Note());
+
+            // test with reference lyric.
+            test(new Note
+            {
+                ReferenceLyric = new Lyric(),
+            });
 
             void test(Note note)
                 => testEveryWritablePropertyInObject<Note, Note>(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedReason(l, propertyName));
-        }
-
-        [Test]
-        public void TestIsWriteNotePropertyLockedByReferenceLyric()
-        {
-            test(new Lyric());
-
-            void test(Lyric lyric)
-                => testEveryWritablePropertyInObject<Note, Lyric>(lyric, (l, propertyName) => HitObjectWritableUtils.IsWriteNotePropertyLockedByReferenceLyric(l, propertyName));
         }
 
         private void testEveryWritablePropertyInObject<THitObject, TProperty>(TProperty property, Action<TProperty, string> action)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
@@ -24,6 +24,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
         }
 
         [Test]
+        public void TestGetLyricPropertyLockedReason()
+        {
+            test(new Lyric());
+
+            void test(Lyric lyric)
+                => testEveryWritablePropertyInObject<Lyric, Lyric>(lyric, (l, propertyName) => HitObjectWritableUtils.GetLyricPropertyLockedReason(l, propertyName));
+        }
+
+        [Test]
         public void TestIsWriteLyricPropertyLockedByState()
         {
             test(LockState.None);
@@ -52,6 +61,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
 
             void test(Note note)
                 => testEveryWritablePropertyInObject<Note, Note>(note, (l, propertyName) => HitObjectWritableUtils.IsWriteNotePropertyLocked(l, propertyName));
+        }
+
+        [Test]
+        public void TestGetNotePropertyLockedReason()
+        {
+            test(new Note());
+
+            void test(Note note)
+                => testEveryWritablePropertyInObject<Note, Note>(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedReason(l, propertyName));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
 {
     public static class HitObjectWritableUtils
     {
+        #region Lyric property
+
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, params string[] propertyNames)
             => propertyNames.All(x => IsWriteLyricPropertyLocked(lyric, x));
 
@@ -19,18 +21,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
 
         public static LockLyricPropertyBy? GetLyricPropertyLockedReason(Lyric lyric, string propertyName)
         {
-            bool lockedByConfig = IsWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
+            bool lockedByConfig = isWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
             if (lockedByConfig)
                 return LockLyricPropertyBy.ReferenceLyricConfig;
 
-            bool lockedByState = IsWriteLyricPropertyLockedByState(lyric.Lock, propertyName);
+            bool lockedByState = isWriteLyricPropertyLockedByState(lyric.Lock, propertyName);
             if (lockedByState)
                 return LockLyricPropertyBy.LockState;
 
             return null;
         }
 
-        public static bool IsWriteLyricPropertyLockedByState(LockState lockState, string propertyName)
+        private static bool isWriteLyricPropertyLockedByState(LockState lockState, string propertyName)
         {
             // partial lock will only lock some property change like texting because they are easy to be modified.
             // fully lock will basically lock all lyric properties.
@@ -56,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             };
         }
 
-        public static bool IsWriteLyricPropertyLockedByConfig(IReferenceLyricPropertyConfig? config, string propertyName)
+        private static bool isWriteLyricPropertyLockedByConfig(IReferenceLyricPropertyConfig? config, string propertyName)
         {
             return config switch
             {
@@ -86,6 +88,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             };
         }
 
+        #endregion
+
+        #region Create or remove notes.
+
         public static bool IsCreateOrRemoveNoteLocked(Lyric lyric)
         {
             return IsCreateOrRemoveNoteLocked(lyric.ReferenceLyricConfig);
@@ -103,6 +109,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             };
         }
 
+        #endregion
+
+        #region Note property
+
         public static bool IsWriteNotePropertyLocked(Note note, params string[] propertyNames)
             => propertyNames.All(x => IsWriteNotePropertyLocked(note, x));
 
@@ -113,18 +123,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         {
             var lyric = note.ReferenceLyric;
 
-            bool lockByReferenceLyricConfig = lyric != null && IsWriteNotePropertyLockedByReferenceLyric(lyric, propertyName);
+            bool lockByReferenceLyricConfig = lyric != null && isWriteNotePropertyLockedByReferenceLyric(lyric, propertyName);
             if (lockByReferenceLyricConfig)
                 return LockNotePropertyBy.ReferenceLyricConfig;
 
             return null;
         }
 
-        public static bool IsWriteNotePropertyLockedByReferenceLyric(Lyric lyric, string propertyName)
+        private static bool isWriteNotePropertyLockedByReferenceLyric(Lyric lyric, string propertyName)
         {
             // todo: implement.
             return false;
         }
+
+        #endregion
     }
 
     public enum LockLyricPropertyBy

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -24,8 +24,28 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
 
         public static bool IsWriteLyricPropertyLockedByState(LockState lockState, string propertyName)
         {
-            // todo: implement.
-            return false;
+            // partial lock will only lock some property change like texting because they are easy to be modified.
+            // fully lock will basically lock all lyric properties.
+            return propertyName switch
+            {
+                nameof(Lyric.ID) => false, // although the id is not changeable, but it's not locked by config.
+                nameof(Lyric.Text) => lockState > LockState.None,
+                nameof(Lyric.TimeTags) => lockState > LockState.None,
+                nameof(Lyric.RubyTags) => lockState > LockState.None,
+                nameof(Lyric.RomajiTags) => lockState > LockState.None,
+                nameof(Lyric.StartTime) => lockState > LockState.Partial,
+                nameof(Lyric.Duration) => lockState > LockState.Partial,
+                nameof(Lyric.Singers) => lockState > LockState.Partial,
+                nameof(Lyric.Translates) => lockState > LockState.Partial,
+                nameof(Lyric.Language) => lockState > LockState.Partial,
+                nameof(Lyric.Order) => false, // order can always be changed.
+                nameof(Lyric.Lock) => false, // order can always be changed.
+                nameof(Lyric.ReferenceLyric) => lockState > LockState.Partial,
+                nameof(Lyric.ReferenceLyricConfig) => lockState > LockState.Partial,
+                // base class
+                nameof(Lyric.Samples) => false,
+                _ => throw new NotSupportedException()
+            };
         }
 
         public static bool IsWriteLyricPropertyLockedByConfig(IReferenceLyricPropertyConfig? config, string propertyName)

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -15,11 +15,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             => propertyNames.All(x => IsWriteLyricPropertyLocked(lyric, x));
 
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, string propertyName)
-        {
-            bool checkByState = IsWriteLyricPropertyLockedByState(lyric.Lock, propertyName);
-            bool changeByReferenceLyricConfig = IsWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
+            => GetLyricPropertyLockedReason(lyric, propertyName) != null;
 
-            return checkByState || changeByReferenceLyricConfig;
+        public static LockLyricPropertyBy? GetLyricPropertyLockedReason(Lyric lyric, string propertyName)
+        {
+            bool lockedByConfig = IsWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
+            if (lockedByConfig)
+                return LockLyricPropertyBy.ReferenceLyricConfig;
+
+            bool lockedByState = IsWriteLyricPropertyLockedByState(lyric.Lock, propertyName);
+            if (lockedByState)
+                return LockLyricPropertyBy.LockState;
+
+            return null;
         }
 
         public static bool IsWriteLyricPropertyLockedByState(LockState lockState, string propertyName)
@@ -99,9 +107,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             => propertyNames.All(x => IsWriteNotePropertyLocked(note, x));
 
         public static bool IsWriteNotePropertyLocked(Note note, string propertyName)
+            => GetNotePropertyLockedReason(note, propertyName) != null;
+
+        public static LockNotePropertyBy? GetNotePropertyLockedReason(Note note, string propertyName)
         {
             var lyric = note.ReferenceLyric;
-            return lyric != null && IsWriteNotePropertyLockedByReferenceLyric(lyric, propertyName);
+
+            bool lockByReferenceLyricConfig = lyric != null && IsWriteNotePropertyLockedByReferenceLyric(lyric, propertyName);
+            if (lockByReferenceLyricConfig)
+                return LockNotePropertyBy.ReferenceLyricConfig;
+
+            return null;
         }
 
         public static bool IsWriteNotePropertyLockedByReferenceLyric(Lyric lyric, string propertyName)
@@ -109,5 +125,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             // todo: implement.
             return false;
         }
+    }
+
+    public enum LockLyricPropertyBy
+    {
+        ReferenceLyricConfig,
+
+        LockState,
+    }
+
+    public enum LockNotePropertyBy
+    {
+        ReferenceLyricConfig,
     }
 }


### PR DESCRIPTION
What's done in this PR:
- Should restrict some property not edit in the `isWriteLyricPropertyLockedByState` (Implement the method).
- Able to get the lock reason in the utils.
- Only expose the method that lyric editor only care.