### PR TITLE
Refactor the editor and the layer in the lyric editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
+{
+    public abstract class BaseLayer : CompositeDrawable
+    {
+        protected readonly Lyric Lyric;
+
+        protected BaseLayer(Lyric lyric)
+        {
+            Lyric = lyric;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -13,6 +14,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         protected BaseLayer(Lyric lyric)
         {
             Lyric = lyric;
+
+            RelativeSizeAxes = Axes.Both;
         }
 
         public abstract void UpdateDisableEditState(bool editable);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BaseLayer.cs
@@ -14,5 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         {
             Lyric = lyric;
         }
+
+        public abstract void UpdateDisableEditState(bool editable);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
@@ -4,23 +4,19 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
-    public class BlueprintLayer : CompositeDrawable
+    public class BlueprintLayer : BaseLayer
     {
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
         private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
 
-        private readonly Lyric lyric;
-
         public BlueprintLayer(Lyric lyric)
+            : base(lyric)
         {
-            this.lyric = lyric;
-
             bindableMode.BindValueChanged(_ =>
             {
                 // Initial blueprint container.
@@ -49,7 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             // create preview and real caret
             var mode = bindableMode.Value;
             var timeTagEditMode = bindableTimeTagEditMode.Value;
-            var blueprintContainer = createBlueprintContainer(mode, timeTagEditMode, lyric);
+            var blueprintContainer = createBlueprintContainer(mode, timeTagEditMode, Lyric);
             if (blueprintContainer == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
         private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
 
+        // should block all blueprint action if not editable.
+        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && editable;
+
+        private bool editable = true;
+
         public BlueprintLayer(Lyric lyric)
             : base(lyric)
         {
@@ -59,6 +64,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
                     LyricEditorMode.EditTimeTag => timeTagEditMode == TimeTagEditMode.Adjust ? new TimeTagBlueprintContainer(lyric) : null,
                     _ => null
                 };
+        }
+
+        public override void UpdateDisableEditState(bool editable)
+        {
+            this.editable = editable;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/BlueprintLayer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -57,7 +55,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 
             AddInternal(blueprintContainer);
 
-            static Drawable createBlueprintContainer(LyricEditorMode mode, TimeTagEditMode timeTagEditMode, Lyric lyric) =>
+            static Drawable? createBlueprintContainer(LyricEditorMode mode, TimeTagEditMode timeTagEditMode, Lyric lyric) =>
                 mode switch
                 {
                     LyricEditorMode.EditRuby => new RubyBlueprintContainer(lyric),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
@@ -17,7 +16,7 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
-    public class CaretLayer : CompositeDrawable
+    public class CaretLayer : BaseLayer
     {
         [Resolved, AllowNull]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
@@ -31,12 +30,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
         private readonly IBindable<ICaretPositionAlgorithm?> bindableCaretPositionAlgorithm = new Bindable<ICaretPositionAlgorithm?>();
 
-        private readonly Lyric lyric;
-
         public CaretLayer(Lyric lyric)
+            : base(lyric)
         {
-            this.lyric = lyric;
-
             bindableCaretPositionAlgorithm.BindValueChanged(e =>
             {
                 // initial default caret.
@@ -95,27 +91,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             switch (bindableCaretPositionAlgorithm.Value)
             {
                 case CuttingCaretPositionAlgorithm:
-                    int cuttingLyricStringIndex = Math.Clamp(TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position)), 0, lyric.Text.Length - 1);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TextCaretPosition(lyric, cuttingLyricStringIndex));
+                    int cuttingLyricStringIndex = Math.Clamp(TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position)), 0, Lyric.Text.Length - 1);
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TextCaretPosition(Lyric, cuttingLyricStringIndex));
                     break;
 
                 case TypingCaretPositionAlgorithm:
                     int typingStringIndex = TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position));
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TextCaretPosition(lyric, typingStringIndex));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TextCaretPosition(Lyric, typingStringIndex));
                     break;
 
                 case NavigateCaretPositionAlgorithm:
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(lyric));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(Lyric));
                     break;
 
                 case TimeTagIndexCaretPositionAlgorithm:
                     var textIndex = karaokeSpriteText.GetHoverIndex(position);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(lyric, textIndex));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(Lyric, textIndex));
                     break;
 
                 case TimeTagCaretPositionAlgorithm:
                     var timeTag = karaokeSpriteText.GetHoverTimeTag(position);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagCaretPosition(lyric, timeTag));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagCaretPosition(Lyric, timeTag));
                     break;
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
@@ -158,6 +159,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
                 default:
                     return false;
             }
+        }
+
+        public override void UpdateDisableEditState(bool editable)
+        {
+            this.FadeTo(editable ? 1 : 0.7f, 100);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/CaretLayer.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -20,17 +19,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
     public class CaretLayer : CompositeDrawable
     {
-        [Resolved]
+        [Resolved, AllowNull]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
 
-        [Resolved]
+        [Resolved, AllowNull]
         private ILyricCaretState lyricCaretState { get; set; }
 
-        [Resolved]
+        [Resolved, AllowNull]
         private ILyricsChangeHandler lyricsChangeHandler { get; set; }
 
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
-        private readonly IBindable<ICaretPositionAlgorithm> bindableCaretPositionAlgorithm = new Bindable<ICaretPositionAlgorithm>();
+        private readonly IBindable<ICaretPositionAlgorithm?> bindableCaretPositionAlgorithm = new Bindable<ICaretPositionAlgorithm?>();
 
         private readonly Lyric lyric;
 
@@ -64,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
                 AddInternal(caret);
             }
 
-            static DrawableCaret createCaret(ICaretPositionAlgorithm caretPositionAlgorithm, bool isPreview) =>
+            static DrawableCaret? createCaret(ICaretPositionAlgorithm? caretPositionAlgorithm, bool isPreview) =>
                 caretPositionAlgorithm switch
                 {
                     // cutting lyric

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/EditorKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/EditorKaraokeSpriteText.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 
         public Lyric HitObject;
 
+        public Action SizeChanged;
+
         public EditorKaraokeSpriteText(Lyric lyric)
             : base(lyric)
         {
@@ -139,6 +141,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 
                 LeftLyricTextShaders = SkinConvertorTool.ConvertLeftSideShader(shaderManager, newStyle);
                 RightLyricTextShaders = SkinConvertorTool.ConvertRightSideShader(shaderManager, newStyle);
+
+                triggerSizeChangedEvent();
             }, true);
 
             skin.GetConfig<Lyric, LyricConfig>(HitObject)?.BindValueChanged(lyricConfig =>
@@ -156,9 +160,40 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
                 RubyFont = getFont(rubyFont.Size);
                 RomajiFont = getFont(romajiFont.Size);
 
+                triggerSizeChangedEvent();
+
                 static FontUsage getFont(float? charSize = null)
                     => FontUsage.Default.With(size: charSize * 2);
             }, true);
+        }
+
+        protected override void UpdateText()
+        {
+            base.UpdateText();
+
+            triggerSizeChangedEvent();
+        }
+
+        protected override void UpdateRubies()
+        {
+            base.UpdateRubies();
+
+            triggerSizeChangedEvent();
+        }
+
+        protected override void UpdateRomajies()
+        {
+            base.UpdateRomajies();
+
+            triggerSizeChangedEvent();
+        }
+
+        private void triggerSizeChangedEvent()
+        {
+            ScheduleAfterChildren(() =>
+            {
+                SizeChanged?.Invoke();
+            });
         }
 
         public override bool RemoveCompletedTransforms => false;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/LyricLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/LyricLayer.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
+{
+    public class LyricLayer : BaseLayer
+    {
+        public LyricLayer(Lyric lyric, Drawable karaokeSpriteText)
+            : base(lyric)
+        {
+            InternalChild = karaokeSpriteText;
+        }
+
+        public override void UpdateDisableEditState(bool editable)
+        {
+            this.FadeTo(editable ? 1 : 0.5f, 100);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
@@ -33,14 +33,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             bindableLyricPropertyWritableVersion = lyric.LyricPropertyWritableVersion.GetBoundCopy();
 
             CornerRadius = 5;
-            AutoSizeAxes = Axes.Y;
             Padding = new MarginPadding { Bottom = 10 };
             Children = new Drawable[]
             {
-                karaokeSpriteText = new EditorKaraokeSpriteText(lyric),
+                new LyricLayer(lyric, karaokeSpriteText = new EditorKaraokeSpriteText(lyric)),
                 new TimeTagLayer(lyric),
                 new CaretLayer(lyric),
                 new BlueprintLayer(lyric),
+            };
+
+            karaokeSpriteText.SizeChanged = () =>
+            {
+                Height = karaokeSpriteText.DrawHeight;
             };
 
             bindableMode.BindValueChanged(x =>
@@ -61,10 +65,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             var loadReason = GetLyricPropertyLockedReason(lyric, bindableMode.Value);
             lockReason = loadReason;
 
-            bool editable = lockReason == null;
-
             // adjust the style.
-            karaokeSpriteText.FadeTo(editable ? 1 : 0.5f, 300);
+            bool editable = lockReason == null;
             Children.OfType<BaseLayer>().ForEach(x => x.UpdateDisableEditState(editable));
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -22,10 +24,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
         private readonly IBindable<int> bindableLyricPropertyWritableVersion;
 
+        private readonly Lyric lyric;
         private LocalisableString? lockReason;
 
         public SingleLyricEditor(Lyric lyric)
         {
+            this.lyric = lyric;
             bindableLyricPropertyWritableVersion = lyric.LyricPropertyWritableVersion.GetBoundCopy();
 
             CornerRadius = 5;
@@ -59,15 +63,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             });
 
             updateLockReasonAndStyle();
+        }
 
-            void updateLockReasonAndStyle()
-            {
-                var loadReason = GetLyricPropertyLockedReason(lyric, bindableMode.Value);
-                lockReason = loadReason;
+        private void updateLockReasonAndStyle()
+        {
+            var loadReason = GetLyricPropertyLockedReason(lyric, bindableMode.Value);
+            lockReason = loadReason;
 
-                // adjust the style.
-                Alpha = loadReason == null ? 1 : 0.5f;
-            }
+            bool editable = lockReason == null;
+
+            // adjust the style.
+            karaokeSpriteText.FadeTo(editable ? 1 : 0.5f, 300);
+            Children.OfType<BaseLayer>().ForEach(x => x.UpdateDisableEditState(editable));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
@@ -16,7 +16,7 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
-    public class SingleLyricEditor : Container, IHasTooltip
+    public class SingleLyricEditor : CompositeDrawable, IHasTooltip
     {
         [Cached]
         private readonly EditorKaraokeSpriteText karaokeSpriteText;
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 
             CornerRadius = 5;
             Padding = new MarginPadding { Bottom = 10 };
-            Children = new Drawable[]
+            InternalChildren = new Drawable[]
             {
                 new LyricLayer(lyric, karaokeSpriteText = new EditorKaraokeSpriteText(lyric)),
                 new TimeTagLayer(lyric),
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 
             // adjust the style.
             bool editable = lockReason == null;
-            Children.OfType<BaseLayer>().ForEach(x => x.UpdateDisableEditState(editable));
+            InternalChildren.OfType<BaseLayer>().ForEach(x => x.UpdateDisableEditState(editable));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/SingleLyricEditor.cs
@@ -38,18 +38,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
             Children = new Drawable[]
             {
                 karaokeSpriteText = new EditorKaraokeSpriteText(lyric),
-                new TimeTagLayer(lyric)
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
-                new CaretLayer(lyric)
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
-                new BlueprintLayer(lyric)
-                {
-                    RelativeSizeAxes = Axes.Both,
-                }
+                new TimeTagLayer(lyric),
+                new CaretLayer(lyric),
+                new BlueprintLayer(lyric),
             };
 
             bindableMode.BindValueChanged(x =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
@@ -4,13 +4,12 @@
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
-    public class TimeTagLayer : CompositeDrawable
+    public class TimeTagLayer : BaseLayer
     {
         [Resolved, AllowNull]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
@@ -18,6 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
         private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();
 
         public TimeTagLayer(Lyric lyric)
+            : base(lyric)
         {
             timeTagsBindable.BindCollectionChanged((_, _) =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -13,7 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
 {
     public class TimeTagLayer : CompositeDrawable
     {
-        [Resolved]
+        [Resolved, AllowNull]
         private EditorKaraokeSpriteText karaokeSpriteText { get; set; }
 
         private readonly IBindableList<TimeTag> timeTagsBindable = new BindableList<TimeTag>();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Rows/Edit/TimeTagLayer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -39,6 +40,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Rows.Edit
                     Position = position
                 });
             }
+        }
+
+        public override void UpdateDisableEditState(bool editable)
+        {
+            this.FadeTo(editable ? 1 : 0.5f, 100);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Graphics/Sprites/DrawableKaraokeSpriteText.cs
@@ -28,13 +28,13 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
         {
             this.chunkIndex = chunkIndex;
 
-            textBindable.BindValueChanged(_ => updateText(), true);
-            timeTagsVersion.BindValueChanged(_ => updateTimeTags());
-            timeTagsBindable.BindCollectionChanged((_, _) => updateTimeTags());
-            rubyTagsVersion.BindValueChanged(_ => updateRubies());
-            rubyTagsBindable.BindCollectionChanged((_, _) => updateRubies());
-            romajiTagsVersion.BindValueChanged(_ => updateRomajies());
-            romajiTagsBindable.BindCollectionChanged((_, _) => updateRomajies());
+            textBindable.BindValueChanged(_ => UpdateText(), true);
+            timeTagsVersion.BindValueChanged(_ => UpdateTimeTags());
+            timeTagsBindable.BindCollectionChanged((_, _) => UpdateTimeTags());
+            rubyTagsVersion.BindValueChanged(_ => UpdateRubies());
+            rubyTagsBindable.BindCollectionChanged((_, _) => UpdateRubies());
+            romajiTagsVersion.BindValueChanged(_ => UpdateRomajies());
+            romajiTagsBindable.BindCollectionChanged((_, _) => UpdateRomajies());
 
             textBindable.BindTo(lyric.TextBindable);
             timeTagsVersion.BindTo(lyric.TimeTagsVersion);
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             romajiTagsBindable.BindTo(lyric.RomajiTagsBindable);
         }
 
-        private void updateText()
+        protected virtual void UpdateText()
         {
             if (chunkIndex == whole_chunk_index)
             {
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void updateTimeTags()
+        protected virtual void UpdateTimeTags()
         {
             if (chunkIndex == whole_chunk_index)
             {
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void updateRubies()
+        protected virtual void UpdateRubies()
         {
             if (chunkIndex == whole_chunk_index)
             {
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
             }
         }
 
-        private void updateRomajies()
+        protected virtual void UpdateRomajies()
         {
             if (chunkIndex == whole_chunk_index)
             {
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
                     return;
 
                 displayRuby = value;
-                Schedule(updateRubies);
+                Schedule(UpdateRubies);
             }
         }
 
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Karaoke.Graphics.Sprites
                     return;
 
                 displayRomaji = value;
-                Schedule(updateRomajies);
+                Schedule(UpdateRomajies);
             }
         }
     }


### PR DESCRIPTION
Continuous of issue #1540.

What's done in this PR:
- Implement the base layer interface and apply the disable state.
- Move karaoke sprite text into the layer.
- User should not be able to interact with the blueprint if lyric is not editable.
- Will have lyric size changed event for able to adjust the row height.

For now, `SingleLyricEditor` should be composite drawable and with layers.