### PR TITLE
Display reference lyric amount at the end of the lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                 {
                     if (model == null)
                     {
-                        // todo: show the empty text to let user select.
+                        textFlowContainer.AddText("<Empty>");
                     }
                     else
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
@@ -112,7 +112,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                 public DrawableLyricListItem(Lyric? item)
                     : base(item)
                 {
-                    Padding = new MarginPadding { Left = 5 };
                 }
 
                 public override IEnumerable<LocalisableString> FilterTerms => new[]

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
@@ -60,14 +60,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                     },
                     new Drawable[]
                     {
-                        lyricList = new RearrangeableLyricListContainer
+                        lyricList = CreateRearrangeableLyricListContainer().With(x =>
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            RequestSelection = item =>
+                            x.RelativeSizeAxes = Axes.Both;
+                            x.RequestSelection = item =>
                             {
                                 Current.Value = item;
-                            },
-                        }
+                            };
+                        })
                     }
                 }
             };
@@ -75,6 +75,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
             filter.Current.BindValueChanged(e => lyricList.Filter(e.NewValue));
             Current.BindValueChanged(e => lyricList.SelectedSet.Value = e.NewValue);
         }
+
+        protected virtual RearrangeableLyricListContainer CreateRearrangeableLyricListContainer() => new();
 
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap editorBeatmap)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledLyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledLyricSelector.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
                 => new LyricSelectorPopover(Current);
         }
 
-        public class LyricSelectorPopover : OsuPopover
+        private class LyricSelectorPopover : OsuPopover
         {
             private readonly LyricSelector lyricSelector;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledLyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledLyricSelector.cs
@@ -1,15 +1,23 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 {
@@ -54,11 +62,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 
         private class LyricSelectorPopover : OsuPopover
         {
-            private readonly LyricSelector lyricSelector;
+            private readonly ReferenceLyricSelector lyricSelector;
 
             public LyricSelectorPopover(Bindable<Lyric?> bindable)
             {
-                Child = lyricSelector = new LyricSelector
+                Child = lyricSelector = new ReferenceLyricSelector
                 {
                     Width = 400,
                     Height = 600,
@@ -71,6 +79,65 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
                 base.LoadComplete();
 
                 GetContainingInputManager().ChangeFocus(lyricSelector);
+            }
+        }
+
+        protected class ReferenceLyricSelector : LyricSelector
+        {
+            protected override RearrangeableLyricListContainer CreateRearrangeableLyricListContainer()
+                => new RearrangeableReferenceLyricListContainer();
+
+            protected class RearrangeableReferenceLyricListContainer : RearrangeableLyricListContainer
+            {
+                protected override DrawableTextListItem CreateDrawable(Lyric? item)
+                    => new DrawableReferenceLyricListItem(item);
+
+                protected class DrawableReferenceLyricListItem : DrawableLyricListItem
+                {
+                    [Resolved, AllowNull]
+                    private OsuColour colours { get; set; }
+
+                    [Resolved, AllowNull]
+                    private EditorBeatmap editorBeatmap { get; set; }
+
+                    public DrawableReferenceLyricListItem(Lyric? item)
+                        : base(item)
+                    {
+                    }
+
+                    protected override bool OnClick(ClickEvent e)
+                    {
+                        // cannot select those lyric that already contains reference lyric.
+                        if (!selectable(Model))
+                            return false;
+
+                        return base.OnClick(e);
+                    }
+
+                    protected override void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, Lyric? model)
+                    {
+                        base.CreateDisplayContent(textFlowContainer, model);
+
+                        // should have disable style if lyric is not selectable.
+                        textFlowContainer.Alpha = selectable(model) ? 1 : 0.5f;
+
+                        if (model == null)
+                            return;
+
+                        Schedule(() =>
+                        {
+                            // add reference text at the end of the text.
+                            int referenceLyricsAmount = EditorBeatmapUtils.GetAllReferenceLyrics(editorBeatmap, model).Count();
+
+                            if (referenceLyricsAmount > 0)
+                            {
+                                textFlowContainer.AddText($"({referenceLyricsAmount} reference)", x => x.Colour = colours.Red);
+                            }
+                        });
+                    }
+
+                    private static bool selectable(Lyric? lyric) => lyric?.ReferenceLyric == null;
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
                 : base(item)
             {
                 Padding = new MarginPadding { Left = 5 };
+                ShowDragHandle.Value = false;
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LanguageSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/LanguageSelector.cs
@@ -101,7 +101,6 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
                 public DrawableLanguageListItem(CultureInfo item)
                     : base(item)
                 {
-                    Padding = new MarginPadding { Left = 5 };
                 }
 
                 public override IEnumerable<LocalisableString> FilterTerms => new[]


### PR DESCRIPTION
Implement most part of #1445.

![image](https://user-images.githubusercontent.com/9100368/188304616-912d9670-040f-47e8-b70e-967a19fcc771.png)
Display reference lyric amount at the end of the lyric.

![image](https://user-images.githubusercontent.com/9100368/188306352-226d2eb3-7187-409e-b3c0-c9a70932e733.png)
And here's result after auto-detected reference lyric.