### PR TITLE
Should reset selected items in the mode status

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldSwitchButton.cs
@@ -59,11 +59,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             SelectedItems.Add(item);
         }
 
-        protected void TriggerUnselect()
-        {
-            SelectedItems.Remove(item);
-        }
-
         protected abstract bool GetFieldValue(T item);
 
         protected abstract void ApplyValue(T item, bool value);
@@ -73,13 +68,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             Selected = selected =>
             {
                 if (selected)
-                {
                     TriggerSelect();
-                }
-                else
-                {
-                    TriggerUnselect();
-                }
             }
         };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -134,6 +134,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             {
                 base.OnFocusLost(e);
 
+                // should not change the border size because still need to highlight the textarea without focus.
+                BorderThickness = 3f;
+
                 // note: should trigger commit event first in the base class.
                 Selected?.Invoke(false);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -73,11 +73,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             SelectedItems.Add(item);
         }
 
-        protected void TriggerUnselect()
-        {
-            SelectedItems.Remove(item);
-        }
-
         protected abstract string GetFieldValue(T item);
 
         protected abstract void ApplyValue(T item, string value);
@@ -92,13 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             Selected = selected =>
             {
                 if (selected)
-                {
                     TriggerSelect();
-                }
-                else
-                {
-                    TriggerUnselect();
-                }
             }
         };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/LabelledObjectFieldTextBox.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             {
                 bool highLight = SelectedItems.Contains(item);
                 Component.HighLight = highLight;
+
+                if (SelectedItems.Contains(item) && SelectedItems.Count == 1)
+                    focus();
             });
 
             if (InternalChildren[1] is not FillFlowContainer fillFlowContainer)
@@ -99,13 +102,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
             }
         };
 
-        public void Focus()
+        private void focus()
         {
             Schedule(() =>
             {
+                var focusedDrawable = GetContainingInputManager().FocusedDrawable;
+                if (focusedDrawable != null && IsFocused(focusedDrawable))
+                    return;
+
                 GetContainingInputManager().ChangeFocus(Component);
             });
         }
+
+        protected virtual bool IsFocused(Drawable focusedDrawable)
+            => focusedDrawable == Component;
 
         protected class ObjectFieldTextBox : OsuTextBox
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertySection.cs
@@ -74,16 +74,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
             }
         }
 
-        protected override void UpdateDisabledState(bool disabled)
-        {
-            if (disabled)
-                return;
-
-            // should auto-focus to the first note property if change the lyric.
-            var firstTextTagTextBox = Children.OfType<LabelledObjectFieldTextBox<Note>>().FirstOrDefault();
-            firstTextTagTextBox?.Focus();
-        }
-
         [BackgroundDependencyLoader]
         private void load(IEditNoteModeState editNoteModeState)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -153,6 +153,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
 
         protected abstract void RemoveTextTag(T item);
 
+        protected override bool IsFocused(Drawable focusedDrawable)
+            => base.IsFocused(focusedDrawable) || focusedDrawable == indexShiftingPart;
+
         public new CompositeDrawable TabbableContentContainer
         {
             set

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -65,14 +65,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
                             // trigger selected if hover on delete button.
                             TriggerSelect();
                         }
-                        else
-                        {
-                            // do not clear current selected if typing.
-                            if (Component.HasFocus)
-                                return;
-
-                            TriggerUnselect();
-                        }
                     }
                 }
             });
@@ -95,13 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components
                     Selected = selected =>
                     {
                         if (selected)
-                        {
                             TriggerSelect();
-                        }
-                        else
-                        {
-                            TriggerUnselect();
-                        }
                     },
                     Action = (indexType, action) =>
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagEditSection.cs
@@ -57,16 +57,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
             TextTags.BindTo(GetBindableTextTags(lyric));
         }
 
-        protected override void UpdateDisabledState(bool disabled)
-        {
-            if (disabled)
-                return;
-
-            // should auto-focus to the first time-tag if change the lyric.
-            var firstTextTagTextBox = Children.OfType<LabelledTextTagTextBox<TTextTag>>().FirstOrDefault();
-            firstTextTagTextBox?.Focus();
-        }
-
         private void addCreateButton()
         {
             var fillFlowContainer = Content as FillFlowContainer;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
@@ -1,6 +1,8 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes;
@@ -17,6 +19,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
         private readonly Bindable<NoteEditMode> bindableEditMode = new();
         private readonly BindableList<HitObject> selectedHitObjects = new();
 
+        [Resolved, AllowNull]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         public IBindable<NoteEditMode> BindableEditMode => bindableEditMode;
 
         public void ChangeEditMode(NoteEditMode mode)
@@ -27,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
         public Bindable<NoteEditPropertyMode> NoteEditPropertyMode { get; } = new();
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap editorBeatmap)
+        private void load()
         {
             BindablesUtils.Sync(SelectedItems, selectedHitObjects);
             selectedHitObjects.BindTo(editorBeatmap.SelectedHitObjects);
@@ -35,5 +40,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
             => HitObjectWritableUtils.IsCreateOrRemoveNoteLocked(lyric);
+
+        protected override bool SelectFirstProperty(Lyric lyric)
+            => BindableEditMode.Value == NoteEditMode.Edit;
+
+        protected override IEnumerable<Note> SelectableProperties(Lyric lyric)
+            => EditorBeatmapUtils.GetNotesByLyric(editorBeatmap, lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditNoteModeState.cs
@@ -3,8 +3,8 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Rulesets.Objects;
@@ -12,7 +12,7 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public class EditNoteModeState : Component, IEditNoteModeState
+    public class EditNoteModeState : ModeStateWithBlueprintContainer<Note>, IEditNoteModeState
     {
         private readonly Bindable<NoteEditMode> bindableEditMode = new();
         private readonly BindableList<HitObject> selectedHitObjects = new();
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         public void ChangeEditMode(NoteEditMode mode)
             => bindableEditMode.Value = mode;
-
-        public BindableList<Note> SelectedItems { get; } = new();
 
         public Bindable<NoteEditModeSpecialAction> BindableSpecialAction { get; } = new();
 
@@ -34,5 +32,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
             BindablesUtils.Sync(SelectedItems, selectedHitObjects);
             selectedHitObjects.BindTo(editorBeatmap.SelectedHitObjects);
         }
+
+        protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.IsCreateOrRemoveNoteLocked(lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -18,5 +19,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
             => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.RomajiTags));
+
+        protected override bool SelectFirstProperty(Lyric lyric)
+            => BindableEditMode.Value == TextTagEditMode.Edit;
+
+        protected override IEnumerable<RomajiTag> SelectableProperties(Lyric lyric)
+            => lyric.RomajiTags;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRomajiModeState.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public class EditRomajiModeState : Component, IEditRomajiModeState
+    public class EditRomajiModeState : ModeStateWithBlueprintContainer<RomajiTag>, IEditRomajiModeState
     {
         private readonly Bindable<TextTagEditMode> bindableEditMode = new();
 
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
         public void ChangeEditMode(TextTagEditMode mode)
             => bindableEditMode.Value = mode;
 
-        public BindableList<RomajiTag> SelectedItems { get; } = new();
+        protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.RomajiTags));
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -18,5 +19,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
             => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.RubyTags));
+
+        protected override bool SelectFirstProperty(Lyric lyric)
+            => BindableEditMode.Value == TextTagEditMode.Edit;
+
+        protected override IEnumerable<RubyTag> SelectableProperties(Lyric lyric)
+            => lyric.RubyTags;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditRubyModeState.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public class EditRubyModeState : Component, IEditRubyModeState
+    public class EditRubyModeState : ModeStateWithBlueprintContainer<RubyTag>, IEditRubyModeState
     {
         private readonly Bindable<TextTagEditMode> bindableEditMode = new();
 
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
         public void ChangeEditMode(TextTagEditMode mode)
             => bindableEditMode.Value = mode;
 
-        public BindableList<RubyTag> SelectedItems { get; } = new();
+        protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.RubyTags));
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ModeStateWithBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ModeStateWithBlueprintContainer.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
+{
+    public abstract class ModeStateWithBlueprintContainer<TObject> : Component, IHasBlueprintSelection<TObject> where TObject : class
+    {
+        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+        private readonly IBindable<ICaretPosition?> bindableCaretPosition = new Bindable<ICaretPosition?>();
+        private readonly IBindable<int> bindableLyricPropertyWritableVersion = new Bindable<int>();
+
+        public BindableList<TObject> SelectedItems { get; } = new();
+
+        protected ModeStateWithBlueprintContainer()
+        {
+            bindableMode.BindValueChanged(e =>
+            {
+                triggerDisableStateChanged();
+            });
+
+            bindableCaretPosition.BindValueChanged(e =>
+            {
+                bindableLyricPropertyWritableVersion.UnbindBindings();
+
+                var lyric = e.NewValue?.Lyric;
+
+                if (lyric == null)
+                    return;
+
+                bindableLyricPropertyWritableVersion.BindTo(lyric.LyricPropertyWritableVersion);
+                triggerDisableStateChanged();
+            });
+
+            bindableLyricPropertyWritableVersion.BindValueChanged(_ =>
+            {
+                triggerDisableStateChanged();
+            });
+        }
+
+        private void triggerDisableStateChanged()
+        {
+            var lyric = bindableCaretPosition.Value?.Lyric;
+            if (lyric == null)
+                return;
+
+            bool locked = IsWriteLyricPropertyLocked(lyric);
+            if (locked)
+                SelectedItems.Clear();
+        }
+
+        protected abstract bool IsWriteLyricPropertyLocked(Lyric lyric);
+
+        [BackgroundDependencyLoader]
+        private void load(ILyricEditorState state, ILyricCaretState lyricCaretState)
+        {
+            bindableMode.BindTo(state.BindableMode);
+            bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
@@ -1,6 +1,8 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
@@ -36,5 +38,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
             => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.TimeTags));
+
+        protected override bool SelectFirstProperty(Lyric lyric)
+            => false;
+
+        protected override IEnumerable<TimeTag> SelectableProperties(Lyric lyric)
+            => Array.Empty<TimeTag>();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TimeTagModeState.cs
@@ -3,20 +3,17 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 {
-    public class TimeTagModeState : Component, ITimeTagModeState
+    public class TimeTagModeState : ModeStateWithBlueprintContainer<TimeTag>, ITimeTagModeState
     {
         private readonly Bindable<TimeTagEditMode> bindableEditMode = new();
 
         public IBindable<TimeTagEditMode> BindableEditMode => bindableEditMode;
-
-        public BindableList<TimeTag> SelectedItems { get; } = new();
 
         public BindableFloat BindableRecordZoom { get; } = new();
 
@@ -36,5 +33,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         public void ChangeEditMode(TimeTagEditMode mode)
             => bindableEditMode.Value = mode;
+
+        protected override bool IsWriteLyricPropertyLocked(Lyric lyric)
+            => HitObjectWritableUtils.IsWriteLyricPropertyLocked(lyric, nameof(Lyric.TimeTags));
     }
 }


### PR DESCRIPTION
Fix remaining part of #1540 and closes issue #1578.

What's done in this PR:
- Should clear the blueprint after lyric writeable state change to disabled(#1540).
- Move the select first property in the lyric logic into the state.
- Adjust the focus logic. Will focus to the textbox only exactly one selected items, and lost focus will not de-select the selected items.