### PR TITLE
Change caret position format from class to structure

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
-    public abstract class BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret> where TAlgorithm : CaretPositionAlgorithm<TCaret> where TCaret : class, ICaretPosition
+    public abstract class BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret> where TAlgorithm : CaretPositionAlgorithm<TCaret> where TCaret : struct, ICaretPosition
     {
         protected void TestPositionMovable(Lyric[] lyrics, TCaret caret, bool expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             }
             else
             {
-                AssertEqual(expected, actual);
+                AssertEqual(expected.Value, actual.Value);
             }
         }
 
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             if (actual == null)
                 return;
 
-            Assert.AreEqual(expected, actual.GenerateType);
+            Assert.AreEqual(expected, actual.Value.GenerateType);
         }
 
         protected abstract void AssertEqual(TCaret expected, TCaret actual);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlgorithm where TCaretPosition : class, ICaretPosition
+    public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlgorithm where TCaretPosition : struct, ICaretPosition
     {
         // Lyrics is not lock and can be accessible.
         protected readonly Lyric[] Lyrics;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
@@ -47,6 +47,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return null;
         }
 
-        public override ClickingCaretPosition MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
+        public override ClickingCaretPosition? MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
@@ -65,6 +65,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
+        public override NavigateCaretPosition? MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public abstract class TextCaretPositionAlgorithm<TCaretPosition> : CaretPositionAlgorithm<TCaretPosition> where TCaretPosition : class, ITextCaretPosition
+    public abstract class TextCaretPositionAlgorithm<TCaretPosition> : CaretPositionAlgorithm<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
     {
         protected TextCaretPositionAlgorithm(Lyric[] lyrics)
             : base(lyrics)
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, GetMaxIndex(lyric.Text));
         }
 
-        public override TCaretPosition MoveToTarget(Lyric lyric) => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
+        public override TCaretPosition? MoveToTarget(Lyric lyric) => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
 
         private bool lyricMovable(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, index);
         }
 
-        public override TimeTagIndexCaretPosition MoveToTarget(Lyric lyric)
+        public override TimeTagIndexCaretPosition? MoveToTarget(Lyric lyric)
         {
             var index = new TextIndex(0, suitableState(TextIndex.IndexState.Start));
             return new TimeTagIndexCaretPosition(lyric, index, CaretGenerateType.TargetLyric);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/ClickingCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/ClickingCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class ClickingCaretPosition : ICaretPosition
+    public struct ClickingCaretPosition : ICaretPosition
     {
         public ClickingCaretPosition(Lyric lyric, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/CuttingCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/CuttingCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class CuttingCaretPosition : ITextCaretPosition
+    public struct CuttingCaretPosition : ITextCaretPosition
     {
         public CuttingCaretPosition(Lyric lyric, int index, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/NavigateCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/NavigateCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class NavigateCaretPosition : ICaretPosition
+    public struct NavigateCaretPosition : ICaretPosition
     {
         public NavigateCaretPosition(Lyric lyric, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class TimeTagCaretPosition : ICaretPosition
+    public struct TimeTagCaretPosition : ICaretPosition
     {
         public TimeTagCaretPosition(Lyric lyric, TimeTag timeTag, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagIndexCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagIndexCaretPosition.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class TimeTagIndexCaretPosition : ICaretPosition
+    public struct TimeTagIndexCaretPosition : ICaretPosition
     {
         public TimeTagIndexCaretPosition(Lyric lyric, TextIndex index, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TypingCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TypingCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public class TypingCaretPosition : ITextCaretPosition
+    public struct TypingCaretPosition : ITextCaretPosition
     {
         public TypingCaretPosition(Lyric lyric, int index, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableCaret.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 {
-    public abstract class DrawableCaret<TCaret> : DrawableCaret where TCaret : class, ICaretPosition
+    public abstract class DrawableCaret<TCaret> : DrawableCaret where TCaret : struct, ICaretPosition
     {
         protected DrawableCaret(DrawableCaretType type)
             : base(type)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
         private Box drawableCaret;
         private InputCaretTextBox inputCaretTextBox;
 
-        private TypingCaretPosition caretPosition;
+        private TypingCaretPosition? caretPosition;
 
         public DrawableLyricInputCaret(DrawableCaretType type)
             : base(type)
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                         if (caretPosition == null)
                             throw new ArgumentNullException(nameof(caretPosition));
 
-                        int index = caretPosition.Index;
+                        int index = caretPosition.Value.Index;
                         lyricTextChangeHandler.InsertText(index, text);
 
                         moveCaret(text.Length);
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                         if (caretPosition == null)
                             throw new ArgumentNullException(nameof(caretPosition));
 
-                        int index = caretPosition.Index;
+                        int index = caretPosition.Value.Index;
                         if (index == 0)
                             return;
 
@@ -104,8 +104,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                     throw new ArgumentNullException(nameof(caretPosition));
 
                 // calculate new caret position.
-                var lyric = caretPosition.Lyric;
-                int index = caretPosition.Index + offset;
+                var lyric = caretPosition.Value.Lyric;
+                int index = caretPosition.Value.Index + offset;
                 caretPosition = new TypingCaretPosition(lyric, index);
                 lyricCaretState.MoveCaretToTargetPosition(caretPosition);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricTextCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricTextCaret.cs
@@ -10,7 +10,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
 {
-    public abstract class DrawableLyricTextCaret<TCaretPosition> : DrawableCaret<TCaretPosition> where TCaretPosition : class, ITextCaretPosition
+    public abstract class DrawableLyricTextCaret<TCaretPosition> : DrawableCaret<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
     {
         [Resolved]
         private InteractableKaraokeSpriteText karaokeSpriteText { get; set; }


### PR DESCRIPTION
Why need this change:
- For better comparation to check if the same caret or not.
- Technically, caret should be the same if all property(lyric and some index) are same. There's no case that we need to separate them.

Also should notice that in #496 we use struct in the `CaretPosition`.
Not really sure way it changed to the class, maybe just forgot to use the struct at that time.

Also, all test case passed and seems no issue while testing it with hand.