### PR TITLE
Adjust the inherit class in the lyric editor extend area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/EditModeSection.cs
@@ -14,7 +14,6 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Markdown;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
@@ -39,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
         }
     }
 
-    public abstract class EditModeSection<TEditMode> : Section where TEditMode : Enum
+    public abstract class EditModeSection<TEditMode> : LyricEditorSection where TEditMode : Enum
     {
         private const int horizontal_padding = 20;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SpecialActionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Components/SpecialActionSection.cs
@@ -8,13 +8,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components
 {
-    public abstract class SpecialActionSection<TAction> : Section where TAction : struct, Enum
+    public abstract class SpecialActionSection<TAction> : LyricEditorSection where TAction : struct, Enum
     {
         protected sealed override LocalisableString Title => "Action";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
@@ -19,19 +16,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 
         public abstract float ExtendWidth { get; }
 
-        protected override IReadOnlyList<Drawable> CreateSections() => Array.Empty<Drawable>();
-
-        protected IReadOnlyList<Drawable> Children
+        protected void ReloadSections()
         {
-            get => this.ChildrenOfType<FillFlowContainer>().First().Children;
-            set
-            {
-                // should delay assign the children after loaded.
-                Schedule(() =>
-                {
-                    this.ChildrenOfType<FillFlowContainer>().First().Children = value;
-                });
-            }
+            this.ChildrenOfType<FillFlowContainer>().First().Children = CreateSections();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/EditExtend.cs
@@ -1,53 +1,44 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 {
-    public abstract class EditExtend : Container
+    public abstract class EditExtend : EditorRoundedScreenSettings
     {
         public abstract ExtendDirection Direction { get; }
 
         public abstract float ExtendWidth { get; }
 
-        protected override Container<Drawable> Content => content;
+        protected override IReadOnlyList<Drawable> CreateSections() => Array.Empty<Drawable>();
 
-        private readonly Box background;
-        private readonly FillFlowContainer content;
-
-        protected EditExtend()
+        protected IReadOnlyList<Drawable> Children
         {
-            RelativeSizeAxes = Axes.Both;
-            InternalChildren = new Drawable[]
+            get => this.ChildrenOfType<FillFlowContainer>().First().Children;
+            set
             {
-                background = new Box
+                // should delay assign the children after loaded.
+                Schedule(() =>
                 {
-                    Depth = float.MaxValue,
-                    RelativeSizeAxes = Axes.Both,
-                },
-                new OsuScrollContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = content = new FillFlowContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                    }
-                }
-            };
+                    this.ChildrenOfType<FillFlowContainer>().First().Children = value;
+                });
+            }
         }
 
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider)
         {
-            background.Colour = colourProvider.Background3(state.Mode);
+            // change the background colour to the lighter one.
+            this.ChildrenOfType<Box>().First().Colour = colourProvider.Background3(state.Mode);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Language/LanguageExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Language/LanguageExtend.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -18,38 +18,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Language
 
         private readonly IBindable<LanguageEditMode> bindableMode = new Bindable<LanguageEditMode>();
 
-        public LanguageExtend()
-        {
-            bindableMode.BindValueChanged(e =>
-            {
-                switch (e.NewValue)
-                {
-                    case LanguageEditMode.Generate:
-                        Children = new Drawable[]
-                        {
-                            new LanguageEditModeSection(),
-                            new LanguageSwitchSpecialActionSection(),
-                        };
-                        break;
-
-                    case LanguageEditMode.Verify:
-                        Children = new Drawable[]
-                        {
-                            new LanguageEditModeSection(),
-                            new LanguageMissingSection(),
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
         [BackgroundDependencyLoader]
         private void load(ILanguageModeState languageModeState)
         {
             bindableMode.BindTo(languageModeState.BindableEditMode);
+            bindableMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
         }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+        {
+            LanguageEditMode.Generate => new Drawable[]
+            {
+                new LanguageEditModeSection(),
+                new LanguageSwitchSpecialActionSection(),
+            },
+            LanguageEditMode.Verify => new Drawable[]
+            {
+                new LanguageEditModeSection(),
+                new LanguageMissingSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Language/LanguageMissingSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Language/LanguageMissingSection.cs
@@ -17,14 +17,13 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Language
 {
-    public class LanguageMissingSection : Section
+    public class LanguageMissingSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Invalid lyric (missing language)";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/LyricEditorSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/LyricEditorSection.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
+{
+    /// <summary>
+    /// Base section class for lyric editor.
+    /// todo: should inherit the EditorRoundedScreenSettingsSection eventually, but seems that class haven't ready.
+    /// </summary>
+    public abstract class LyricEditorSection : Section
+    {
+        protected LyricEditorSection()
+        {
+            Padding = new MarginPadding(0);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/LyricPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/LyricPropertySection.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
@@ -17,7 +16,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends
 {
-    public abstract class LyricPropertySection : Section
+    public abstract class LyricPropertySection : LyricEditorSection
     {
         private readonly IBindable<ICaretPosition?> bindableCaretPosition = new Bindable<ICaretPosition?>();
         private readonly IBindable<int> bindablePropertyWritableVersion = new Bindable<int>();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteConfigSection.cs
@@ -6,13 +6,12 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
-    public class NoteConfigSection : Section
+    public class NoteConfigSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Config";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteEditPropertyModeSection.cs
@@ -7,12 +7,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
-    public class NoteEditPropertyModeSection : Section
+    public class NoteEditPropertyModeSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Edit property";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteExtend.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -18,48 +18,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 
         private readonly IBindable<NoteEditMode> bindableMode = new Bindable<NoteEditMode>();
 
-        public NoteExtend()
-        {
-            bindableMode.BindValueChanged(e =>
-            {
-                switch (e.NewValue)
-                {
-                    case NoteEditMode.Generate:
-                        Children = new Drawable[]
-                        {
-                            new NoteEditModeSection(),
-                            new NoteConfigSection(),
-                            new NoteSwitchSpecialActionSection(),
-                        };
-                        break;
-
-                    case NoteEditMode.Edit:
-                        Children = new Drawable[]
-                        {
-                            new NoteEditModeSection(),
-                            new NoteEditPropertyModeSection(),
-                            new NoteEditPropertySection(),
-                        };
-                        break;
-
-                    case NoteEditMode.Verify:
-                        Children = new Drawable[]
-                        {
-                            new NoteEditModeSection(),
-                            new NoteIssueSection()
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
         [BackgroundDependencyLoader]
         private void load(IEditNoteModeState editNoteModeState)
         {
             bindableMode.BindTo(editNoteModeState.BindableEditMode);
+            bindableMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
         }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+        {
+            NoteEditMode.Generate => new Drawable[]
+            {
+                new NoteEditModeSection(),
+                new NoteConfigSection(),
+                new NoteSwitchSpecialActionSection(),
+            },
+            NoteEditMode.Edit => new Drawable[]
+            {
+                new NoteEditModeSection(),
+                new NoteEditPropertyModeSection(),
+                new NoteEditPropertySection(),
+            },
+            NoteEditMode.Verify => new Drawable[]
+            {
+                new NoteEditModeSection(),
+                new NoteIssueSection()
+            },
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Notes/NoteIssueSection.cs
@@ -4,11 +4,10 @@
 #nullable disable
 
 using osu.Framework.Localisation;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Notes
 {
-    public class NoteIssueSection : Section
+    public class NoteIssueSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Invalid notes";
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceExtend.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
@@ -11,14 +12,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 
         public override float ExtendWidth => 300;
 
-        public ReferenceExtend()
+        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
-            Children = new Drawable[]
-            {
-                new ReferenceLyricAutoGenerateSection(),
-                new ReferenceLyricSection(),
-                new ReferenceLyricConfigSection()
-            };
-        }
+            new ReferenceLyricAutoGenerateSection(),
+            new ReferenceLyricSection(),
+            new ReferenceLyricConfigSection()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Reference/ReferenceLyricAutoGenerateSection.cs
@@ -3,14 +3,13 @@
 
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Configs.Generator.ReferenceLyric;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Reference
 {
-    public class ReferenceLyricAutoGenerateSection : Section
+    public class ReferenceLyricAutoGenerateSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagExtend.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
@@ -11,46 +11,34 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
     public class RomajiTagExtend : TextTagExtend
     {
-        public RomajiTagExtend()
-        {
-            EditMode.BindValueChanged(e =>
-            {
-                switch (e.NewValue)
-                {
-                    case TextTagEditMode.Generate:
-                        Children = new Drawable[]
-                        {
-                            new RomajiTagEditModeSection(),
-                            new RomajiTagAutoGenerateSection(),
-                        };
-                        break;
-
-                    case TextTagEditMode.Edit:
-                        Children = new Drawable[]
-                        {
-                            new RomajiTagEditModeSection(),
-                            new RomajiTagEditSection(),
-                        };
-                        break;
-
-                    case TextTagEditMode.Verify:
-                        Children = new Drawable[]
-                        {
-                            new RomajiTagEditModeSection(),
-                            new RomajiTagIssueSection(),
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
         [BackgroundDependencyLoader]
         private void load(IEditRomajiModeState romajiModeState)
         {
             EditMode.BindTo(romajiModeState.BindableEditMode);
+            EditMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
         }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => EditMode.Value switch
+        {
+            TextTagEditMode.Generate => new Drawable[]
+            {
+                new RomajiTagEditModeSection(),
+                new RomajiTagAutoGenerateSection(),
+            },
+            TextTagEditMode.Edit => new Drawable[]
+            {
+                new RomajiTagEditModeSection(),
+                new RomajiTagEditSection(),
+            },
+            TextTagEditMode.Verify => new Drawable[]
+            {
+                new RomajiTagEditModeSection(),
+                new RomajiTagIssueSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RomajiTagIssueSection.cs
@@ -12,13 +12,12 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class RomajiTagIssueSection : Section
+    public class RomajiTagIssueSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Invalid romaji-tag";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagExtend.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
@@ -11,46 +11,34 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
     public class RubyTagExtend : TextTagExtend
     {
-        public RubyTagExtend()
-        {
-            EditMode.BindValueChanged(e =>
-            {
-                switch (e.NewValue)
-                {
-                    case TextTagEditMode.Generate:
-                        Children = new Drawable[]
-                        {
-                            new RubyTagEditModeSection(),
-                            new RubyTagAutoGenerateSection(),
-                        };
-                        break;
-
-                    case TextTagEditMode.Edit:
-                        Children = new Drawable[]
-                        {
-                            new RubyTagEditModeSection(),
-                            new RubyTagEditSection(),
-                        };
-                        break;
-
-                    case TextTagEditMode.Verify:
-                        Children = new Drawable[]
-                        {
-                            new RubyTagEditModeSection(),
-                            new RubyTagIssueSection(),
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
         [BackgroundDependencyLoader]
         private void load(IEditRubyModeState editRubyModeState)
         {
             EditMode.BindTo(editRubyModeState.BindableEditMode);
+            EditMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
         }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => EditMode.Value switch
+        {
+            TextTagEditMode.Generate => new Drawable[]
+            {
+                new RubyTagEditModeSection(),
+                new RubyTagAutoGenerateSection(),
+            },
+            TextTagEditMode.Edit => new Drawable[]
+            {
+                new RubyTagEditModeSection(),
+                new RubyTagEditSection(),
+            },
+            TextTagEditMode.Verify => new Drawable[]
+            {
+                new RubyTagEditModeSection(),
+                new RubyTagIssueSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/RubyTagIssueSection.cs
@@ -12,13 +12,12 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public class RubyTagIssueSection : Section
+    public class RubyTagIssueSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Invalid ruby-tag";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagAutoGenerateSection.cs
@@ -5,13 +5,12 @@
 
 using J2N.Collections.Generic;
 using osu.Framework.Localisation;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.RubyRomaji
 {
-    public abstract class TextTagAutoGenerateSection : Section
+    public abstract class TextTagAutoGenerateSection : LyricEditorSection
     {
         protected sealed override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/RubyRomaji/TextTagExtend.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Singers/SingerExtend.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
+using System.Collections.Generic;
+using osu.Framework.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 {
@@ -11,12 +12,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Singers
 
         public override float ExtendWidth => 300;
 
-        public SingerExtend()
+        protected override IReadOnlyList<Drawable> CreateSections() => new[]
         {
-            Children = new[]
-            {
-                new SingerEditSection(),
-            };
-        }
+            new SingerEditSection(),
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/Texting/TextingExtend.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
@@ -11,13 +12,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Texting
 
         public override float ExtendWidth => 300;
 
-        public TextingExtend()
+        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
-            Children = new Drawable[]
-            {
-                new TextingEditModeSection(),
-                new TextingSwitchSpecialActionSection()
-            };
-        }
+            new TextingEditModeSection(),
+            new TextingSwitchSpecialActionSection()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAdjustConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAdjustConfigSection.cs
@@ -7,14 +7,13 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
-    public class TimeTagAdjustConfigSection : Section
+    public class TimeTagAdjustConfigSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Config";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagAutoGenerateSection.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Configs.Generator.TimeTags.Ja;
 using osu.Game.Rulesets.Karaoke.Edit.Configs.Generator.TimeTags.Zh;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
@@ -16,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
-    public class TimeTagAutoGenerateSection : Section
+    public class TimeTagAutoGenerateSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagCreateConfigSection.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
-    public class TimeTagCreateConfigSection : Section
+    public class TimeTagCreateConfigSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Config Tool";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagExtend.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -17,50 +17,38 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 
         private readonly IBindable<TimeTagEditMode> bindableMode = new Bindable<TimeTagEditMode>();
 
-        public TimeTagExtend()
-        {
-            bindableMode.BindValueChanged(e =>
-            {
-                switch (e.NewValue)
-                {
-                    case TimeTagEditMode.Create:
-                        Children = new Drawable[]
-                        {
-                            new TimeTagEditModeSection(),
-                            new TimeTagAutoGenerateSection(),
-                            new TimeTagCreateConfigSection(),
-                            new CreateTimeTagActionReceiver()
-                        };
-                        break;
-
-                    case TimeTagEditMode.Recording:
-                        Children = new Drawable[]
-                        {
-                            new TimeTagEditModeSection(),
-                            new TimeTagRecordingConfigSection(),
-                            new RecordTimeTagActionReceiver()
-                        };
-                        break;
-
-                    case TimeTagEditMode.Adjust:
-                        Children = new Drawable[]
-                        {
-                            new TimeTagEditModeSection(),
-                            new TimeTagAdjustConfigSection(),
-                            new TimeTagIssueSection(),
-                        };
-                        break;
-
-                    default:
-                        return;
-                }
-            }, true);
-        }
-
         [BackgroundDependencyLoader]
         private void load(ITimeTagModeState timeTagModeState)
         {
             bindableMode.BindTo(timeTagModeState.BindableEditMode);
+            bindableMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
         }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+        {
+            TimeTagEditMode.Create => new Drawable[]
+            {
+                new TimeTagEditModeSection(),
+                new TimeTagAutoGenerateSection(),
+                new TimeTagCreateConfigSection(),
+                new CreateTimeTagActionReceiver()
+            },
+            TimeTagEditMode.Recording => new Drawable[]
+            {
+                new TimeTagEditModeSection(),
+                new TimeTagRecordingConfigSection(),
+                new RecordTimeTagActionReceiver()
+            },
+            TimeTagEditMode.Adjust => new Drawable[]
+            {
+                new TimeTagEditModeSection(),
+                new TimeTagAdjustConfigSection(),
+                new TimeTagIssueSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagIssueSection.cs
@@ -18,7 +18,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checker;
 using osu.Game.Rulesets.Karaoke.Edit.Checks.Components;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.Components;
@@ -32,7 +31,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
-    public class TimeTagIssueSection : Section
+    public class TimeTagIssueSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Invalid time-tag";
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagRecordingConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Extends/TimeTags/TimeTagRecordingConfigSection.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
@@ -16,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Extends.TimeTags
 {
-    public class TimeTagRecordingConfigSection : Section
+    public class TimeTagRecordingConfigSection : LyricEditorSection
     {
         protected override LocalisableString Title => "Config";
 


### PR DESCRIPTION
Prepare of issue #1596

What's done in this PR:
- base extend class should inherit the `EditorRoundedScreenSettings`.
- all sections in the lyric editor should inherit the `LyricEditorSection`.