### PR TITLE
Should be able to get the main and sub edit mode change from lyric editor state.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
@@ -341,12 +341,38 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
         {
             private readonly Bindable<LyricEditorMode> bindableMode = new();
 
+            private readonly Bindable<ModeWithSubMode> bindableModeWitSubMode = new();
+
             public IBindable<LyricEditorMode> BindableMode => bindableMode;
+
+            public IBindable<ModeWithSubMode> BindableModeAndSubMode => bindableModeWitSubMode;
 
             public LyricEditorMode Mode => bindableMode.Value;
 
             public void SwitchMode(LyricEditorMode mode)
-                => bindableMode.Value = mode;
+            {
+                bindableMode.Value = mode;
+                bindableModeWitSubMode.Value = bindableModeWitSubMode.Value with
+                {
+                    Mode = mode,
+                    SubMode = getTheSubMode(mode)
+                };
+            }
+
+            private static Enum? getTheSubMode(LyricEditorMode mode) =>
+                mode switch
+                {
+                    LyricEditorMode.View => null,
+                    LyricEditorMode.Texting => TextingEditMode.Typing,
+                    LyricEditorMode.Reference => null,
+                    LyricEditorMode.Language => LanguageEditMode.Generate,
+                    LyricEditorMode.EditRuby => TextTagEditMode.Generate,
+                    LyricEditorMode.EditRomaji => TextTagEditMode.Generate,
+                    LyricEditorMode.EditTimeTag => TimeTagEditMode.Create,
+                    LyricEditorMode.EditNote => NoteEditMode.Generate,
+                    LyricEditorMode.Singer => null,
+                    _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+                };
 
             public void NavigateToFix(LyricEditorMode mode)
                 => throw new NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/ValueChangedEventUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/ValueChangedEventUtilsTest.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -57,6 +58,33 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Utils
             var newCaret = new TimeTagCaretPosition(lyric1, new TimeTag(new TextIndex(1)));
 
             Assert.IsFalse(ValueChangedEventUtils.LyricChanged(new ValueChangedEvent<ICaretPosition?>(oldCaret, newCaret)));
+        }
+
+        [Test]
+        public void TestEditModeChangedWithDefaultValue()
+        {
+            var oldMode = default(ModeWithSubMode);
+            var newMode = new ModeWithSubMode
+            {
+                Mode = LyricEditorMode.View
+            };
+
+            Assert.IsTrue(ValueChangedEventUtils.EditModeChanged(new ValueChangedEvent<ModeWithSubMode>(oldMode, newMode)));
+        }
+
+        [Test]
+        public void TestEditModeChanged()
+        {
+            var oldMode = new ModeWithSubMode
+            {
+                Mode = LyricEditorMode.View
+            };
+            var newMode = new ModeWithSubMode
+            {
+                Mode = LyricEditorMode.View
+            };
+
+            Assert.IsFalse(ValueChangedEventUtils.EditModeChanged(new ValueChangedEvent<ModeWithSubMode>(oldMode, newMode)));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/BlueprintLayer.cs
@@ -41,20 +41,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
             ClearInternal();
 
             // create preview and real caret
-            var mode = bindableModeAndSubMode.Value.Mode;
-            var subMode = bindableModeAndSubMode.Value.SubMode;
-            var blueprintContainer = createBlueprintContainer(mode, subMode, Lyric);
+            var modeWithSubMode = bindableModeAndSubMode.Value;
+            var blueprintContainer = createBlueprintContainer(modeWithSubMode, Lyric);
             if (blueprintContainer == null)
                 return;
 
             AddInternal(blueprintContainer);
 
-            static Drawable? createBlueprintContainer(LyricEditorMode mode, Enum? subMode, Lyric lyric) =>
-                mode switch
+            static Drawable? createBlueprintContainer(ModeWithSubMode modeWithSubMode, Lyric lyric) =>
+                modeWithSubMode.Mode switch
                 {
                     LyricEditorMode.EditRuby => new RubyBlueprintContainer(lyric),
                     LyricEditorMode.EditRomaji => new RomajiBlueprintContainer(lyric),
-                    LyricEditorMode.EditTimeTag => subMode is TimeTagEditMode.Adjust ? new TimeTagBlueprintContainer(lyric) : null,
+                    LyricEditorMode.EditTimeTag => modeWithSubMode.SubMode is TimeTagEditMode.Adjust ? new TimeTagBlueprintContainer(lyric) : null,
                     _ => null
                 };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/BlueprintLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/BlueprintLayer.cs
@@ -12,8 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
 {
     public class BlueprintLayer : BaseLayer
     {
-        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
-        private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
+        private readonly IBindable<ModeWithSubMode> bindableModeAndSubMode = new Bindable<ModeWithSubMode>();
 
         // should block all blueprint action if not editable.
         public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && editable;
@@ -23,13 +22,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
         public BlueprintLayer(Lyric lyric)
             : base(lyric)
         {
-            bindableMode.BindValueChanged(_ =>
-            {
-                // Initial blueprint container.
-                InitializeBlueprint();
-            });
-
-            bindableTimeTagEditMode.BindValueChanged(_ =>
+            bindableModeAndSubMode.BindValueChanged(_ =>
             {
                 // Initial blueprint container.
                 InitializeBlueprint();
@@ -39,8 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state, ITimeTagModeState timeTagModeState)
         {
-            bindableMode.BindTo(state.BindableMode);
-            bindableTimeTagEditMode.BindTo(timeTagModeState.BindableEditMode);
+            bindableModeAndSubMode.BindTo(state.BindableModeAndSubMode);
         }
 
         protected void InitializeBlueprint()
@@ -49,20 +41,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
             ClearInternal();
 
             // create preview and real caret
-            var mode = bindableMode.Value;
-            var timeTagEditMode = bindableTimeTagEditMode.Value;
-            var blueprintContainer = createBlueprintContainer(mode, timeTagEditMode, Lyric);
+            var mode = bindableModeAndSubMode.Value.Mode;
+            var subMode = bindableModeAndSubMode.Value.SubMode;
+            var blueprintContainer = createBlueprintContainer(mode, subMode, Lyric);
             if (blueprintContainer == null)
                 return;
 
             AddInternal(blueprintContainer);
 
-            static Drawable? createBlueprintContainer(LyricEditorMode mode, TimeTagEditMode timeTagEditMode, Lyric lyric) =>
+            static Drawable? createBlueprintContainer(LyricEditorMode mode, Enum? subMode, Lyric lyric) =>
                 mode switch
                 {
                     LyricEditorMode.EditRuby => new RubyBlueprintContainer(lyric),
                     LyricEditorMode.EditRomaji => new RomajiBlueprintContainer(lyric),
-                    LyricEditorMode.EditTimeTag => timeTagEditMode == TimeTagEditMode.Adjust ? new TimeTagBlueprintContainer(lyric) : null,
+                    LyricEditorMode.EditTimeTag => subMode is TimeTagEditMode.Adjust ? new TimeTagBlueprintContainer(lyric) : null,
                     _ => null
                 };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
@@ -277,15 +277,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
 
         private void toggleChangeBottomEditor()
         {
-            var mode = bindableModeAndSubMode.Value.Mode;
-            var subMode = bindableModeAndSubMode.Value.SubMode;
-            bindableBottomEditorType.Value = getBottomEditorType(mode, subMode);
+            var modeWithSubMode = bindableModeAndSubMode.Value;
+            bindableBottomEditorType.Value = getBottomEditorType(modeWithSubMode);
 
-            static BottomEditorType? getBottomEditorType(LyricEditorMode mode, Enum? subMode) =>
-                mode switch
+            static BottomEditorType? getBottomEditorType(ModeWithSubMode modeWithSubMode) =>
+                modeWithSubMode.Mode switch
                 {
-                    LyricEditorMode.EditTimeTag when subMode is TimeTagEditMode.Recording => BottomEditorType.RecordingTimeTag,
-                    LyricEditorMode.EditTimeTag when subMode is TimeTagEditMode.Adjust => BottomEditorType.AdjustTimeTags,
+                    LyricEditorMode.EditTimeTag when modeWithSubMode.SubMode is TimeTagEditMode.Recording => BottomEditorType.RecordingTimeTag,
+                    LyricEditorMode.EditTimeTag when modeWithSubMode.SubMode is TimeTagEditMode.Adjust => BottomEditorType.AdjustTimeTags,
                     LyricEditorMode.EditNote => BottomEditorType.Note,
                     _ => null
                 };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
@@ -15,6 +15,7 @@ using osu.Framework.Layout;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
@@ -24,8 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         private readonly Bindable<PanelLayout> bindablePanelLayout = new();
         private readonly Bindable<BottomEditorType?> bindableBottomEditorType = new();
 
-        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
-        private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
+        private readonly IBindable<ModeWithSubMode> bindableModeAndSubMode = new Bindable<ModeWithSubMode>();
 
         private readonly IDictionary<PanelType, Bindable<bool>> panelStatus = new Dictionary<PanelType, Bindable<bool>>();
         private readonly IDictionary<PanelType, Panel> panelInstance = new Dictionary<PanelType, Panel>();
@@ -102,21 +102,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                 },
             };
 
-            bindableMode.BindValueChanged(x =>
+            bindableModeAndSubMode.BindValueChanged(e =>
             {
                 toggleChangeBottomEditor();
 
                 Schedule(() =>
                 {
-                    centerEditorBackground.Colour = colourProvider.Background1(x.NewValue);
-                    bottomEditorBackground.Colour = colourProvider.Background5(x.NewValue);
+                    if (!ValueChangedEventUtils.EditModeChanged(e) && IsLoaded)
+                        return;
+
+                    centerEditorBackground.Colour = colourProvider.Background1(e.NewValue.Mode);
+                    bottomEditorBackground.Colour = colourProvider.Background5(e.NewValue.Mode);
                 });
             }, true);
-
-            bindableTimeTagEditMode.BindValueChanged(_ =>
-            {
-                toggleChangeBottomEditor();
-            });
 
             initializePanel();
 
@@ -152,9 +150,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.ShowPropertyPanelInComposer, panelStatus[PanelType.Property]);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.ShowInvalidInfoInComposer, panelStatus[PanelType.InvalidInfo]);
 
-            bindableMode.BindTo(state.BindableMode);
-
-            bindableTimeTagEditMode.BindTo(timeTagModeState.BindableEditMode);
+            bindableModeAndSubMode.BindTo(state.BindableModeAndSubMode);
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
@@ -281,13 +277,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
 
         private void toggleChangeBottomEditor()
         {
-            bindableBottomEditorType.Value = getBottomEditorType(bindableMode.Value, bindableTimeTagEditMode.Value);
+            var mode = bindableModeAndSubMode.Value.Mode;
+            var subMode = bindableModeAndSubMode.Value.SubMode;
+            bindableBottomEditorType.Value = getBottomEditorType(mode, subMode);
 
-            static BottomEditorType? getBottomEditorType(LyricEditorMode mode, TimeTagEditMode timeTagEditMode) =>
+            static BottomEditorType? getBottomEditorType(LyricEditorMode mode, Enum? subMode) =>
                 mode switch
                 {
-                    LyricEditorMode.EditTimeTag when timeTagEditMode == TimeTagEditMode.Recording => BottomEditorType.RecordingTimeTag,
-                    LyricEditorMode.EditTimeTag when timeTagEditMode == TimeTagEditMode.Adjust => BottomEditorType.AdjustTimeTags,
+                    LyricEditorMode.EditTimeTag when subMode is TimeTagEditMode.Recording => BottomEditorType.RecordingTimeTag,
+                    LyricEditorMode.EditTimeTag when subMode is TimeTagEditMode.Adjust => BottomEditorType.AdjustTimeTags,
                     LyricEditorMode.EditNote => BottomEditorType.Note,
                     _ => null
                 };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorState.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
 using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
@@ -11,10 +10,28 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
     {
         IBindable<LyricEditorMode> BindableMode { get; }
 
+        IBindable<ModeWithSubMode> BindableModeAndSubMode { get; }
+
         LyricEditorMode Mode { get; }
 
         void SwitchMode(LyricEditorMode mode);
 
         void NavigateToFix(LyricEditorMode mode);
+    }
+
+    public struct ModeWithSubMode
+    {
+        public LyricEditorMode Mode;
+
+        public Enum? SubMode;
+
+        public bool Default;
+
+        public ModeWithSubMode()
+        {
+            Mode = LyricEditorMode.View;
+            SubMode = null;
+            Default = true;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -99,9 +99,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         private void refreshAlgorithmAndCaretPosition()
         {
             // refresh algorithm
-            var mode = bindableModeAndSubMode.Value.Mode;
-            var subMode = bindableModeAndSubMode.Value.SubMode;
-            bindableCaretPositionAlgorithm.Value = getAlgorithmByMode(mode, subMode);
+            bindableCaretPositionAlgorithm.Value = getAlgorithmByMode(bindableModeAndSubMode.Value);
 
             // refresh caret position
             var lyric = bindableCaretPosition.Value?.Lyric;
@@ -123,9 +121,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             }
         }
 
-        private ICaretPositionAlgorithm? getAlgorithmByMode(LyricEditorMode mode, Enum? subMode)
+        private ICaretPositionAlgorithm? getAlgorithmByMode(ModeWithSubMode modeWithSubMode)
         {
             var lyrics = bindableLyrics.ToArray();
+            var mode = modeWithSubMode.Mode;
+            var subMode = modeWithSubMode.SubMode;
+
             return mode switch
             {
                 LyricEditorMode.View => null,

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -36,11 +36,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         private readonly IBindableList<Lyric> bindableLyrics = new BindableList<Lyric>();
 
         private readonly BindableList<HitObject> selectedHitObjects = new();
-        private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
+        private readonly IBindable<ModeWithSubMode> bindableModeAndSubMode = new Bindable<ModeWithSubMode>();
 
         // it might be special for create time-tag mode.
-        private readonly IBindable<TextingEditMode> bindableTextingEditMode = new Bindable<TextingEditMode>();
-        private readonly IBindable<TimeTagEditMode> bindableTimeTagEditMode = new Bindable<TimeTagEditMode>();
         private readonly IBindable<CreateTimeTagEditMode> bindableCreateTimeTagEditMode = new Bindable<CreateTimeTagEditMode>();
         private readonly IBindable<MovingTimeTagCaretMode> bindableCreateMovingCaretMode = new Bindable<MovingTimeTagCaretMode>();
         private readonly IBindable<MovingTimeTagCaretMode> bindableRecordingMovingCaretMode = new Bindable<MovingTimeTagCaretMode>();
@@ -66,20 +64,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 refreshAlgorithmAndCaretPosition();
             });
 
-            bindableMode.BindValueChanged(e =>
+            bindableModeAndSubMode.BindValueChanged(e =>
             {
                 // Should refresh algorithm until all component loaded.
                 Schedule(refreshAlgorithmAndCaretPosition);
-            });
-
-            bindableTextingEditMode.BindValueChanged(e =>
-            {
-                refreshAlgorithmAndCaretPosition();
-            });
-
-            bindableTimeTagEditMode.BindValueChanged(e =>
-            {
-                refreshAlgorithmAndCaretPosition();
             });
 
             bindableCreateTimeTagEditMode.BindValueChanged(_ =>
@@ -111,7 +99,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         private void refreshAlgorithmAndCaretPosition()
         {
             // refresh algorithm
-            bindableCaretPositionAlgorithm.Value = getAlgorithmByMode();
+            var mode = bindableModeAndSubMode.Value.Mode;
+            var subMode = bindableModeAndSubMode.Value.SubMode;
+            bindableCaretPositionAlgorithm.Value = getAlgorithmByMode(mode, subMode);
 
             // refresh caret position
             var lyric = bindableCaretPosition.Value?.Lyric;
@@ -133,27 +123,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             }
         }
 
-        private ICaretPositionAlgorithm? getAlgorithmByMode()
+        private ICaretPositionAlgorithm? getAlgorithmByMode(LyricEditorMode mode, Enum? subMode)
         {
             var lyrics = bindableLyrics.ToArray();
-            var lyricEditorMode = bindableMode.Value;
-            return lyricEditorMode switch
+            return mode switch
             {
                 LyricEditorMode.View => null,
-                LyricEditorMode.Texting => getTextingmodeAlgorithm(),
+                LyricEditorMode.Texting => subMode is TextingEditMode textingEditMode ? getTextingmodeAlgorithm(textingEditMode) : throw new InvalidCastException(),
                 LyricEditorMode.Reference => new NavigateCaretPositionAlgorithm(lyrics),
                 LyricEditorMode.Language => new ClickingCaretPositionAlgorithm(lyrics),
                 LyricEditorMode.EditRuby => new NavigateCaretPositionAlgorithm(lyrics),
                 LyricEditorMode.EditRomaji => new NavigateCaretPositionAlgorithm(lyrics),
-                LyricEditorMode.EditTimeTag => getTimeTagModeAlgorithm(),
+                LyricEditorMode.EditTimeTag => subMode is TimeTagEditMode timeTagEditMode ? getTimeTagModeAlgorithm(timeTagEditMode) : throw new InvalidCastException(),
                 LyricEditorMode.EditNote => new NavigateCaretPositionAlgorithm(lyrics),
                 LyricEditorMode.Singer => new NavigateCaretPositionAlgorithm(lyrics),
-                _ => throw new InvalidOperationException(nameof(lyricEditorMode))
+                _ => throw new InvalidOperationException(nameof(mode))
             };
 
-            ICaretPositionAlgorithm getTextingmodeAlgorithm()
+            ICaretPositionAlgorithm getTextingmodeAlgorithm(TextingEditMode textingEditMode)
             {
-                var textingEditMode = bindableTextingEditMode.Value;
                 return textingEditMode switch
                 {
                     TextingEditMode.Typing => new TypingCaretPositionAlgorithm(lyrics),
@@ -162,9 +150,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 };
             }
 
-            ICaretPositionAlgorithm getTimeTagModeAlgorithm()
+            ICaretPositionAlgorithm getTimeTagModeAlgorithm(TimeTagEditMode timeTagEditMode)
             {
-                var timeTagEditMode = bindableTimeTagEditMode.Value;
                 return timeTagEditMode switch
                 {
                     TimeTagEditMode.Create => getCreateTimeTagEditModeAlgorithm(lyrics, bindableCreateTimeTagEditMode.Value, bindableCreateMovingCaretMode.Value),
@@ -184,17 +171,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
         }
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap beatmap, ILyricsProvider lyricsProvider, ILyricEditorState state, ITextingModeState textingModeState, ITimeTagModeState timeTagModeState,
-                          KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
+        private void load(EditorBeatmap beatmap, ILyricsProvider lyricsProvider, ILyricEditorState state, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
             selectedHitObjects.BindTo(beatmap.SelectedHitObjects);
 
             bindableLyrics.BindTo(lyricsProvider.BindableLyrics);
 
-            bindableMode.BindTo(state.BindableMode);
-
-            bindableTextingEditMode.BindTo(textingModeState.BindableEditMode);
-            bindableTimeTagEditMode.BindTo(timeTagModeState.BindableEditMode);
+            bindableModeAndSubMode.BindTo(state.BindableModeAndSubMode);
 
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagEditMode, bindableCreateTimeTagEditMode);
             lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.CreateTimeTagMovingCaretMode, bindableCreateMovingCaretMode);

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Utils
@@ -14,6 +15,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Utils
             var newLyric = e.NewValue?.Lyric;
 
             return oldLyric != newLyric;
+        }
+
+        public static bool EditModeChanged(ValueChangedEvent<ModeWithSubMode> e)
+        {
+            if (e.OldValue.Default ^ e.NewValue.Default)
+                return true;
+
+            return e.OldValue.Mode != e.NewValue.Mode;
         }
     }
 }


### PR DESCRIPTION
Prepare of issue #1610.
Need to design the better interface for able to get the main edit mode and sub edit mode change.

What's done in this PR:
- Add the bindable for able to get the main and sub edit mode change from lyric editor state.
- Add the utils to check if main edit mode changed.
- Use the new bindable to replace several bindable to get the different state.