### PR TITLE
Disable click the select reference button if being referenced.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/LyricSelector.cs
@@ -129,16 +129,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                     }
                     else
                     {
-                        Schedule(() =>
-                        {
-                            // display the lyric order.
-                            textFlowContainer.AddText($"#{model.Order}", x => x.Colour = colours.Yellow);
-                            textFlowContainer.AddText("  ");
+                        // display the lyric order.
+                        textFlowContainer.AddText($"#{model.Order}", x => x.Colour = colours.Yellow);
+                        textFlowContainer.AddText("  ");
 
-                            // main text
-                            textFlowContainer.AddText(model.Text);
-                            textFlowContainer.AddText(" ");
-                        });
+                        // main text
+                        textFlowContainer.AddText(model.Text);
+                        textFlowContainer.AddText(" ");
                     }
                 }
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
@@ -147,24 +147,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 
                     protected override void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, Lyric? model)
                     {
+                        // should have disable style if lyric is not selectable.
+                        textFlowContainer.Alpha = selectable(model) ? 1 : 0.5f;
+
                         base.CreateDisplayContent(textFlowContainer, model);
 
                         if (model == null)
                             return;
 
-                        Schedule(() =>
+                        // add reference text at the end of the text.
+                        int referenceLyricsAmount = EditorBeatmapUtils.GetAllReferenceLyrics(editorBeatmap, model).Count();
+
+                        if (referenceLyricsAmount > 0)
                         {
-                            // should have disable style if lyric is not selectable.
-                            textFlowContainer.Alpha = selectable(model) ? 1 : 0.5f;
-
-                            // add reference text at the end of the text.
-                            int referenceLyricsAmount = EditorBeatmapUtils.GetAllReferenceLyrics(editorBeatmap, model).Count();
-
-                            if (referenceLyricsAmount > 0)
-                            {
-                                textFlowContainer.AddText($"({referenceLyricsAmount} reference)", x => x.Colour = colours.Red);
-                            }
-                        });
+                            textFlowContainer.AddText($"({referenceLyricsAmount} reference)", x => x.Colour = colours.Red);
+                        }
                     }
 
                     private bool selectable(Lyric? lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
@@ -21,9 +21,9 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 {
-    public class LabelledLyricSelector : LabelledComponent<LabelledLyricSelector.SelectLyricButton, Lyric?>
+    public class LabelledReferenceLyricSelector : LabelledComponent<LabelledReferenceLyricSelector.SelectLyricButton, Lyric?>
     {
-        public LabelledLyricSelector()
+        public LabelledReferenceLyricSelector()
             : base(true)
         {
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/LabelledReferenceLyricSelector.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 
         public class SelectLyricButton : OsuButton, IHasCurrentValue<Lyric?>, IHasPopover
         {
+            [Resolved, AllowNull]
+            private EditorBeatmap editorBeatmap { get; set; }
+
             private readonly BindableWithCurrent<Lyric?> current = new();
 
             public Bindable<Lyric?> Current
@@ -50,7 +53,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
                 set => current.Current = value;
             }
 
-            public Lyric? IgnoredLyric { get; set; }
+            private Lyric? ignoredLyric;
+
+            public Lyric? IgnoredLyric
+            {
+                get => ignoredLyric;
+                set
+                {
+                    ignoredLyric = value;
+
+                    // should not enable the selection if current lyric is being referenced.
+                    Enabled.Value = ignoredLyric != null && !EditorBeatmapUtils.GetAllReferenceLyrics(editorBeatmap, ignoredLyric).Any();
+                }
+            }
 
             public SelectLyricButton()
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
                 return;
 
             labelledReferenceLyricSelector.Current = lyric.ReferenceLyricBindable;
+            labelledReferenceLyricSelector.IgnoredLyric = lyric;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
@@ -16,20 +16,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
         [Resolved, AllowNull]
         private ILyricReferenceChangeHandler lyricReferenceChangeHandler { get; set; }
 
-        private readonly LabelledLyricSelector labelledLyricSelector;
+        private readonly LabelledReferenceLyricSelector labelledReferenceLyricSelector;
 
         public ReferenceLyricSection()
         {
             Children = new[]
             {
-                labelledLyricSelector = new LabelledLyricSelector
+                labelledReferenceLyricSelector = new LabelledReferenceLyricSelector
                 {
                     Label = "Referenced lyric",
                     Description = "Select the similar lyric that want to reference or sync the property."
                 }
             };
 
-            labelledLyricSelector.Current.BindValueChanged(x =>
+            labelledReferenceLyricSelector.Current.BindValueChanged(x =>
             {
                 if (!IsRebinding)
                     lyricReferenceChangeHandler.UpdateReferenceLyric(x.NewValue);
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
             if (lyric == null)
                 return;
 
-            labelledLyricSelector.Current = lyric.ReferenceLyricBindable;
+            labelledReferenceLyricSelector.Current = lyric.ReferenceLyricBindable;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterface/RearrangeableTextFlowListContainer.cs
@@ -95,7 +95,14 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterface
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-            }.With(x => CreateDisplayContent(x, Model));
+            }.With(x =>
+            {
+                Schedule(() =>
+                {
+                    // should create the text after BDL loaded.
+                    CreateDisplayContent(x, Model);
+                });
+            });
 
             protected override bool OnClick(ClickEvent e)
             {

--- a/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/FontSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/UserInterfaceV2/FontSelector.cs
@@ -271,21 +271,18 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2
                     protected override void CreateDisplayContent(OsuTextFlowContainer textFlowContainer, string model)
                     {
                         textFlowContainer.TextAnchor = Anchor.BottomLeft;
-                        Schedule(() =>
+                        textFlowContainer.AddText(model);
+
+                        var matchedFormat = fontManager.Fonts
+                                                       .Where(x => x.Family == Model).Select(x => x.FontFormat)
+                                                       .Distinct()
+                                                       .ToArray();
+
+                        foreach (var format in matchedFormat)
                         {
-                            textFlowContainer.AddText(model);
-
-                            var matchedFormat = fontManager.Fonts
-                                                           .Where(x => x.Family == Model).Select(x => x.FontFormat)
-                                                           .Distinct()
-                                                           .ToArray();
-
-                            foreach (var format in matchedFormat)
-                            {
-                                textFlowContainer.AddText(" ");
-                                textFlowContainer.AddArbitraryDrawable(new FontFormatBadge(format));
-                            }
-                        });
+                            textFlowContainer.AddText(" ");
+                            textFlowContainer.AddArbitraryDrawable(new FontFormatBadge(format));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Last part of #1445.

What's done in this PR:
- Rename the reference lyric selector component.
- Should not let user select the same lyric as reference lyric.
- Should not let lyric selectable if already being referenced.
- Misc.