### PR TITLE
Should be able to check if editable in the hit-object property related change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Properties;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
 {
     public abstract class LyricPropertyChangeHandlerTest<TChangeHandler> : BaseHitObjectPropertyChangeHandlerTest<TChangeHandler, Lyric>
-        where TChangeHandler : LyricPropertyChangeHandler, new()
+        where TChangeHandler : LyricPropertyChangeHandler, ILyricPropertyChangeHandler, new()
     {
         protected Lyric PrepareLyricWithSyncConfig(Lyric referencedLyric, IReferenceLyricPropertyConfig? config = null, bool selected = true)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricAutoGenerateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricAutoGenerateChangeHandler.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricAutoGenerateChangeHandler
+    public interface ILyricAutoGenerateChangeHandler : ILyricPropertyChangeHandler
     {
         bool CanGenerate(LyricAutoGenerateProperty autoGenerateProperty);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricLanguageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricLanguageChangeHandler.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricLanguageChangeHandler
+    public interface ILyricLanguageChangeHandler : ILyricPropertyChangeHandler
     {
         void SetLanguage(CultureInfo? language);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricListPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricListPropertyChangeHandler.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricListPropertyChangeHandler<in TItem>
+    public interface ILyricListPropertyChangeHandler<in TItem> : ILyricPropertyChangeHandler
     {
         void Add(TItem item);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricPropertyChangeHandler.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
+{
+    public interface ILyricPropertyChangeHandler
+    {
+        bool IsSelectionsLocked();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricReferenceChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricReferenceChangeHandler.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects.Properties;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricReferenceChangeHandler
+    public interface ILyricReferenceChangeHandler : ILyricPropertyChangeHandler
     {
         void UpdateReferenceLyric(Lyric? referenceLyric);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTextChangeHandler.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricTextChangeHandler
+    public interface ILyricTextChangeHandler : ILyricPropertyChangeHandler
     {
         void InsertText(int index, string text);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTranslateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTranslateChangeHandler.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricTranslateChangeHandler
+    public interface ILyricTranslateChangeHandler : ILyricPropertyChangeHandler
     {
         void UpdateTranslate(CultureInfo cultureInfo, string translate);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricsChangeHandler.cs
@@ -16,9 +16,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         void CreateAtLast();
 
-        void AddBelowToSelection(Lyric lyric);
+        void AddBelowToSelection(Lyric newLyric);
 
-        void AddRangeBelowToSelection(IEnumerable<Lyric> lyrics);
+        void AddRangeBelowToSelection(IEnumerable<Lyric> newLyrics);
 
         void Remove();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandler.cs
@@ -236,6 +236,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             }
         }
 
+        public override bool IsSelectionsLocked()
+            => throw new InvalidOperationException("Auto-generator does not support this check method.");
+
         protected override bool IsWritePropertyLocked(Lyric lyric) =>
             currentAutoGenerateProperty switch
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricPropertyChangeHandler.cs
@@ -1,11 +1,20 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public abstract class LyricPropertyChangeHandler : HitObjectPropertyChangeHandler<Lyric>
+    public abstract class LyricPropertyChangeHandler : HitObjectPropertyChangeHandler<Lyric>, ILyricPropertyChangeHandler
     {
+        [Resolved, AllowNull]
+        private EditorBeatmap beatmap { get; set; }
+
+        public virtual bool IsSelectionsLocked()
+            => beatmap.SelectedHitObjects.OfType<Lyric>().Any(IsWritePropertyLocked);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricsChangeHandler.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             AddRangeBelowToSelection(new[] { newLyric });
         }
 
-        public void AddRangeBelowToSelection(IEnumerable<Lyric> newlyrics)
+        public void AddRangeBelowToSelection(IEnumerable<Lyric> newLyrics)
         {
             CheckExactlySelectedOneHitObject();
 
@@ -94,12 +94,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                 int order = lyric.Order;
 
                 // Shifting order that order is larger than current lyric.
-                OrderUtils.ShiftingOrder(HitObjects.Where(x => x.Order > order), newlyrics.Count());
+                OrderUtils.ShiftingOrder(HitObjects.Where(x => x.Order > order), newLyrics.Count());
 
-                foreach (var newlyric in newlyrics)
+                foreach (var newLyric in newLyrics)
                 {
-                    newlyric.Order = ++order;
-                    Add(newlyric);
+                    newLyric.Order = ++order;
+                    Add(newLyric);
                 }
             });
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
@@ -42,6 +42,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
         }
 
         protected override bool IsWritePropertyLocked(Note note)
-            => HitObjectWritableUtils.IsWriteNotePropertyLocked(note, nameof(Note.Text) , nameof(Note.RubyText) , nameof(Note.Display));
+            => HitObjectWritableUtils.IsWriteNotePropertyLocked(note, nameof(Note.Text), nameof(Note.RubyText), nameof(Note.Display));
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/HitObjectWritableUtils.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
         public static bool IsCreateOrRemoveNoteLocked(Lyric lyric)
             => GetCreateOrRemoveNoteLockedBy(lyric) != null;
 
-        public static LockLyricPropertyBy? GetCreateOrRemoveNoteLockedBy(Lyric lyric, params string[] propertyNames)
+        public static LockLyricPropertyBy? GetCreateOrRemoveNoteLockedBy(Lyric lyric)
         {
             bool lockedByConfig = isCreateOrRemoveNoteLocked(lyric.ReferenceLyricConfig);
             if (lockedByConfig)


### PR DESCRIPTION
Part of issue #1585.
Implement for lyric property related change handler only in this PR because one change handler exactly only change one property.

What's done in this PR:
- Some code clean-up
- Implement the `ILyricPropertyChangeHandler` for those property-related change handler.
- Apply the interface and the implement the the utils to check if selected lyrics locked or not.