### PR TITLE
Implement check lyric change utils.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/ValueChangedEventUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/ValueChangedEventUtilsTest.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
+{
+    public class ValueChangedEventUtilsTest
+    {
+        [Test]
+        public void TestLyricChangedWithSameLyric()
+        {
+            var lyric1 = new Lyric
+            {
+                Text = "lyric 1"
+            };
+
+            var oldCaret = new ClickingCaretPosition(lyric1);
+            var newCaret = new ClickingCaretPosition(lyric1);
+
+            Assert.IsFalse(ValueChangedEventUtils.LyricChanged(new ValueChangedEvent<ICaretPosition?>(oldCaret, newCaret)));
+        }
+
+        [Test]
+        public void TestLyricChangedWithDifferentLyric()
+        {
+            var lyric1 = new Lyric
+            {
+                Text = "lyric 1"
+            };
+
+            var lyric2 = new Lyric
+            {
+                Text = "lyric 2"
+            };
+
+            var oldCaret = new ClickingCaretPosition(lyric1);
+            var newCaret = new ClickingCaretPosition(lyric2);
+
+            Assert.IsTrue(ValueChangedEventUtils.LyricChanged(new ValueChangedEvent<ICaretPosition?>(oldCaret, newCaret)));
+        }
+
+        [Test]
+        public void TestLyricChangedWithSameLyricButDifferentCaretPosiiton()
+        {
+            var lyric1 = new Lyric
+            {
+                Text = "lyric 1"
+            };
+
+            var oldCaret = new ClickingCaretPosition(lyric1);
+            var newCaret = new TimeTagCaretPosition(lyric1, new TimeTag(new TextIndex(1)));
+
+            Assert.IsFalse(ValueChangedEventUtils.LyricChanged(new ValueChangedEvent<ICaretPosition?>(oldCaret, newCaret)));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -19,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
 {
     public abstract class DrawableLyricList : OrderRearrangeableListContainer<Lyric>
     {
-        private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
+        private readonly IBindable<ICaretPosition?> bindableCaretPosition = new Bindable<ICaretPosition?>();
 
         protected DrawableLyricList()
         {
@@ -31,7 +29,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
                 if (newLyric == null)
                     return;
 
-                if (!ScrollToPosition(bindableCaretPosition.Value))
+                if (!ScrollToPosition(e.NewValue!))
                     return;
 
                 int skippingRows = SkipRows();
@@ -68,7 +66,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
             bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
         }
 
-        private bool moveItemToTargetPosition(Lyric newLyric, Lyric oldLyric, int skippingRows)
+        private bool moveItemToTargetPosition(Lyric newLyric, Lyric? oldLyric, int skippingRows)
         {
             var oldItem = getListItem(oldLyric);
             var newItem = getListItem(newLyric);
@@ -94,10 +92,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
             ScrollContainer.ScrollTo(scrollPosition - spacing + getOffsetPosition(newItem, oldItem));
             return true;
 
-            DrawableLyricListItem getListItem(Lyric lyric)
+            DrawableLyricListItem? getListItem(Lyric? lyric)
                 => ListContainer.Children.FirstOrDefault(x => x.Model == lyric) as DrawableLyricListItem;
 
-            float getOffsetPosition(DrawableLyricListItem newItem, DrawableLyricListItem oldItem)
+            float getOffsetPosition(DrawableLyricListItem newItem, DrawableLyricListItem? oldItem)
             {
                 if (oldItem == null)
                     return 0;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
@@ -10,6 +10,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
             {
                 var oldLyric = e.OldValue?.Lyric;
                 var newLyric = e.NewValue?.Lyric;
-                if (newLyric == null)
+                if (newLyric == null || !ValueChangedEventUtils.LyricChanged(e))
                     return;
 
                 if (!ScrollToPosition(e.NewValue!))

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/Rows/Row.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/Rows/Row.cs
@@ -14,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Graphics.UserInterface;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osuTK.Graphics;
@@ -100,14 +101,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows
                 WritableVersionChanged?.Invoke(bindableMode.Value);
             });
 
-            bindableHoverCaretPosition.BindValueChanged(_ =>
+            bindableHoverCaretPosition.BindValueChanged(e =>
             {
-                updateBackgroundColour();
+                if (ValueChangedEventUtils.LyricChanged(e))
+                    updateBackgroundColour();
             });
 
             bindableCaretPosition.BindValueChanged(e =>
             {
-                updateBackgroundColour();
+                if (ValueChangedEventUtils.LyricChanged(e))
+                    updateBackgroundColour();
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Utils
+{
+    public static class ValueChangedEventUtils
+    {
+        public static bool LyricChanged(ValueChangedEvent<ICaretPosition?> e)
+        {
+            var oldLyric = e.OldValue?.Lyric;
+            var newLyric = e.NewValue?.Lyric;
+
+            return oldLyric != newLyric;
+        }
+    }
+}


### PR DESCRIPTION
Closes issue #1618.
For the case that need to get the `ICaretPosition`, but only need to do the action if lyric changed.
E.g. change the background or scroll the position if lyric in the caret changed. But still need to get the caret type.