### PR TITLE
Should disable the move up and down button if not movable

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/KeyActionButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/KeyActionButton.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 
@@ -15,10 +14,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar
 
         public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
         {
-            if (e.Action != EditAction)
-                return false;
-
-            IconContainer.FadeOut(100).Then().FadeIn();
+            if (e.Action == EditAction)
+                ToggleClickEffect();
 
             return false;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/MoveCaretPositionButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/MoveCaretPositionButton.cs
@@ -3,7 +3,10 @@
 
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar
 {
@@ -14,12 +17,30 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar
         [Resolved, AllowNull]
         private ILyricCaretState lyricCaretState { get; set; }
 
+        private readonly IBindable<ICaretPosition?> bindableCaretPosition = new Bindable<ICaretPosition?>();
+
         protected MoveCaretPositionButton()
         {
             Action = () =>
             {
                 lyricCaretState.MoveCaret(AcceptAction);
             };
+
+            bindableCaretPosition.BindValueChanged(e =>
+            {
+                if (!ValueChangedEventUtils.LyricChanged(e))
+                    return;
+
+                bool movable = lyricCaretState.GetCaretPositionByAction(AcceptAction) != null;
+                SetState(movable);
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            bindableCaretPosition.BindTo(lyricCaretState.BindableCaretPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/ToolbarButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/ToolbarButton.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osuTK;
 
@@ -26,6 +27,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar
         private TextureStore textures { get; set; }
 
         [Resolved]
+        private OsuColour colours { get; set; }
+
+        [Resolved]
         private ReadableKeyCombinationProvider keyCombinationProvider { get; set; }
 
         public void SetIcon(string texture) =>
@@ -39,6 +43,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar
             {
                 Icon = iconUsage
             });
+
+        protected void ToggleClickEffect()
+        {
+            if (Enabled.Value)
+            {
+                IconContainer.FadeOut(100).Then().FadeIn();
+            }
+            else
+            {
+                IconContainer.FadeColour(colours.Red, 100).Then().FadeColour(Colour4.White);
+            }
+        }
+
+        protected void SetState(bool enabled)
+        {
+            IconContainer.Icon.Alpha = enabled ? 1f : 0.5f;
+            Enabled.Value = enabled;
+        }
 
         protected ConstrainedIconContainer IconContainer;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         bool MoveCaret(MovingCaretAction action);
 
+        ICaretPosition? GetCaretPositionByAction(MovingCaretAction action);
+
         void MoveCaretToTargetPosition(Lyric lyric);
 
         void MoveCaretToTargetPosition(ICaretPosition position);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -185,12 +185,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public bool MoveCaret(MovingCaretAction action)
         {
-            if (algorithm == null)
+            var position = GetCaretPositionByAction(action);
+            if (position == null)
                 return false;
+
+            MoveCaretToTargetPosition(position);
+            return true;
+        }
+
+        public ICaretPosition? GetCaretPositionByAction(MovingCaretAction action)
+        {
+            if (algorithm == null)
+                return null;
 
             var currentPosition = bindableCaretPosition.Value;
 
-            var position = action switch
+            return action switch
             {
                 MovingCaretAction.Up => moveIfNotNull(currentPosition, algorithm.MoveUp),
                 MovingCaretAction.Down => moveIfNotNull(currentPosition, algorithm.MoveDown),
@@ -200,12 +210,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 MovingCaretAction.Last => algorithm.MoveToLast(),
                 _ => throw new InvalidEnumArgumentException(nameof(action))
             };
-
-            if (position == null)
-                return false;
-
-            MoveCaretToTargetPosition(position);
-            return true;
 
             static ICaretPosition? moveIfNotNull(ICaretPosition? caretPosition, Func<ICaretPosition, ICaretPosition?> action)
                 => caretPosition != null ? action.Invoke(caretPosition) : caretPosition;


### PR DESCRIPTION
Implement ticket #1639.
![image](https://user-images.githubusercontent.com/9100368/195134416-4efe09b2-9643-44ab-83bf-a761dccaa6ae.png)
Like this.

What's done in this PR:
- Add the method in the caret state to check if the move action is valid or not.
- Implement some method in the `ToolbarButton` to disable or enable the button and trigger the click effect.
- Disable the button if not clickable.