### PR TITLE
Add the `LyricPropertyWritableVersion` property in the lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
@@ -259,5 +259,33 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
         }
 
         #endregion
+
+        #region MyRegion
+
+        [Test]
+        public void TestLyricPropertyWritableVersion()
+        {
+            var lyric = new Lyric();
+            Assert.AreEqual(0, lyric.LyricPropertyWritableVersion.Value);
+
+            lyric.Lock = LockState.Partial;
+            Assert.AreEqual(1, lyric.LyricPropertyWritableVersion.Value);
+
+            lyric.ReferenceLyric = new Lyric();
+            Assert.AreEqual(2, lyric.LyricPropertyWritableVersion.Value);
+
+            lyric.ReferenceLyricConfig = new SyncLyricConfig();
+            Assert.AreEqual(3, lyric.LyricPropertyWritableVersion.Value);
+
+            (lyric.ReferenceLyricConfig as SyncLyricConfig)!.OffsetTime = 200;
+            Assert.AreEqual(4, lyric.LyricPropertyWritableVersion.Value);
+
+            // version number will not increase if change not related property or assign the same value.
+            lyric.Lock = LockState.Partial;
+            lyric.Text = "karaoke";
+            Assert.AreEqual(4, lyric.LyricPropertyWritableVersion.Value);
+        }
+
+        #endregion
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -228,6 +228,9 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             set => ReferenceLyricConfigBindable.Value = value;
         }
 
+        [JsonIgnore]
+        public readonly Bindable<int> LyricPropertyWritableVersion = new();
+
         public Lyric()
         {
             initInternalBindingEvent();

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
@@ -72,6 +72,11 @@ namespace osu.Game.Rulesets.Karaoke.Objects
                 void invalidate() => RomajiTagsVersion.Value++;
             };
 
+            LockBindable.ValueChanged += e =>
+            {
+                LyricPropertyWritableVersion.Value++;
+            };
+
             ReferenceLyricConfigBindable.ValueChanged += e =>
             {
                 if (e.OldValue != null)
@@ -102,6 +107,8 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
             ReferenceLyricBindable.ValueChanged += e =>
             {
+                LyricPropertyWritableVersion.Value++;
+
                 // text.
                 bindValueChange(e, l => l.TextBindable, (lyric, config) =>
                 {


### PR DESCRIPTION
Closes issue #1557.

This property is focused on let editor know should re-check if property is writable again.
Will increase the number if related property changed.