### PR TITLE
Fix issue in the note popover

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -3,98 +3,119 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
 {
     public class NoteEditPopover : OsuPopover
     {
-        [Resolved(canBeNull: true)]
-        private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
-
         public NoteEditPopover(Note note)
         {
-            LabelledTextBox text;
-            LabelledTextBox rubyText;
-            LabelledSwitchButton display;
+            if (note == null)
+                throw new ArgumentNullException(nameof(note));
 
-            Children = new Drawable[]
+            Child = new OsuScrollContainer
             {
-                new FillFlowContainer
+                Height = 320,
+                Width = 300,
+                Child = new FillFlowContainer<Section>
                 {
-                    Width = 200,
                     Direction = FillDirection.Vertical,
+                    RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Children = new Drawable[]
+                    Children = new Section[]
                     {
-                        text = new LabelledTextBox
-                        {
-                            Label = "Text",
-                            Description = "The text display on the note.",
-                            Current = note.TextBindable,
-                            TabbableContentContainer = this
-                        },
-                        rubyText = new LabelledTextBox
-                        {
-                            Label = "Ruby text",
-                            Description = "Should place something like ruby, 拼音 or ふりがな.",
-                            Current = note.RubyTextBindable,
-                            TabbableContentContainer = this
-                        },
-                        display = new LabelledSwitchButton
-                        {
-                            Label = "Display",
-                            Description = "This note will be hidden and not scorable if not display.",
-                            Current = note.DisplayBindable,
-                        }
+                        new NoteSection(note),
                     }
                 }
             };
-
-            ScheduleAfterChildren(() =>
-            {
-                GetContainingInputManager().ChangeFocus(text);
-            });
-
-            text.OnCommit += (sender, newText) =>
-            {
-                if (!newText)
-                    return;
-
-                string text = sender.Text.Trim();
-                notePropertyChangeHandler?.ChangeText(text);
-            };
-
-            rubyText.OnCommit += (sender, newText) =>
-            {
-                if (!newText)
-                    return;
-
-                string text = sender.Text.Trim();
-                notePropertyChangeHandler?.ChangeRubyText(text);
-            };
-
-            display.Current.BindValueChanged(v =>
-            {
-                notePropertyChangeHandler?.ChangeDisplayState(v.NewValue);
-            });
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(HitObjectComposer composer)
+        private class NoteSection : Section
         {
-            if (notePropertyChangeHandler != null || composer == null)
-                return;
+            private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
 
-            // todo: not a good way to get change handler, might remove or found another way eventually.
-            // cannot get change handler directly in editor screen, so should trying to get from karaoke hit object composer.
-            notePropertyChangeHandler = composer.Dependencies.Get<INotePropertyChangeHandler>();
+            protected override LocalisableString Title => "Note property";
+
+            public NoteSection(Note note)
+            {
+                LabelledTextBox text;
+                LabelledTextBox rubyText;
+                LabelledSwitchButton display;
+
+                Children = new Drawable[]
+                {
+                    text = new LabelledTextBox
+                    {
+                        Label = "Text",
+                        Description = "The text display on the note.",
+                        Current = note.TextBindable,
+                        TabbableContentContainer = this
+                    },
+                    rubyText = new LabelledTextBox
+                    {
+                        Label = "Ruby text",
+                        Description = "Should place something like ruby, 拼音 or ふりがな.",
+                        Current = note.RubyTextBindable,
+                        TabbableContentContainer = this
+                    },
+                    display = new LabelledSwitchButton
+                    {
+                        Label = "Display",
+                        Description = "This note will be hidden and not scorable if not display.",
+                        Current = note.DisplayBindable,
+                    }
+                };
+
+                ScheduleAfterChildren(() =>
+                {
+                    GetContainingInputManager().ChangeFocus(text);
+                });
+
+                text.OnCommit += (sender, newText) =>
+                {
+                    if (!newText)
+                        return;
+
+                    string text = sender.Text.Trim();
+                    notePropertyChangeHandler?.ChangeText(text);
+                };
+
+                rubyText.OnCommit += (sender, newText) =>
+                {
+                    if (!newText)
+                        return;
+
+                    string text = sender.Text.Trim();
+                    notePropertyChangeHandler?.ChangeRubyText(text);
+                };
+
+                display.Current.BindValueChanged(v =>
+                {
+                    notePropertyChangeHandler?.ChangeDisplayState(v.NewValue);
+                });
+            }
+
+            [BackgroundDependencyLoader(true)]
+            private void load(HitObjectComposer composer)
+            {
+                if (notePropertyChangeHandler != null || composer == null)
+                    return;
+
+                // todo: not a good way to get change handler, might remove or found another way eventually.
+                // cannot get change handler directly in editor screen, so should trying to get from karaoke hit object composer.
+                notePropertyChangeHandler = composer.Dependencies.Get<INotePropertyChangeHandler>();
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -37,23 +37,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.UserInterfaceV2
                         {
                             Label = "Text",
                             Description = "The text display on the note.",
-                            Current = note.TextBindable
+                            Current = note.TextBindable,
+                            TabbableContentContainer = this
                         },
                         rubyText = new LabelledTextBox
                         {
                             Label = "Ruby text",
                             Description = "Should place something like ruby, 拼音 or ふりがな.",
-                            Current = note.RubyTextBindable
+                            Current = note.RubyTextBindable,
+                            TabbableContentContainer = this
                         },
                         display = new LabelledSwitchButton
                         {
                             Label = "Display",
                             Description = "This note will be hidden and not scorable if not display.",
-                            Current = note.DisplayBindable
+                            Current = note.DisplayBindable,
                         }
                     }
                 }
             };
+
+            ScheduleAfterChildren(() =>
+            {
+                GetContainingInputManager().ChangeFocus(text);
+            });
 
             text.OnCommit += (sender, newText) =>
             {


### PR DESCRIPTION
What's done in this PR:
- should focus to the popover after opened.
- fix the bad UX style.

Before:
![image](https://user-images.githubusercontent.com/9100368/189516068-d5372843-df84-4468-a654-d5f74d6eddbc.png)


After:
![image](https://user-images.githubusercontent.com/9100368/189516058-2f8e6cc5-a403-496c-bde1-6e51348231b1.png)
