### PR TITLE
Refactor the lock utils and remove the utils in the lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -378,8 +378,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             return mode switch
             {
                 LyricEditorMode.View => null,
-                LyricEditorMode.Texting => HitObjectWritableUtils.GetLyricPropertyLockedReasons(lyric, nameof(Lyric.Text), nameof(Lyric.RubyTags), nameof(Lyric.RomajiTags), nameof(Lyric.TimeTags)),
-                LyricEditorMode.Reference => HitObjectWritableUtils.GetLyricPropertyLockedReasons(lyric, nameof(Lyric.ReferenceLyric), nameof(Lyric.ReferenceLyricConfig)),
+                LyricEditorMode.Texting => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.Text), nameof(Lyric.RubyTags), nameof(Lyric.RomajiTags), nameof(Lyric.TimeTags)),
+                LyricEditorMode.Reference => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.ReferenceLyric), nameof(Lyric.ReferenceLyricConfig)),
                 LyricEditorMode.Language => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.Language)),
                 LyricEditorMode.EditRuby => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.RubyTags)),
                 LyricEditorMode.EditRomaji => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.RomajiTags)),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends;
@@ -26,9 +25,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
-using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Extensions;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -358,36 +355,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             };
 
             public IScrollAlgorithm Algorithm { get; } = new SequentialScrollAlgorithm(new List<MultiplierControlPoint>());
-        }
-
-        public static LocalisableString? GetLyricPropertyLockedReason(Lyric lyric, LyricEditorMode mode)
-        {
-            var reasons = getLyricPropertyLockedReasons(lyric, mode);
-
-            return reasons switch
-            {
-                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this lyric is property is sync from another lyric.",
-                LockLyricPropertyBy.LockState => "This property is locked and not editable",
-                null => null,
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
-
-        private static LockLyricPropertyBy? getLyricPropertyLockedReasons(Lyric lyric, LyricEditorMode mode)
-        {
-            return mode switch
-            {
-                LyricEditorMode.View => null,
-                LyricEditorMode.Texting => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.Text), nameof(Lyric.RubyTags), nameof(Lyric.RomajiTags), nameof(Lyric.TimeTags)),
-                LyricEditorMode.Reference => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.ReferenceLyric), nameof(Lyric.ReferenceLyricConfig)),
-                LyricEditorMode.Language => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.Language)),
-                LyricEditorMode.EditRuby => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.RubyTags)),
-                LyricEditorMode.EditRomaji => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.RomajiTags)),
-                LyricEditorMode.EditTimeTag => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.TimeTags)),
-                LyricEditorMode.EditNote => HitObjectWritableUtils.GetCreateOrRemoveNoteLockedReason(lyric),
-                LyricEditorMode.Singer => HitObjectWritableUtils.GetLyricPropertyLockedReason(lyric, nameof(Lyric.Singers)),
-                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
-            };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, string propertyName)
             => GetLyricPropertyLockedReason(lyric, propertyName) != null;
 
-        public static LockLyricPropertyBy? GetLyricPropertyLockedReasons(Lyric lyric, params string[] propertyNames)
+        public static LockLyricPropertyBy? GetLyricPropertyLockedReason(Lyric lyric, params string[] propertyNames)
         {
             var reasons = propertyNames.Select(x => GetLyricPropertyLockedReason(lyric, x))
                                        .Where(x => x != null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -14,14 +15,31 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         #region Lyric property
 
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, params string[] propertyNames)
-            => propertyNames.All(x => IsWriteLyricPropertyLocked(lyric, x));
+            => getLyricPropertyLockedBy(lyric, propertyNames) != null;
 
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, string propertyName)
-            => GetLyricPropertyLockedReason(lyric, propertyName) != null;
+            => getLyricPropertyLockedBy(lyric, propertyName) != null;
 
-        public static LockLyricPropertyBy? GetLyricPropertyLockedReason(Lyric lyric, params string[] propertyNames)
+        public static LocalisableString? GetLyricPropertyLockedReason(Lyric lyric, params string[] propertyNames)
+            => getLyricPropertyLockedMessage(getLyricPropertyLockedBy(lyric, propertyNames));
+
+        public static LocalisableString? GetLyricPropertyLockedReason(Lyric lyric, string propertyName)
+            => getLyricPropertyLockedMessage(getLyricPropertyLockedBy(lyric, propertyName));
+
+        private static LocalisableString? getLyricPropertyLockedMessage(LockLyricPropertyBy? reasons)
         {
-            var reasons = propertyNames.Select(x => GetLyricPropertyLockedReason(lyric, x))
+            return reasons switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this lyric is property is sync from another lyric.",
+                LockLyricPropertyBy.LockState => "This property is locked and not editable",
+                null => default(LocalisableString?),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        private static LockLyricPropertyBy? getLyricPropertyLockedBy(Lyric lyric, params string[] propertyNames)
+        {
+            var reasons = propertyNames.Select(x => getLyricPropertyLockedBy(lyric, x))
                                        .Where(x => x != null)
                                        .OfType<LockLyricPropertyBy>()
                                        .ToArray();
@@ -35,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             return null;
         }
 
-        public static LockLyricPropertyBy? GetLyricPropertyLockedReason(Lyric lyric, string propertyName)
+        private static LockLyricPropertyBy? getLyricPropertyLockedBy(Lyric lyric, string propertyName)
         {
             bool lockedByConfig = isWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
             if (lockedByConfig)
@@ -111,7 +129,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         public static bool IsCreateOrRemoveNoteLocked(Lyric lyric)
             => GetCreateOrRemoveNoteLockedReason(lyric) != null;
 
-        public static LockLyricPropertyBy? GetCreateOrRemoveNoteLockedReason(Lyric lyric)
+        public static LocalisableString? GetCreateOrRemoveNoteLockedReason(Lyric lyric)
+            => getCreateOrRemoveNoteLockedMessage(getCreateOrRemoveNoteLockedBy(lyric));
+
+        private static LocalisableString? getCreateOrRemoveNoteLockedMessage(LockLyricPropertyBy? reasons)
+        {
+            return reasons switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this lyric is property is sync from another lyric.",
+                LockLyricPropertyBy.LockState => "This property is locked and not editable",
+                null => default(LocalisableString?),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        private static LockLyricPropertyBy? getCreateOrRemoveNoteLockedBy(Lyric lyric, params string[] propertyNames)
         {
             bool lockedByConfig = isCreateOrRemoveNoteLocked(lyric.ReferenceLyricConfig);
             if (lockedByConfig)
@@ -137,12 +169,41 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         #region Note property
 
         public static bool IsWriteNotePropertyLocked(Note note, params string[] propertyNames)
-            => propertyNames.All(x => IsWriteNotePropertyLocked(note, x));
+            => getNotePropertyLockedBy(note, propertyNames) != null;
 
         public static bool IsWriteNotePropertyLocked(Note note, string propertyName)
-            => GetNotePropertyLockedReason(note, propertyName) != null;
+            => getNotePropertyLockedBy(note, propertyName) != null;
 
-        public static LockNotePropertyBy? GetNotePropertyLockedReason(Note note, string propertyName)
+        public static LocalisableString? GetNotePropertyLockedReason(Note note, params string[] propertyNames)
+            => getNotePropertyLockedMessage(getNotePropertyLockedBy(note, propertyNames));
+
+        public static LocalisableString? GetNotePropertyLockedReason(Note note, string propertyName)
+            => getNotePropertyLockedMessage(getNotePropertyLockedBy(note, propertyName));
+
+        private static LocalisableString? getNotePropertyLockedMessage(LockNotePropertyBy? reasons)
+        {
+            return reasons switch
+            {
+                LockNotePropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this note's lyric is property is sync from another lyric.",
+                null => default(LocalisableString?),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        private static LockNotePropertyBy? getNotePropertyLockedBy(Note note, params string[] propertyNames)
+        {
+            var reasons = propertyNames.Select(x => getNotePropertyLockedBy(note, x))
+                                       .Where(x => x != null)
+                                       .OfType<LockNotePropertyBy>()
+                                       .ToArray();
+
+            if (reasons.Contains(LockNotePropertyBy.ReferenceLyricConfig))
+                return LockNotePropertyBy.ReferenceLyricConfig;
+
+            return null;
+        }
+
+        private static LockNotePropertyBy? getNotePropertyLockedBy(Note note, string propertyName)
         {
             var lyric = note.ReferenceLyric;
 
@@ -161,14 +222,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
 
         #endregion
 
-        public enum LockLyricPropertyBy
+        private enum LockLyricPropertyBy
         {
             ReferenceLyricConfig,
 
             LockState,
         }
 
-        public enum LockNotePropertyBy
+        private enum LockNotePropertyBy
         {
             ReferenceLyricConfig,
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -160,18 +160,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         }
 
         #endregion
-    }
 
-    [Flags]
-    public enum LockLyricPropertyBy
-    {
-        ReferenceLyricConfig,
+        public enum LockLyricPropertyBy
+        {
+            ReferenceLyricConfig,
 
-        LockState,
-    }
+            LockState,
+        }
 
-    public enum LockNotePropertyBy
-    {
-        ReferenceLyricConfig,
+        public enum LockNotePropertyBy
+        {
+            ReferenceLyricConfig,
+        }
     }
 }


### PR DESCRIPTION
Inspired while implementing #1563.

![image](https://user-images.githubusercontent.com/9100368/188483248-ae4a5a98-9798-4009-ab55-756570390eab.png)
Remove the check writable logic in the lyric editor because one lyric edit mode does not only exactly match to one check type.

Also, let the writable utils able to get property lock reason.