### PR TITLE
Should block edit in the lyric property section if property is not editable.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
@@ -48,8 +48,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
                 testEveryWritablePropertiesInObjectAtTheSameTime(lyric, (l, propertyName) => HitObjectWritableUtils.IsWriteLyricPropertyLocked(l, propertyName));
                 testEveryWritablePropertiesInObject(lyric, (l, propertyName) => HitObjectWritableUtils.IsWriteLyricPropertyLocked(l, propertyName));
 
-                testEveryWritablePropertiesInObjectAtTheSameTime(lyric, (l, propertyName) => HitObjectWritableUtils.GetLyricPropertyLockedReason(l, propertyName));
-                testEveryWritablePropertiesInObject(lyric, (l, propertyName) => HitObjectWritableUtils.GetLyricPropertyLockedReason(l, propertyName));
+                testEveryWritablePropertiesInObjectAtTheSameTime(lyric, (l, propertyName) => HitObjectWritableUtils.GetLyricPropertyLockedBy(l, propertyName));
+                testEveryWritablePropertiesInObject(lyric, (l, propertyName) => HitObjectWritableUtils.GetLyricPropertyLockedBy(l, propertyName));
             }
         }
 
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
             void test(Lyric lyric)
             {
                 HitObjectWritableUtils.IsCreateOrRemoveNoteLocked(lyric);
-                HitObjectWritableUtils.GetCreateOrRemoveNoteLockedReason(lyric);
+                HitObjectWritableUtils.GetCreateOrRemoveNoteLockedBy(lyric);
             }
         }
 
@@ -111,8 +111,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
                 testEveryWritablePropertiesInObjectAtTheSameTime(note, (l, propertyName) => HitObjectWritableUtils.IsWriteNotePropertyLocked(l, propertyName));
                 testEveryWritablePropertiesInObject(note, (l, propertyName) => HitObjectWritableUtils.IsWriteNotePropertyLocked(l, propertyName));
 
-                testEveryWritablePropertiesInObjectAtTheSameTime(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedReason(l, propertyName));
-                testEveryWritablePropertiesInObject(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedReason(l, propertyName));
+                testEveryWritablePropertiesInObjectAtTheSameTime(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedBy(l, propertyName));
+                testEveryWritablePropertiesInObject(note, (l, propertyName) => HitObjectWritableUtils.GetNotePropertyLockedBy(l, propertyName));
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/BlockSectionWrapper.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/BlockSectionWrapper.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
+{
+    public class BlockSectionWrapper : CompositeDrawable, IHasTooltip
+    {
+        public BlockSectionWrapper(IconUsage iconUsage, LocalisableString name, LocalisableString description, LocalisableString tooltip)
+        {
+            TooltipText = tooltip;
+
+            RelativeSizeAxes = Axes.Both;
+            Padding = new MarginPadding { Top = 30 };
+
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 15,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.3f,
+                        Colour = Color4.Black
+                    },
+                },
+                new BlockSectionMessage(iconUsage, name, description)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                }
+            };
+        }
+
+        public LocalisableString TooltipText { get; }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            return true;
+        }
+
+        public class BlockSectionMessage : CompositeDrawable
+        {
+            private FillFlowContainer textContainer { get; }
+
+            private readonly Container boxContainer;
+
+            private const double transition_time = 1000;
+
+            public BlockSectionMessage(IconUsage iconUsage, LocalisableString name, LocalisableString description)
+            {
+                AutoSizeAxes = Axes.Both;
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                var colour = Color4.Gray;
+
+                InternalChildren = new Drawable[]
+                {
+                    boxContainer = new Container
+                    {
+                        CornerRadius = 12,
+                        Masking = true,
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+
+                                Colour = colour.Darken(0.8f),
+                                Alpha = 0.8f,
+                            },
+                            textContainer = new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Padding = new MarginPadding(20),
+                                Direction = FillDirection.Vertical,
+                                Children = new Drawable[]
+                                {
+                                    new SpriteIcon
+                                    {
+                                        Icon = iconUsage,
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Size = new Vector2(32),
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Text = name,
+                                        Colour = colour,
+                                        Font = OsuFont.GetFont(size: 18),
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
+                                        Text = description,
+                                        Font = OsuFont.GetFont(size: 14),
+                                    },
+                                }
+                            },
+                        }
+                    },
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                textContainer.Position = new Vector2(DrawSize.X / 16, 0);
+
+                boxContainer.Hide();
+                boxContainer.ScaleTo(0.2f);
+                boxContainer.RotateTo(-20);
+
+                using (BeginDelayedSequence(300))
+                {
+                    boxContainer.ScaleTo(1, transition_time, Easing.OutElastic);
+                    boxContainer.RotateTo(0, transition_time / 2, Easing.OutQuint);
+
+                    textContainer.MoveTo(Vector2.Zero, transition_time, Easing.OutExpo);
+                    boxContainer.FadeIn(transition_time, Easing.OutExpo);
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -85,6 +85,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             notes.Value = EditorBeatmapUtils.GetNotesByLyric(beatmap, lyric).ToArray();
         }
 
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetCreateOrRemoveNoteLockedBy(lyric); //todo: should reference by another utils.
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Notes is sync to another notes.",
+                LockLyricPropertyBy.LockState => "Notes is locked.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot edit the notes because it's sync to another lyric's notes.",
+                LockLyricPropertyBy.LockState => "The lyric is locked, so cannot edit the note.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
         private class LabelledNoteTextTextBox : LabelledObjectFieldTextBox<Note>
         {
             [Resolved]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricConfigSection.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
@@ -115,6 +116,23 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
             if (lyric != null)
                 bindableReferenceLyricPropertyConfig.BindTo(lyric.ReferenceLyricConfigBindable);
         }
+
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetLyricPropertyLockedBy(lyric, nameof(Lyric.ReferenceLyric), nameof(lyric.ReferenceLyricConfig));
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                // technically the property is always editable.
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                // technically the property is always editable.
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
 
         private void onConfigChanged()
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricSection.cs
@@ -1,10 +1,12 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
@@ -44,5 +46,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
             labelledReferenceLyricSelector.Current = lyric.ReferenceLyricBindable;
             labelledReferenceLyricSelector.IgnoredLyric = lyric;
         }
+
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetLyricPropertyLockedBy(lyric, nameof(Lyric.ReferenceLyric), nameof(lyric.ReferenceLyricConfig));
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                // technically the property is always editable.
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                // technically the property is always editable.
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagEditSection.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -10,6 +11,7 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
@@ -29,6 +31,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         protected override void AddTextTag(RomajiTag textTag)
             => romajiTagsChangeHandler.Add(textTag);
+
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetLyricPropertyLockedBy(lyric, nameof(Lyric.RomajiTags));
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Romaji is sync to another romaji.",
+                LockLyricPropertyBy.LockState => "Romaji is locked.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot edit the romaji because it's sync to another lyric's text.",
+                LockLyricPropertyBy.LockState => "The lyric is locked, so cannot edit the romaji.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
 
         protected class LabelledRomajiTagTextBox : LabelledTextTagTextBox<RomajiTag>
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagEditSection.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -10,6 +11,7 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
@@ -29,6 +31,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 
         protected override void AddTextTag(RubyTag textTag)
             => rubyTagsChangeHandler.Add(textTag);
+
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetLyricPropertyLockedBy(lyric, nameof(Lyric.RubyTags));
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Ruby is sync to another ruby.",
+                LockLyricPropertyBy.LockState => "Ruby is locked.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot edit the ruby because it's sync to another lyric's text.",
+                LockLyricPropertyBy.LockState => "The lyric is locked, so cannot edit the ruby.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
 
         protected class LabelledRubyTagTextBox : LabelledTextTagTextBox<RubyTag>
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerEditSection.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -14,6 +15,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Singers;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -88,6 +90,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
             // singer index might be able to change from other place like singer editor.
             singerIndexes.BindTo(lyric.SingersBindable);
         }
+
+        protected override LockLyricPropertyBy? IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.GetLyricPropertyLockedBy(lyric, nameof(Lyric.Singers));
+
+        protected override LocalisableString GetWriteLyricPropertyLockedDescription(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Singers is sync to another notes.",
+                LockLyricPropertyBy.LockState => "Singers is locked.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
+
+        protected override LocalisableString GetWriteLyricPropertyLockedTooltip(LockLyricPropertyBy lockLyricPropertyBy) =>
+            lockLyricPropertyBy switch
+            {
+                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot edit the singers because it's sync to another lyric's singers.",
+                LockLyricPropertyBy.LockState => "The lyric is locked, so cannot edit the singers.",
+                _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
+            };
 
         public class LabelledSingerSwitchButton : LabelledSwitchButton, IHasCustomTooltip<Singer>
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -15,31 +14,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         #region Lyric property
 
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, params string[] propertyNames)
-            => getLyricPropertyLockedBy(lyric, propertyNames) != null;
+            => GetLyricPropertyLockedBy(lyric, propertyNames) != null;
 
         public static bool IsWriteLyricPropertyLocked(Lyric lyric, string propertyName)
-            => getLyricPropertyLockedBy(lyric, propertyName) != null;
+            => GetLyricPropertyLockedBy(lyric, propertyName) != null;
 
-        public static LocalisableString? GetLyricPropertyLockedReason(Lyric lyric, params string[] propertyNames)
-            => getLyricPropertyLockedMessage(getLyricPropertyLockedBy(lyric, propertyNames));
-
-        public static LocalisableString? GetLyricPropertyLockedReason(Lyric lyric, string propertyName)
-            => getLyricPropertyLockedMessage(getLyricPropertyLockedBy(lyric, propertyName));
-
-        private static LocalisableString? getLyricPropertyLockedMessage(LockLyricPropertyBy? reasons)
+        public static LockLyricPropertyBy? GetLyricPropertyLockedBy(Lyric lyric, params string[] propertyNames)
         {
-            return reasons switch
-            {
-                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this lyric is property is sync from another lyric.",
-                LockLyricPropertyBy.LockState => "This property is locked and not editable",
-                null => default(LocalisableString?),
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
-
-        private static LockLyricPropertyBy? getLyricPropertyLockedBy(Lyric lyric, params string[] propertyNames)
-        {
-            var reasons = propertyNames.Select(x => getLyricPropertyLockedBy(lyric, x))
+            var reasons = propertyNames.Select(x => GetLyricPropertyLockedBy(lyric, x))
                                        .Where(x => x != null)
                                        .OfType<LockLyricPropertyBy>()
                                        .ToArray();
@@ -53,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             return null;
         }
 
-        private static LockLyricPropertyBy? getLyricPropertyLockedBy(Lyric lyric, string propertyName)
+        public static LockLyricPropertyBy? GetLyricPropertyLockedBy(Lyric lyric, string propertyName)
         {
             bool lockedByConfig = isWriteLyricPropertyLockedByConfig(lyric.ReferenceLyricConfig, propertyName);
             if (lockedByConfig)
@@ -127,23 +109,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         #region Create or remove notes.
 
         public static bool IsCreateOrRemoveNoteLocked(Lyric lyric)
-            => GetCreateOrRemoveNoteLockedReason(lyric) != null;
+            => GetCreateOrRemoveNoteLockedBy(lyric) != null;
 
-        public static LocalisableString? GetCreateOrRemoveNoteLockedReason(Lyric lyric)
-            => getCreateOrRemoveNoteLockedMessage(getCreateOrRemoveNoteLockedBy(lyric));
-
-        private static LocalisableString? getCreateOrRemoveNoteLockedMessage(LockLyricPropertyBy? reasons)
-        {
-            return reasons switch
-            {
-                LockLyricPropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this lyric is property is sync from another lyric.",
-                LockLyricPropertyBy.LockState => "This property is locked and not editable",
-                null => default(LocalisableString?),
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
-
-        private static LockLyricPropertyBy? getCreateOrRemoveNoteLockedBy(Lyric lyric, params string[] propertyNames)
+        public static LockLyricPropertyBy? GetCreateOrRemoveNoteLockedBy(Lyric lyric, params string[] propertyNames)
         {
             bool lockedByConfig = isCreateOrRemoveNoteLocked(lyric.ReferenceLyricConfig);
             if (lockedByConfig)
@@ -169,30 +137,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         #region Note property
 
         public static bool IsWriteNotePropertyLocked(Note note, params string[] propertyNames)
-            => getNotePropertyLockedBy(note, propertyNames) != null;
+            => GetNotePropertyLockedBy(note, propertyNames) != null;
 
         public static bool IsWriteNotePropertyLocked(Note note, string propertyName)
-            => getNotePropertyLockedBy(note, propertyName) != null;
+            => GetNotePropertyLockedBy(note, propertyName) != null;
 
-        public static LocalisableString? GetNotePropertyLockedReason(Note note, params string[] propertyNames)
-            => getNotePropertyLockedMessage(getNotePropertyLockedBy(note, propertyNames));
-
-        public static LocalisableString? GetNotePropertyLockedReason(Note note, string propertyName)
-            => getNotePropertyLockedMessage(getNotePropertyLockedBy(note, propertyName));
-
-        private static LocalisableString? getNotePropertyLockedMessage(LockNotePropertyBy? reasons)
+        public static LockNotePropertyBy? GetNotePropertyLockedBy(Note note, params string[] propertyNames)
         {
-            return reasons switch
-            {
-                LockNotePropertyBy.ReferenceLyricConfig => "Cannot modify this property due to this note's lyric is property is sync from another lyric.",
-                null => default(LocalisableString?),
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
-
-        private static LockNotePropertyBy? getNotePropertyLockedBy(Note note, params string[] propertyNames)
-        {
-            var reasons = propertyNames.Select(x => getNotePropertyLockedBy(note, x))
+            var reasons = propertyNames.Select(x => GetNotePropertyLockedBy(note, x))
                                        .Where(x => x != null)
                                        .OfType<LockNotePropertyBy>()
                                        .ToArray();
@@ -203,7 +155,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             return null;
         }
 
-        private static LockNotePropertyBy? getNotePropertyLockedBy(Note note, string propertyName)
+        public static LockNotePropertyBy? GetNotePropertyLockedBy(Note note, string propertyName)
         {
             var lyric = note.ReferenceLyric;
 
@@ -221,17 +173,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         }
 
         #endregion
+    }
 
-        private enum LockLyricPropertyBy
-        {
-            ReferenceLyricConfig,
+    public enum LockLyricPropertyBy
+    {
+        ReferenceLyricConfig,
 
-            LockState,
-        }
+        LockState,
+    }
 
-        private enum LockNotePropertyBy
-        {
-            ReferenceLyricConfig,
-        }
+    public enum LockNotePropertyBy
+    {
+        ReferenceLyricConfig,
     }
 }


### PR DESCRIPTION
Main part of #1536.

Will lock the section in the lyric editor if property is not editable.
![image](https://user-images.githubusercontent.com/9100368/188667422-4be13d5b-b083-4f4a-be17-d1067387387d.png)
