### PR TITLE
Refactor the drawable caret and drawable part layer.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -75,7 +74,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
 
             var caret = InternalChildren.OfType<DrawableCaret>().FirstOrDefault(x => x.Type == type);
             if (caret == null)
-                throw new NullReferenceException();
+                return;
 
             if (position.Lyric != Lyric)
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -23,24 +24,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
         {
             bindableCaretPosition.BindValueChanged(e =>
             {
-                if (e.OldValue?.GetType() == e.NewValue?.GetType())
-                    return;
+                if (e.OldValue?.GetType() != e.NewValue?.GetType())
+                    updateDrawableCaret(DrawableCaretType.Caret);
 
-                // initial default caret.
-                initializeCaret(DrawableCaretType.Caret);
+                applyTheCaretPosition(e.NewValue, DrawableCaretType.Caret);
             }, true);
 
             bindableHoverCaretPosition.BindValueChanged(e =>
             {
-                if (e.OldValue?.GetType() == e.NewValue?.GetType())
-                    return;
+                if (e.OldValue?.GetType() != e.NewValue?.GetType())
+                    updateDrawableCaret(DrawableCaretType.HoverCaret);
 
-                // initial default caret.
-                initializeCaret(DrawableCaretType.HoverCaret);
+                applyTheCaretPosition(e.NewValue, DrawableCaretType.HoverCaret);
             }, true);
         }
 
-        private void initializeCaret(DrawableCaretType type)
+        private void updateDrawableCaret(DrawableCaretType type)
         {
             var oldCaret = InternalChildren.OfType<DrawableCaret>().FirstOrDefault(x => x.Type == type);
             if (oldCaret != null)
@@ -67,6 +66,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
                     TimeTagCaretPosition => new DrawableTimeTagRecordCaret(type),
                     _ => null
                 };
+        }
+
+        private void applyTheCaretPosition(ICaretPosition? position, DrawableCaretType type)
+        {
+            if (position == null)
+                return;
+
+            var caret = InternalChildren.OfType<DrawableCaret>().FirstOrDefault(x => x.Type == type);
+            if (caret == null)
+                throw new NullReferenceException();
+
+            if (position.Lyric != Lyric)
+            {
+                caret.Hide();
+                return;
+            }
+
+            caret.Show();
+            caret.Apply(position);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
             }
 
             caret.Show();
-            caret.Apply(position);
+            caret.ApplyCaretPosition(position);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/CaretLayer.cs
@@ -34,13 +34,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
         {
             ClearInternal();
 
-            // create preview and real caret
-            addCaret(false);
-            addCaret(true);
+            // create caret and hover caret.
+            addCaret(DrawableCaretType.Caret);
+            addCaret(DrawableCaretType.HoverCaret);
 
-            void addCaret(bool isPreview)
+            void addCaret(DrawableCaretType type)
             {
-                var caret = createCaret(bindableCaretPosition.Value, isPreview);
+                var caret = createCaret(bindableCaretPosition.Value, type);
                 if (caret == null)
                     return;
 
@@ -49,17 +49,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
                 AddInternal(caret);
             }
 
-            static DrawableCaret? createCaret(ICaretPosition? caretPositionAlgorithm, bool isPreview) =>
+            static DrawableCaret? createCaret(ICaretPosition? caretPositionAlgorithm, DrawableCaretType type) =>
                 caretPositionAlgorithm switch
                 {
                     // cutting lyric
-                    CuttingCaretPosition => new DrawableLyricSplitterCaret(isPreview),
+                    CuttingCaretPosition => new DrawableLyricSplitterCaret(type),
                     // typing
-                    TypingCaretPosition => new DrawableLyricInputCaret(isPreview),
+                    TypingCaretPosition => new DrawableLyricInputCaret(type),
                     // creat time-tag
-                    TimeTagIndexCaretPosition => new DrawableTimeTagEditCaret(isPreview),
+                    TimeTagIndexCaretPosition => new DrawableTimeTagEditCaret(type),
                     // record time-tag
-                    TimeTagCaretPosition => new DrawableTimeTagRecordCaret(isPreview),
+                    TimeTagCaretPosition => new DrawableTimeTagRecordCaret(type),
                     _ => null
                 };
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -4,42 +4,16 @@
 #nullable disable
 
 using System;
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 {
     public abstract class DrawableCaret<TCaret> : DrawableCaret where TCaret : class, ICaretPosition
     {
-        private IBindable<ICaretPosition> caretPosition;
-
         protected DrawableCaret(DrawableCaretType type)
             : base(type)
         {
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(ILyricCaretState lyricCaretState, InteractableKaraokeSpriteText karaokeSpriteText)
-        {
-            caretPosition = Type == DrawableCaretType.HoverCaret ? lyricCaretState.BindableHoverCaretPosition.GetBoundCopy() : lyricCaretState.BindableCaretPosition.GetBoundCopy();
-            caretPosition.BindValueChanged(e =>
-            {
-                var position = e.NewValue;
-                if (position == null)
-                    return;
-
-                if (position.Lyric != karaokeSpriteText.HitObject)
-                {
-                    Hide();
-                    return;
-                }
-
-                Show();
-                Apply(position);
-            });
         }
 
         protected static float GetAlpha(DrawableCaretType type) =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -16,15 +16,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
     {
         private IBindable<ICaretPosition> caretPosition;
 
-        protected DrawableCaret(bool preview)
-            : base(preview)
+        protected DrawableCaret(DrawableCaretType type)
+            : base(type)
         {
         }
 
         [BackgroundDependencyLoader]
         private void load(ILyricCaretState lyricCaretState, InteractableKaraokeSpriteText karaokeSpriteText)
         {
-            caretPosition = Preview ? lyricCaretState.BindableHoverCaretPosition.GetBoundCopy() : lyricCaretState.BindableCaretPosition.GetBoundCopy();
+            caretPosition = Type == DrawableCaretType.HoverCaret ? lyricCaretState.BindableHoverCaretPosition.GetBoundCopy() : lyricCaretState.BindableCaretPosition.GetBoundCopy();
             caretPosition.BindValueChanged(e =>
             {
                 var position = e.NewValue;
@@ -42,10 +42,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             });
         }
 
-        protected static float GetAlpha(bool isHover)
-        {
-            return isHover ? 0.5f : 1;
-        }
+        protected static float GetAlpha(DrawableCaretType type) =>
+            type switch
+            {
+                DrawableCaretType.Caret => 1,
+                DrawableCaretType.HoverCaret => 0.5f,
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
 
         public override void Apply(ICaretPosition caret)
         {
@@ -60,11 +63,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 
     public abstract class DrawableCaret : CompositeDrawable
     {
-        protected readonly bool Preview;
+        protected readonly DrawableCaretType Type;
 
-        protected DrawableCaret(bool preview)
+        protected DrawableCaret(DrawableCaretType type)
         {
-            Preview = preview;
+            Type = type;
         }
 
         public abstract void Apply(ICaretPosition caret);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             });
         }
 
+        protected static float GetAlpha(bool isHover)
+        {
+            return isHover ? 0.5f : 1;
+        }
+
         public override void Apply(ICaretPosition caret)
         {
             if (caret is not TCaret tCaret)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 
     public abstract class DrawableCaret : CompositeDrawable
     {
-        protected readonly DrawableCaretType Type;
+        public readonly DrawableCaretType Type;
 
         protected DrawableCaret(DrawableCaretType type)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };
 
-        public override void Apply(ICaretPosition caret)
+        public override void ApplyCaretPosition(ICaretPosition caret)
         {
             if (caret is not TCaret tCaret)
                 throw new InvalidCastException();
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             Type = type;
         }
 
-        public abstract void Apply(ICaretPosition caret);
+        public abstract void ApplyCaretPosition(ICaretPosition caret);
 
         public abstract void TriggerDisallowEditEffect(LyricEditorMode editorMode);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -38,12 +38,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                 }
 
                 Show();
-
-                if (position is not TCaret tCaret)
-                    throw new InvalidCastException();
-
-                Apply(tCaret);
+                Apply(position);
             });
+        }
+
+        public override void Apply(ICaretPosition caret)
+        {
+            if (caret is not TCaret tCaret)
+                throw new InvalidCastException();
+
+            Apply(tCaret);
         }
 
         protected abstract void Apply(TCaret caret);
@@ -57,6 +61,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
         {
             Preview = preview;
         }
+
+        public abstract void Apply(ICaretPosition caret);
 
         public abstract void TriggerDisallowEditEffect(LyricEditorMode editorMode);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaretType.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaretType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
+{
+    public enum DrawableCaretType
+    {
+        Caret,
+
+        HoverCaret
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 
         private TypingCaretPosition caretPosition;
 
-        public DrawableLyricInputCaret(bool preview)
-            : base(preview)
+        public DrawableLyricInputCaret(DrawableCaretType type)
+            : base(type)
         {
             Width = caret_width;
         }
@@ -48,10 +48,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 RelativeSizeAxes = Axes.Both,
                 Colour = Color4.White,
-                Alpha = GetAlpha(Preview)
+                Alpha = GetAlpha(Type)
             };
 
-            if (!Preview)
+            if (Type == DrawableCaretType.Caret)
             {
                 AddInternal(inputCaretTextBox = new InputCaretTextBox
                 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 RelativeSizeAxes = Axes.Both,
                 Colour = Color4.White,
-                Alpha = Preview ? 0.5f : 1,
+                Alpha = GetAlpha(Preview)
             };
 
             if (!Preview)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricSplitterCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricSplitterCaret.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                 {
                     RelativeSizeAxes = Axes.Y,
                     AutoSizeAxes = Axes.X,
-                    Alpha = preview ? 0.5f : 1,
+                    Alpha = GetAlpha(preview),
                     Children = new Drawable[]
                     {
                         new Triangle

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricSplitterCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricSplitterCaret.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -25,8 +26,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
         [Resolved]
         private InteractableKaraokeSpriteText karaokeSpriteText { get; set; }
 
-        public DrawableLyricSplitterCaret(bool preview)
-            : base(preview)
+        public DrawableLyricSplitterCaret(DrawableCaretType type)
+            : base(type)
         {
             Width = 10;
             Origin = Anchor.TopCentre;
@@ -41,13 +42,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                     X = 7,
                     Y = -5,
                     Size = new Vector2(10),
-                    Alpha = preview ? 1 : 0
                 },
                 splitter = new Container
                 {
                     RelativeSizeAxes = Axes.Y,
                     AutoSizeAxes = Axes.X,
-                    Alpha = GetAlpha(preview),
+                    Alpha = GetAlpha(type),
                     Children = new Drawable[]
                     {
                         new Triangle
@@ -68,6 +68,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                     }
                 }
             };
+
+            switch (type)
+            {
+                case DrawableCaretType.Caret:
+                    splitIcon.Hide();
+                    break;
+
+                case DrawableCaretType.HoverCaret:
+                    splitIcon.Show();
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricTextCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricTextCaret.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
         [Resolved]
         private InteractableKaraokeSpriteText karaokeSpriteText { get; set; }
 
-        protected DrawableLyricTextCaret(bool preview)
-            : base(preview)
+        protected DrawableLyricTextCaret(DrawableCaretType type)
+            : base(type)
         {
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagEditCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagEditCaret.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 
         private readonly DrawableTextIndex drawableTextIndex;
 
-        public DrawableTimeTagEditCaret(bool preview)
-            : base(preview)
+        public DrawableTimeTagEditCaret(DrawableCaretType type)
+            : base(type)
         {
             AutoSizeAxes = Axes.Both;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 Name = "Text index",
                 Size = new Vector2(triangle_width),
-                Alpha = GetAlpha(preview),
+                Alpha = GetAlpha(type),
             };
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagEditCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagEditCaret.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 Name = "Text index",
                 Size = new Vector2(triangle_width),
-                Alpha = preview ? 0.5f : 1
+                Alpha = GetAlpha(preview),
             };
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
@@ -25,8 +26,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 
         private readonly DrawableTextIndex drawableTextIndex;
 
-        public DrawableTimeTagRecordCaret(bool preview)
-            : base(preview)
+        public DrawableTimeTagRecordCaret(DrawableCaretType type)
+            : base(type)
         {
             AutoSizeAxes = Axes.Both;
 
@@ -34,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 Name = "Text index",
                 Size = new Vector2(triangle_width),
-                Alpha = GetAlpha(preview),
+                Alpha = GetAlpha(type),
             };
         }
 
@@ -42,11 +43,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
         {
             var timeTag = caret.TimeTag;
             var textIndex = timeTag.Index;
-            this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), Preview ? 0 : 100, Easing.OutCubic);
+            this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), getMoveToDuration(Type), Easing.OutCubic);
             Origin = TextIndexUtils.GetValueByState(textIndex, Anchor.BottomLeft, Anchor.BottomRight);
 
             drawableTextIndex.State = textIndex.State;
             drawableTextIndex.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
+
+            static double getMoveToDuration(DrawableCaretType type) =>
+                type switch
+                {
+                    DrawableCaretType.Caret => 100,
+                    DrawableCaretType.HoverCaret => 0,
+                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+                };
         }
 
         public override void TriggerDisallowEditEffect(LyricEditorMode editorMode)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableTimeTagRecordCaret.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
             {
                 Name = "Text index",
                 Size = new Vector2(triangle_width),
-                Alpha = preview ? 0.5f : 1
+                Alpha = GetAlpha(preview),
             };
         }
 


### PR DESCRIPTION
What's done in this PR:
- Make the code more understandable.
- Refactor the logic in the caret layer.
- Reduce some duplicated bindable. We can just pass the caret position to the caret instead of listen the event inside the drawable caret.
- Fix the issue #1649.