### PR TITLE
Remove the extend area in the lyric editor row.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Components/TimeTagEditorScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Components/TimeTagEditorScrollContainer.cs
@@ -18,7 +18,7 @@ using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Components
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Components
 {
     public abstract class TimeTagEditorScrollContainer : EditorScrollContainer
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/EditRowExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/EditRowExtend.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
 {
     public abstract class EditRowExtend : VisibilityContainer
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.UI.Scrolling;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes
 {
     [Cached]
     public class NoteEditor : Container

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditorBlueprintContainer.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes
 {
     internal class EditNoteBlueprintContainer : ExtendBlueprintContainer<Note>
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteEditorHitObjectBlueprint.cs
@@ -22,7 +22,7 @@ using osu.Game.Rulesets.Karaoke.UI.Position;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes
 {
     /// <summary>
     /// Copy from <see cref="NoteSelectionBlueprint"/>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteRowExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/Notes/NoteRowExtend.cs
@@ -7,13 +7,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes
 {
-    public class TimeTagRowExtend : EditRowExtend
+    public class NoteRowExtend : EditRowExtend
     {
-        public override float ContentHeight => 100;
+        public override float ContentHeight => 180;
 
-        public TimeTagRowExtend(Lyric lyric)
+        public NoteRowExtend(Lyric lyric)
             : base(lyric)
         {
         }
@@ -26,10 +26,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
 
         protected override Drawable CreateContent(Lyric lyric)
         {
-            return new TimeTagEditor(lyric)
+            return new NoteEditor(lyric)
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 100,
+                Height = 150,
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/CentreMarker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/CentreMarker.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.RecordingTimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags
 {
     public class CentreMarker : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagEditor.cs
@@ -13,12 +13,12 @@ using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.RecordingTimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags
 {
     [Cached]
     public class RecordingTimeTagEditor : TimeTagEditorScrollContainer

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -24,7 +24,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.RecordingTimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags
 {
     public class RecordingTimeTagPart : TimelinePart
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagRowExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagRowExtend.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.RecordingTimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags
 {
     public class RecordingTimeTagRowExtend : EditRowExtend
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/CurrentTimeMarker.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/CurrentTimeMarker.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
     public class CurrentTimeMarker : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditor.cs
@@ -11,14 +11,14 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Configuration;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
     [Cached]
     public class TimeTagEditor : TimeTagEditorScrollContainer, IPositionSnapProvider

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditorBlueprintContainer.cs
@@ -27,7 +27,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osu.Game.Screens.Edit.Compose.Components;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
     public class TimeTagEditorBlueprintContainer : ExtendBlueprintContainer<TimeTag>
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditorHitObjectBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagEditorHitObjectBlueprint.cs
@@ -23,7 +23,7 @@ using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 using osuTK;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
     public class TimeTagEditorHitObjectBlueprint : SelectionBlueprint<TimeTag>, IHasCustomTooltip<TimeTag>
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagOrderedSelectionContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagOrderedSelectionContainer.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
     /// <summary>
     /// A container for <see cref="SelectionBlueprint{T}"/> ordered by their <see cref="TimeTag"/> start times.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagRowExtend.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTags/TimeTagRowExtend.cs
@@ -7,13 +7,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Objects;
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags
 {
-    public class NoteRowExtend : EditRowExtend
+    public class TimeTagRowExtend : EditRowExtend
     {
-        public override float ContentHeight => 180;
+        public override float ContentHeight => 100;
 
-        public NoteRowExtend(Lyric lyric)
+        public TimeTagRowExtend(Lyric lyric)
             : base(lyric)
         {
         }
@@ -26,10 +26,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes
 
         protected override Drawable CreateContent(Lyric lyric)
         {
-            return new NoteEditor(lyric)
+            return new TimeTagEditor(lyric)
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 150,
+                Height = 100,
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricList.cs
@@ -84,32 +84,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
                 return false;
 
             // do not scroll if position is too large and not able to move to target position.
-            float itemHeight = newItem.Height + newItem.ExtendHeight;
             float contentHeight = ScrollContainer.ScrollContent.Height;
             float containerHeight = ScrollContainer.DrawHeight;
-            if (contentHeight - scrollPosition + itemHeight < containerHeight - spacing)
+            if (contentHeight - scrollPosition < containerHeight - spacing)
                 return false;
 
-            ScrollContainer.ScrollTo(scrollPosition - spacing + getOffsetPosition(newItem, oldItem));
+            ScrollContainer.ScrollTo(scrollPosition - spacing);
             return true;
 
             DrawableLyricListItem? getListItem(Lyric? lyric)
                 => ListContainer.Children.FirstOrDefault(x => x.Model == lyric) as DrawableLyricListItem;
-
-            float getOffsetPosition(DrawableLyricListItem newItem, DrawableLyricListItem? oldItem)
-            {
-                if (oldItem == null)
-                    return 0;
-
-                float newItemPosition = ScrollContainer.GetChildPosInContent(newItem);
-                float oldItemPosition = ScrollContainer.GetChildPosInContent(oldItem);
-                if (oldItemPosition > scrollPosition)
-                    return 0;
-
-                // if previous lyric is in front of current lyric row, due to extend in previous row has been removed.
-                // it will cause offset from previous row extend.
-                return -newItem.ExtendHeight;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawableLyricListItem.cs
@@ -29,8 +29,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
             {
                 // Only draggable in edit mode.
                 ShowDragHandle.Value = e.NewValue == LyricEditorMode.Texting;
-
-                OnModeChanged();
             }, true);
 
             DragActive.BindValueChanged(e =>
@@ -40,18 +38,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
             });
         }
 
-        protected override Drawable CreateContent() => CreateEditRow(Model);
-
-        protected LyricEditorMode EditorMode => bindableMode.Value;
-
-        protected virtual void OnModeChanged()
-        {
-        }
+        protected sealed override Drawable CreateContent() => CreateEditRow(Model);
 
         protected abstract Row CreateEditRow(Lyric lyric);
-
-        // todo: might be removed because will not have extend area after.
-        public virtual float ExtendHeight => 0;
 
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawablePreviewLyricListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawablePreviewLyricListItem.cs
@@ -7,11 +7,11 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.Notes;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.RecordingTimeTags;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Extends.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawablePreviewLyricListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/DrawablePreviewLyricListItem.cs
@@ -1,126 +1,19 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.Notes;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTimeTags;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.TimeTags;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList
 {
     public class DrawablePreviewLyricListItem : DrawableLyricListItem
     {
-        private FillFlowContainer content = null!;
-
-        private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
-        private readonly IBindable<ICaretPosition> bindableCaretPosition = new Bindable<ICaretPosition>();
-
         public DrawablePreviewLyricListItem(Lyric item)
             : base(item)
         {
-            bindableTimeTagEditMode.BindValueChanged(_ =>
-            {
-                // should remove extend when switch mode.
-                removeExtend();
-            });
-
-            bindableCaretPosition.BindValueChanged(e =>
-            {
-                onCaretPositionChanged(e.NewValue);
-            });
-        }
-
-        protected override void OnModeChanged()
-        {
-            base.OnModeChanged();
-
-            // should remove extend when switch mode.
-            removeExtend();
-        }
-
-        private void onCaretPositionChanged(ICaretPosition? caretPosition)
-        {
-            // should wait until time-tag edit mode value updated.
-            Schedule(() =>
-            {
-                // should remove the extend area if caret position does not focus to current lyric row.
-                if (caretPosition?.Lyric != Model)
-                {
-                    removeExtend();
-                    return;
-                }
-
-                // show not create again if contains same extend.
-                var existExtend = getExtend();
-                if (existExtend != null)
-                    return;
-
-                // show extra extend if hover to current lyric.
-                var editExtend = createExtend(EditorMode, bindableTimeTagEditMode.Value, Model);
-                if (editExtend == null)
-                    return;
-
-                editExtend.RelativeSizeAxes = Axes.X;
-                content.Add(editExtend);
-                editExtend.Show();
-            });
-
-            static EditRowExtend? createExtend(LyricEditorMode mode, TimeTagEditMode timeTagEditMode, Lyric lyric) =>
-                mode switch
-                {
-                    LyricEditorMode.EditNote => new NoteRowExtend(lyric),
-                    LyricEditorMode.EditTimeTag when timeTagEditMode == TimeTagEditMode.Recording => new RecordingTimeTagRowExtend(lyric),
-                    LyricEditorMode.EditTimeTag when timeTagEditMode == TimeTagEditMode.Adjust => new TimeTagRowExtend(lyric),
-                    _ => null
-                };
-        }
-
-        private void removeExtend()
-        {
-            var existExtend = getExtend();
-            if (existExtend == null)
-                return;
-
-            // todo : might remove component until Extend effect end.
-            content.Remove(existExtend, true);
-        }
-
-        private EditRowExtend? getExtend()
-        {
-            return content?.Children.OfType<EditRowExtend>().FirstOrDefault();
-        }
-
-        protected override Drawable CreateContent()
-        {
-            return content = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Children = new[]
-                {
-                    base.CreateContent()
-                }
-            };
         }
 
         protected override Row CreateEditRow(Lyric lyric)
             => new EditLyricPreviewRow(lyric);
-
-        public override float ExtendHeight => getExtend()?.ContentHeight ?? 0;
-
-        [BackgroundDependencyLoader]
-        private void load(ITimeTagModeState timeTagModeState)
-        {
-            bindableTimeTagEditMode.BindTo(timeTagModeState.BindableEditMode);
-        }
     }
 }


### PR DESCRIPTION
Closes issue #1617.

Move the extend area into composer and remove some old logic.