### PR TITLE
Refactor caret algorithm (separate the interface and rename).

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             Assert.AreEqual(expected, actual);
         }
 
-        protected void TestMoveUp(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToPreviousLyric(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -32,12 +32,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveUp(caret);
+            var actual = algorithm.MoveToPreviousLyric(caret);
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
-        protected void TestMoveDown(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToNextLyric(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -45,12 +45,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveDown(caret);
+            var actual = algorithm.MoveToNextLyric(caret);
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
-        protected void TestMoveToFirst(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToFirstLyric(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -58,12 +58,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveToFirst();
+            var actual = algorithm.MoveToFirstLyric();
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
-        protected void TestMoveToLast(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToLastLyric(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -71,12 +71,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveToLast();
+            var actual = algorithm.MoveToLastLyric();
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
-        protected void TestMoveToTarget(Lyric[] lyrics, Lyric lyric, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToTargetLyric(Lyric[] lyrics, Lyric lyric, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveToTarget(lyric);
+            var actual = algorithm.MoveToTargetLyric(lyric);
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.TargetLyric, actual);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -33,8 +33,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveUp(caret);
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
         protected void TestMoveDown(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
@@ -46,34 +46,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveDown(caret);
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
-        }
-
-        protected void TestMoveLeft(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
-        {
-            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
-            if (algorithm == null)
-                throw new ArgumentNullException();
-
-            invokeAlgorithm?.Invoke(algorithm);
-
-            var actual = algorithm.MoveLeft(caret);
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
-        }
-
-        protected void TestMoveRight(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
-        {
-            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
-            if (algorithm == null)
-                throw new ArgumentNullException();
-
-            invokeAlgorithm?.Invoke(algorithm);
-
-            var actual = algorithm.MoveRight(caret);
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
         protected void TestMoveToFirst(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
@@ -85,8 +59,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveToFirst();
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
         protected void TestMoveToLast(Lyric[] lyrics, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
@@ -98,8 +72,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveToLast();
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.Action, actual);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
         protected void TestMoveToTarget(Lyric[] lyrics, Lyric lyric, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
@@ -111,11 +85,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveToTarget(lyric);
-            assertEqual(expected, actual);
-            checkCaretGenerateType(CaretGenerateType.TargetLyric, actual);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.TargetLyric, actual);
         }
 
-        private void assertEqual(TCaret? expected, TCaret? actual)
+        protected void AssertEqual(TCaret? expected, TCaret? actual)
         {
             if (expected == null || actual == null)
             {
@@ -128,7 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             }
         }
 
-        private void checkCaretGenerateType(CaretGenerateType expected, TCaret? actual)
+        protected void CheckCaretGenerateType(CaretGenerateType expected, TCaret? actual)
         {
             if (actual == null)
                 return;

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
+{
+    public abstract class BaseIndexCaretPositionAlgorithmTest<TAlgorithm, TCaret> : BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret>
+        where TAlgorithm : IndexCaretPositionAlgorithm<TCaret> where TCaret : struct, IIndexCaretPosition
+    {
+        protected void TestMoveLeft(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        {
+            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
+            if (algorithm == null)
+                throw new ArgumentNullException();
+
+            invokeAlgorithm?.Invoke(algorithm);
+
+            var actual = algorithm.MoveLeft(caret);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
+        }
+
+        protected void TestMoveRight(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        {
+            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
+            if (algorithm == null)
+                throw new ArgumentNullException();
+
+            invokeAlgorithm?.Invoke(algorithm);
+
+            var actual = algorithm.MoveRight(caret);
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
     public abstract class BaseIndexCaretPositionAlgorithmTest<TAlgorithm, TCaret> : BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret>
         where TAlgorithm : IndexCaretPositionAlgorithm<TCaret> where TCaret : struct, IIndexCaretPosition
     {
-        protected void TestMoveLeft(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToPreviousIndex(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -19,12 +19,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveLeft(caret);
+            var actual = algorithm.MoveToPreviousIndex(caret);
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
 
-        protected void TestMoveRight(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        protected void TestMoveToNextIndex(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
             var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
             if (algorithm == null)
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            var actual = algorithm.MoveRight(caret);
+            var actual = algorithm.MoveToNextIndex(caret);
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
@@ -52,34 +52,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveDown(lyrics, caret, expected);
         }
 
-        [TestCase(nameof(singleLyric), 0, null)] // should always not movable.
-        [TestCase(nameof(singleLyricWithNoText), 0, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, null)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, null)]
-        public void TestMoveLeft(string sourceName, int lyricIndex, int? expectedLyricIndex)
-        {
-            var lyrics = GetLyricsByMethodName(sourceName);
-            var caret = createCaretPosition(lyrics, lyricIndex);
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
-
-            // Check is movable
-            TestMoveLeft(lyrics, caret, expected);
-        }
-
-        [TestCase(nameof(singleLyric), 0, null)] // should always not movable.
-        [TestCase(nameof(singleLyricWithNoText), 0, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, null)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, null)]
-        public void TestMoveRight(string sourceName, int lyricIndex, int? expectedLyricIndex)
-        {
-            var lyrics = GetLyricsByMethodName(sourceName);
-            var caret = createCaretPosition(lyrics, lyricIndex);
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
-
-            // Check is movable
-            TestMoveRight(lyrics, caret, expected);
-        }
-
         [TestCase(nameof(singleLyric), null)] // should always not movable.
         [TestCase(nameof(singleLyricWithNoText), null)]
         [TestCase(nameof(twoLyricsWithText), null)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
@@ -28,66 +28,66 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), 0, null)]
         [TestCase(nameof(twoLyricsWithText), 1, null)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, null)]
-        public void TestMoveUp(string sourceName, int lyricIndex, int? expectedLyricIndex)
+        public void TestMoveToPreviousLyric(string sourceName, int lyricIndex, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected);
+            TestMoveToPreviousLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, null)] // should always not movable.
         [TestCase(nameof(singleLyricWithNoText), 0, null)]
         [TestCase(nameof(twoLyricsWithText), 0, null)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, null)]
-        public void TestMoveDown(string sourceName, int lyricIndex, int? expectedLyricIndex)
+        public void TestMoveToNextLyric(string sourceName, int lyricIndex, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected);
+            TestMoveToNextLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), null)] // should always not movable.
         [TestCase(nameof(singleLyricWithNoText), null)]
         [TestCase(nameof(twoLyricsWithText), null)]
         [TestCase(nameof(threeLyricsWithSpacing), null)]
-        public void TestMoveToFirst(string sourceName, int? expectedLyricIndex)
+        public void TestMoveToFirstLyric(string sourceName, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check first position
-            TestMoveToFirst(lyrics, expected);
+            TestMoveToFirstLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), null)] // should always not movable.
         [TestCase(nameof(singleLyricWithNoText), null)]
         [TestCase(nameof(twoLyricsWithText), null)]
         [TestCase(nameof(threeLyricsWithSpacing), null)]
-        public void TestMoveToLast(string sourceName, int? expectedLyricIndex)
+        public void TestMoveToLastLyric(string sourceName, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check last position
-            TestMoveToLast(lyrics, expected);
+            TestMoveToLastLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
-        public void TestMoveToTarget(string sourceName, int expectedLyricIndex)
+        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[expectedLyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected);
+            TestMoveToTargetLyric(lyrics, lyric, expected);
         }
 
         protected override void AssertEqual(ClickingCaretPosition expected, ClickingCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -36,14 +36,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 1, 1, 0, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 1, 0, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 2, 0, 2)]
-        public void TestMoveUp(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToPreviousLyric(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected);
+            TestMoveToPreviousLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 1, null, null)] // cannot move down if at bottom index.
@@ -51,14 +51,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 0, 3, 1, 2)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 1, 2, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 3, 2, 2)]
-        public void TestMoveDown(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToNextLyric(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected);
+            TestMoveToNextLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 1, null, null)]
@@ -93,38 +93,38 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), null, null)]
         [TestCase(nameof(twoLyricsWithText), 0, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 1)]
-        public void TestMoveToFirst(string sourceName, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToFirstLyric(string sourceName, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check first position
-            TestMoveToFirst(lyrics, expected);
+            TestMoveToFirstLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 3)]
         [TestCase(nameof(singleLyricWithNoText), null, null)]
         [TestCase(nameof(twoLyricsWithText), 1, 2)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 2)]
-        public void TestMoveToLast(string sourceName, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToLastLyric(string sourceName, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check last position
-            TestMoveToLast(lyrics, expected);
+            TestMoveToLastLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
-        public void TestMoveToTarget(string sourceName, int expectedLyricIndex)
+        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[expectedLyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, 1);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected);
+            TestMoveToTargetLyric(lyrics, lyric, expected);
         }
 
         protected override void AssertEqual(CuttingCaretPosition expected, CuttingCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -65,28 +65,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 1, 1, 0, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 1, 0, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 3, 2, 2)]
-        public void TestMoveLeft(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToPreviousIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveLeft(lyrics, caret, expected);
+            TestMoveToPreviousIndex(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 3, null, null)]
         [TestCase(nameof(twoLyricsWithText), 0, 3, 1, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 3, 2, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 2, 0, 3)]
-        public void TestMoveRight(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToNextIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveRight(lyrics, caret, expected);
+            TestMoveToNextIndex(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 1)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -12,7 +12,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
     [TestFixture]
-    public class CuttingCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest<CuttingCaretPositionAlgorithm, CuttingCaretPosition>
+    public class CuttingCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithmTest<CuttingCaretPositionAlgorithm, CuttingCaretPosition>
     {
         [TestCase(nameof(singleLyric), 0, 1, true)]
         [TestCase(nameof(singleLyric), 0, 3, true)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
@@ -28,66 +28,66 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), 0, null)]
         [TestCase(nameof(twoLyricsWithText), 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 1)]
-        public void TestMoveUp(string sourceName, int lyricIndex, int? expectedLyricIndex)
+        public void TestMoveToPreviousLyric(string sourceName, int lyricIndex, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected);
+            TestMoveToPreviousLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, null)] // cannot move down if at bottom index.
         [TestCase(nameof(singleLyricWithNoText), 0, null)]
         [TestCase(nameof(twoLyricsWithText), 0, 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 1)]
-        public void TestMoveDown(string sourceName, int lyricIndex, int? expectedLyricIndex)
+        public void TestMoveToNextLyric(string sourceName, int lyricIndex, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected);
+            TestMoveToNextLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
         [TestCase(nameof(twoLyricsWithText), 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0)]
-        public void TestMoveToFirst(string sourceName, int? expectedLyricIndex)
+        public void TestMoveToFirstLyric(string sourceName, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check first position
-            TestMoveToFirst(lyrics, expected);
+            TestMoveToFirstLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
         [TestCase(nameof(twoLyricsWithText), 1)]
         [TestCase(nameof(threeLyricsWithSpacing), 2)]
-        public void TestMoveToLast(string sourceName, int? expectedLyricIndex)
+        public void TestMoveToLastLyric(string sourceName, int? expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check last position
-            TestMoveToLast(lyrics, expected);
+            TestMoveToLastLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
-        public void TestMoveToTarget(string sourceName, int expectedLyricIndex)
+        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[expectedLyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected);
+            TestMoveToTargetLyric(lyrics, lyric, expected);
         }
 
         protected override void AssertEqual(NavigateCaretPosition expected, NavigateCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
@@ -52,34 +52,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveDown(lyrics, caret, expected);
         }
 
-        [TestCase(nameof(singleLyric), 0, null)]
-        [TestCase(nameof(singleLyricWithNoText), 0, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, null)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, null)]
-        public void TestMoveLeft(string sourceName, int lyricIndex, int? expectedLyricIndex)
-        {
-            var lyrics = GetLyricsByMethodName(sourceName);
-            var caret = createCaretPosition(lyrics, lyricIndex);
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
-
-            // Check is movable
-            TestMoveLeft(lyrics, caret, expected);
-        }
-
-        [TestCase(nameof(singleLyric), 0, null)]
-        [TestCase(nameof(singleLyricWithNoText), 0, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, null)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, null)]
-        public void TestMoveRight(string sourceName, int lyricIndex, int? expectedLyricIndex)
-        {
-            var lyrics = GetLyricsByMethodName(sourceName);
-            var caret = createCaretPosition(lyrics, lyricIndex);
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex);
-
-            // Check is movable
-            TestMoveRight(lyrics, caret, expected);
-        }
-
         [TestCase(nameof(singleLyric), 0)]
         [TestCase(nameof(singleLyricWithNoText), 0)]
         [TestCase(nameof(twoLyricsWithText), 0)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -45,14 +45,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, 3, 0, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, 3, 0, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, 3, 0, 4)]
-        public void TestMoveUp(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToPreviousLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToPreviousLyric(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, null, null)]
@@ -64,14 +64,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, 2, 2, 2)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, 2, 2, 2)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, 2, 2, 3)]
-        public void TestMoveDown(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToNextLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToNextLyric(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, null, null)]
@@ -120,13 +120,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, 4)]
-        public void TestMoveToFirst(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToFirstLyric(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveToFirst(lyrics, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToFirstLyric(lyrics, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4)]
@@ -141,13 +141,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, 2)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, 3)]
-        public void TestMoveToLast(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToLastLyric(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveToLast(lyrics, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToLastLyric(lyrics, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0)]
@@ -157,14 +157,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithoutTimeTag), MovingTimeTagCaretMode.OnlyStartTag, 0, null, null)]
         [TestCase(nameof(singleLyricWithoutTimeTag), MovingTimeTagCaretMode.OnlyEndTag, 0, null, null)]
         [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, null, null)] // should not hover to the lyric if contains no text and no time-tag in the lyric
-        public void TestMoveToTarget(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[lyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToTargetLyric(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
         }
 
         protected override void AssertEqual(TimeTagCaretPosition expected, TimeTagCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -81,14 +81,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, 0, 0, 4)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, 0, 0, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, 0, 0, 4)]
-        public void TestMoveLeft(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToPreviousIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveLeft(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToPreviousIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4, null, null)]
@@ -98,14 +98,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, 4, 2, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, 4, 2, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, 4, 2, 3)]
-        public void TestMoveRight(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        public void TestMoveToNextIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
             // Check is movable
-            TestMoveRight(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToNextIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
     [TestFixture]
-    public class TimeTagCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest<TimeTagCaretPositionAlgorithm, TimeTagCaretPosition>
+    public class TimeTagCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithmTest<TimeTagCaretPositionAlgorithm, TimeTagCaretPosition>
     {
         private const int not_exist_tag = -1;
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -44,14 +44,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, "[2,end]", 0, "[2,end]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, "[2,end]", 0, "[2,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, "[2,end]", 0, "[2,end]")]
-        public void TestMoveUp(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToPreviousLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, textTag);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToPreviousLyric(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]", null, null)] // cannot move down if at bottom index.
@@ -65,14 +65,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, "[3,start]", 2, "[2,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, "[3,start]", 2, "[2,end]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, "[3,end]", 2, "[2,end]")]
-        public void TestMoveDown(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToNextLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, textTag);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToNextLyric(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]", null, null)]
@@ -127,13 +127,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, null, null)]
         [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 0, "[0,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, "[0,start]")]
-        public void TestMoveToFirst(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToFirstLyric(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check first position
-            TestMoveToFirst(lyrics, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToFirstLyric(lyrics, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[3,end]")]
@@ -142,27 +142,27 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, null, null)]
         [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 1, "[2,end]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, "[2,end]")]
-        public void TestMoveToLast(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToLastLyric(string sourceName, MovingTimeTagCaretMode mode, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check last position
-            TestMoveToLast(lyrics, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToLastLyric(lyrics, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, "[0,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, "[0,end]")]
         [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, "[0,start]")]
-        public void TestMoveToTarget(string sourceName, MovingTimeTagCaretMode mode, int expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[expectedLyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToTargetLyric(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
         }
 
         protected override void AssertEqual(TimeTagIndexCaretPosition expected, TimeTagIndexCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
     [TestFixture]
-    public class TimeTagIndexCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest<TimeTagIndexCaretPositionAlgorithm, TimeTagIndexCaretPosition>
+    public class TimeTagIndexCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithmTest<TimeTagIndexCaretPositionAlgorithm, TimeTagIndexCaretPosition>
     {
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]", true)]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, "[0,start]", true)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -88,14 +88,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, "[0,start]", 0, "[3,end]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, "[0,start]", 0, "[3,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, "[0,start]", 0, "[3,end]")]
-        public void TestMoveLeft(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToPreviousIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, textTag);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check is movable
-            TestMoveLeft(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToPreviousIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[3,end]", null, null)]
@@ -111,14 +111,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, "[3,end]", 2, "[0,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, "[3,end]", 2, "[0,start]")]
         [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, "[3,end]", 2, "[0,end]")]
-        public void TestMoveRight(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToNextIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, textTag);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
 
             // Check is movable
-            TestMoveRight(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
+            TestMoveToNextIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]")]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -34,14 +34,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 1, 0, 0, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 0, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 3, 1, 0)]
-        public void TestMoveUp(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToPreviousLyric(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveUp(lyrics, caret, expected);
+            TestMoveToPreviousLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 0, null, null)] // cannot move down if at bottom index.
@@ -49,14 +49,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 0, 0, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 0, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 4, 1, 0)]
-        public void TestMoveDown(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToNextLyric(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveDown(lyrics, caret, expected);
+            TestMoveToNextLyric(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 0, null, null)]
@@ -93,38 +93,38 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyricWithNoText), 0, 0)]
         [TestCase(nameof(twoLyricsWithText), 0, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 0)]
-        public void TestMoveToFirst(string sourceName, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToFirstLyric(string sourceName, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check first position
-            TestMoveToFirst(lyrics, expected);
+            TestMoveToFirstLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 4)]
         [TestCase(nameof(singleLyricWithNoText), 0, 0)]
         [TestCase(nameof(twoLyricsWithText), 1, 3)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 3)]
-        public void TestMoveToLast(string sourceName, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToLastLyric(string sourceName, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check last position
-            TestMoveToLast(lyrics, expected);
+            TestMoveToLastLyric(lyrics, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 0)]
         [TestCase(nameof(singleLyricWithNoText), 0, 0)]
-        public void TestMoveToTarget(string sourceName, int expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var lyric = lyrics[expectedLyricIndex];
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check move to target position.
-            TestMoveToTarget(lyrics, lyric, expected);
+            TestMoveToTargetLyric(lyrics, lyric, expected);
         }
 
         protected override void AssertEqual(TypingCaretPosition expected, TypingCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -64,14 +64,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 1, 0, 0, 4)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 0, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 2, 3, 2, 2)]
-        public void TestMoveLeft(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToPreviousIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveLeft(lyrics, caret, expected);
+            TestMoveToPreviousIndex(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 4, null, null)]
@@ -79,14 +79,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(twoLyricsWithText), 0, 4, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 4, 1, 0)]
         [TestCase(nameof(threeLyricsWithSpacing), 0, 3, 0, 4)]
-        public void TestMoveRight(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToNextIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
             var caret = createCaretPosition(lyrics, lyricIndex, index);
             var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
 
             // Check is movable
-            TestMoveRight(lyrics, caret, expected);
+            TestMoveToNextIndex(lyrics, caret, expected);
         }
 
         [TestCase(nameof(singleLyric), 0, 0)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -12,7 +12,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
     [TestFixture]
-    public class TypingCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest<TypingCaretPositionAlgorithm, TypingCaretPosition>
+    public class TypingCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithmTest<TypingCaretPositionAlgorithm, TypingCaretPosition>
     {
         [TestCase(nameof(singleLyric), 0, 0, true)]
         [TestCase(nameof(singleLyric), 0, 4, true)]

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -22,10 +22,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public abstract TCaretPosition? MoveDown(TCaretPosition currentPosition);
 
-        public abstract TCaretPosition? MoveLeft(TCaretPosition currentPosition);
-
-        public abstract TCaretPosition? MoveRight(TCaretPosition currentPosition);
-
         public abstract TCaretPosition? MoveToFirst();
 
         public abstract TCaretPosition? MoveToLast();
@@ -54,22 +50,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 throw new InvalidCastException(nameof(currentPosition));
 
             return MoveDown(tCaretPosition);
-        }
-
-        public ICaretPosition? MoveLeft(ICaretPosition currentPosition)
-        {
-            if (currentPosition is not TCaretPosition tCaretPosition)
-                throw new InvalidCastException(nameof(currentPosition));
-
-            return MoveLeft(tCaretPosition);
-        }
-
-        public ICaretPosition? MoveRight(ICaretPosition currentPosition)
-        {
-            if (currentPosition is not TCaretPosition tCaretPosition)
-                throw new InvalidCastException(nameof(currentPosition));
-
-            return MoveRight(tCaretPosition);
         }
 
         ICaretPosition? ICaretPositionAlgorithm.MoveToFirst()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -18,15 +18,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public abstract bool PositionMovable(TCaretPosition position);
 
-        public abstract TCaretPosition? MoveUp(TCaretPosition currentPosition);
+        public abstract TCaretPosition? MoveToPreviousLyric(TCaretPosition currentPosition);
 
-        public abstract TCaretPosition? MoveDown(TCaretPosition currentPosition);
+        public abstract TCaretPosition? MoveToNextLyric(TCaretPosition currentPosition);
 
-        public abstract TCaretPosition? MoveToFirst();
+        public abstract TCaretPosition? MoveToFirstLyric();
 
-        public abstract TCaretPosition? MoveToLast();
+        public abstract TCaretPosition? MoveToLastLyric();
 
-        public abstract TCaretPosition? MoveToTarget(Lyric lyric);
+        public abstract TCaretPosition? MoveToTargetLyric(Lyric lyric);
 
         public bool PositionMovable(ICaretPosition position)
         {
@@ -36,29 +36,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return PositionMovable(tCaretPosition);
         }
 
-        public ICaretPosition? MoveUp(ICaretPosition currentPosition)
+        public ICaretPosition? MoveToPreviousLyric(ICaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)
                 throw new InvalidCastException(nameof(currentPosition));
 
-            return MoveUp(tCaretPosition);
+            return MoveToPreviousLyric(tCaretPosition);
         }
 
-        public ICaretPosition? MoveDown(ICaretPosition currentPosition)
+        public ICaretPosition? MoveToNextLyric(ICaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)
                 throw new InvalidCastException(nameof(currentPosition));
 
-            return MoveDown(tCaretPosition);
+            return MoveToNextLyric(tCaretPosition);
         }
 
-        ICaretPosition? ICaretPositionAlgorithm.MoveToFirst()
-            => MoveToFirst();
+        ICaretPosition? ICaretPositionAlgorithm.MoveToFirstLyric()
+            => MoveToFirstLyric();
 
-        ICaretPosition? ICaretPositionAlgorithm.MoveToLast()
-            => MoveToLast();
+        ICaretPosition? ICaretPositionAlgorithm.MoveToLastLyric()
+            => MoveToLastLyric();
 
-        ICaretPosition? ICaretPositionAlgorithm.MoveToTarget(Lyric lyric)
-            => MoveToTarget(lyric);
+        ICaretPosition? ICaretPositionAlgorithm.MoveToTargetLyric(Lyric lyric)
+            => MoveToTargetLyric(lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
@@ -17,26 +17,26 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return true;
         }
 
-        public override ClickingCaretPosition? MoveUp(ClickingCaretPosition currentPosition)
+        public override ClickingCaretPosition? MoveToPreviousLyric(ClickingCaretPosition currentPosition)
         {
             return null;
         }
 
-        public override ClickingCaretPosition? MoveDown(ClickingCaretPosition currentPosition)
+        public override ClickingCaretPosition? MoveToNextLyric(ClickingCaretPosition currentPosition)
         {
             return null;
         }
 
-        public override ClickingCaretPosition? MoveToFirst()
+        public override ClickingCaretPosition? MoveToFirstLyric()
         {
             return null;
         }
 
-        public override ClickingCaretPosition? MoveToLast()
+        public override ClickingCaretPosition? MoveToLastLyric()
         {
             return null;
         }
 
-        public override ClickingCaretPosition? MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
+        public override ClickingCaretPosition? MoveToTargetLyric(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
@@ -27,16 +27,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return null;
         }
 
-        public override ClickingCaretPosition? MoveLeft(ClickingCaretPosition currentPosition)
-        {
-            return null;
-        }
-
-        public override ClickingCaretPosition? MoveRight(ClickingCaretPosition currentPosition)
-        {
-            return null;
-        }
-
         public override ClickingCaretPosition? MoveToFirst()
         {
             return null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
@@ -13,10 +13,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         public ICaretPosition? MoveDown(ICaretPosition currentPosition);
 
-        public ICaretPosition? MoveLeft(ICaretPosition currentPosition);
-
-        public ICaretPosition? MoveRight(ICaretPosition currentPosition);
-
         public ICaretPosition? MoveToFirst();
 
         public ICaretPosition? MoveToLast();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
@@ -9,14 +9,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
     {
         public bool PositionMovable(ICaretPosition position);
 
-        public ICaretPosition? MoveUp(ICaretPosition currentPosition);
+        public ICaretPosition? MoveToPreviousLyric(ICaretPosition currentPosition);
 
-        public ICaretPosition? MoveDown(ICaretPosition currentPosition);
+        public ICaretPosition? MoveToNextLyric(ICaretPosition currentPosition);
 
-        public ICaretPosition? MoveToFirst();
+        public ICaretPosition? MoveToFirstLyric();
 
-        public ICaretPosition? MoveToLast();
+        public ICaretPosition? MoveToLastLyric();
 
-        public ICaretPosition? MoveToTarget(Lyric lyric);
+        public ICaretPosition? MoveToTargetLyric(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -5,8 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
     public interface IIndexCaretPositionAlgorithm : ICaretPositionAlgorithm
     {
-        public ICaretPosition? MoveLeft(ICaretPosition currentPosition);
+        public ICaretPosition? MoveToPreviousIndex(ICaretPosition currentPosition);
 
-        public ICaretPosition? MoveRight(ICaretPosition currentPosition);
+        public ICaretPosition? MoveToNextIndex(ICaretPosition currentPosition);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
+{
+    public interface IIndexCaretPositionAlgorithm : ICaretPositionAlgorithm
+    {
+
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -5,6 +5,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
     public interface IIndexCaretPositionAlgorithm : ICaretPositionAlgorithm
     {
+        public ICaretPosition? MoveLeft(ICaretPosition currentPosition);
 
+        public ICaretPosition? MoveRight(ICaretPosition currentPosition);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -14,24 +14,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         {
         }
 
-        public abstract TCaretPosition? MoveLeft(TCaretPosition currentPosition);
+        public abstract TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition);
 
-        public abstract TCaretPosition? MoveRight(TCaretPosition currentPosition);
+        public abstract TCaretPosition? MoveToNextIndex(TCaretPosition currentPosition);
 
-        public ICaretPosition? MoveLeft(ICaretPosition currentPosition)
+        public ICaretPosition? MoveToPreviousIndex(ICaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)
                 throw new InvalidCastException(nameof(currentPosition));
 
-            return MoveLeft(tCaretPosition);
+            return MoveToPreviousIndex(tCaretPosition);
         }
 
-        public ICaretPosition? MoveRight(ICaretPosition currentPosition)
+        public ICaretPosition? MoveToNextIndex(ICaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)
                 throw new InvalidCastException(nameof(currentPosition));
 
-            return MoveRight(tCaretPosition);
+            return MoveToNextIndex(tCaretPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
+{
+    public abstract class IndexCaretPositionAlgorithm<TCaretPosition> : CaretPositionAlgorithm<TCaretPosition>, IIndexCaretPositionAlgorithm
+        where TCaretPosition : struct, IIndexCaretPosition
+    {
+        protected IndexCaretPositionAlgorithm(Lyric[] lyrics)
+            : base(lyrics)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
@@ -11,6 +12,26 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         protected IndexCaretPositionAlgorithm(Lyric[] lyrics)
             : base(lyrics)
         {
+        }
+
+        public abstract TCaretPosition? MoveLeft(TCaretPosition currentPosition);
+
+        public abstract TCaretPosition? MoveRight(TCaretPosition currentPosition);
+
+        public ICaretPosition? MoveLeft(ICaretPosition currentPosition)
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveLeft(tCaretPosition);
+        }
+
+        public ICaretPosition? MoveRight(ICaretPosition currentPosition)
+        {
+            if (currentPosition is not TCaretPosition tCaretPosition)
+                throw new InvalidCastException(nameof(currentPosition));
+
+            return MoveRight(tCaretPosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return true;
         }
 
-        public override NavigateCaretPosition? MoveUp(NavigateCaretPosition currentPosition)
+        public override NavigateCaretPosition? MoveToPreviousLyric(NavigateCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetPrevious(currentPosition.Lyric);
             if (lyric == null)
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition? MoveDown(NavigateCaretPosition currentPosition)
+        public override NavigateCaretPosition? MoveToNextLyric(NavigateCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetNext(currentPosition.Lyric);
             if (lyric == null)
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition? MoveToFirst()
+        public override NavigateCaretPosition? MoveToFirstLyric()
         {
             var lyric = Lyrics.FirstOrDefault();
             if (lyric == null)
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition? MoveToLast()
+        public override NavigateCaretPosition? MoveToLastLyric()
         {
             var lyric = Lyrics.LastOrDefault();
             if (lyric == null)
@@ -55,6 +55,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition? MoveToTarget(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
+        public override NavigateCaretPosition? MoveToTargetLyric(Lyric lyric) => new(lyric, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
@@ -37,16 +37,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new NavigateCaretPosition(lyric);
         }
 
-        public override NavigateCaretPosition? MoveLeft(NavigateCaretPosition currentPosition)
-        {
-            return null;
-        }
-
-        public override NavigateCaretPosition? MoveRight(NavigateCaretPosition currentPosition)
-        {
-            return null;
-        }
-
         public override NavigateCaretPosition? MoveToFirst()
         {
             var lyric = Lyrics.FirstOrDefault();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, index);
         }
 
-        public override TCaretPosition? MoveLeft(TCaretPosition currentPosition)
+        public override TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition)
         {
             // get previous caret and make a check is need to change line.
             var lyric = currentPosition.Lyric;
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(currentPosition.Lyric, previousIndex);
         }
 
-        public override TCaretPosition? MoveRight(TCaretPosition currentPosition)
+        public override TCaretPosition? MoveToNextIndex(TCaretPosition currentPosition)
         {
             // get next caret and make a check is need to change line.
             var lyric = currentPosition.Lyric;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return indexInTextRange(position.Index, position.Lyric);
         }
 
-        public override TCaretPosition? MoveUp(TCaretPosition currentPosition)
+        public override TCaretPosition? MoveToPreviousLyric(TCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetPreviousMatch(currentPosition.Lyric, lyricMovable);
             if (lyric == null)
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, index);
         }
 
-        public override TCaretPosition? MoveDown(TCaretPosition currentPosition)
+        public override TCaretPosition? MoveToNextLyric(TCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetNextMatch(currentPosition.Lyric, lyricMovable);
             if (lyric == null)
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             int previousIndex = currentPosition.Index - 1;
 
             if (!indexInTextRange(previousIndex, lyric))
-                return MoveUp(CreateCaretPosition(currentPosition.Lyric, int.MaxValue));
+                return MoveToPreviousLyric(CreateCaretPosition(currentPosition.Lyric, int.MaxValue));
 
             return CreateCaretPosition(currentPosition.Lyric, previousIndex);
         }
@@ -61,12 +61,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             int nextIndex = currentPosition.Index + 1;
 
             if (!indexInTextRange(nextIndex, lyric))
-                return MoveDown(CreateCaretPosition(currentPosition.Lyric, int.MinValue));
+                return MoveToNextLyric(CreateCaretPosition(currentPosition.Lyric, int.MinValue));
 
             return CreateCaretPosition(currentPosition.Lyric, nextIndex);
         }
 
-        public override TCaretPosition? MoveToFirst()
+        public override TCaretPosition? MoveToFirstLyric()
         {
             var lyric = Lyrics.FirstOrDefault(lyricMovable);
             if (lyric == null)
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, GetMinIndex(lyric.Text));
         }
 
-        public override TCaretPosition? MoveToLast()
+        public override TCaretPosition? MoveToLastLyric()
         {
             var lyric = Lyrics.LastOrDefault(lyricMovable);
             if (lyric == null)
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, GetMaxIndex(lyric.Text));
         }
 
-        public override TCaretPosition? MoveToTarget(Lyric lyric) => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
+        public override TCaretPosition? MoveToTargetLyric(Lyric lyric) => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
 
         private bool lyricMovable(Lyric lyric)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public abstract class TextCaretPositionAlgorithm<TCaretPosition> : CaretPositionAlgorithm<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
+    public abstract class TextCaretPositionAlgorithm<TCaretPosition> : IndexCaretPositionAlgorithm<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
     {
         protected TextCaretPositionAlgorithm(Lyric[] lyrics)
             : base(lyrics)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(downTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveLeft(TimeTagCaretPosition currentPosition)
+        public override TimeTagCaretPosition? MoveToPreviousIndex(TimeTagCaretPosition currentPosition)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
             var previousTimeTag = timeTags.GetPreviousMatch(currentPosition.TimeTag, timeTagMovable);
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(previousTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveRight(TimeTagCaretPosition currentPosition)
+        public override TimeTagCaretPosition? MoveToNextIndex(TimeTagCaretPosition currentPosition)
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
             var nextTimeTag = timeTags.GetNextMatch(currentPosition.TimeTag, timeTagMovable);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public class TimeTagCaretPositionAlgorithm : CaretPositionAlgorithm<TimeTagCaretPosition>
+    public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTagCaretPosition>
     {
         public MovingTimeTagCaretMode Mode { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                    && timeTagMovable(timeTag);
         }
 
-        public override TimeTagCaretPosition? MoveUp(TimeTagCaretPosition currentPosition)
+        public override TimeTagCaretPosition? MoveToPreviousLyric(TimeTagCaretPosition currentPosition)
         {
             var currentTimeTag = currentPosition.TimeTag;
 
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(upTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveDown(TimeTagCaretPosition currentPosition)
+        public override TimeTagCaretPosition? MoveToNextLyric(TimeTagCaretPosition currentPosition)
         {
             var currentTimeTag = currentPosition.TimeTag;
 
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(nextTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveToFirst()
+        public override TimeTagCaretPosition? MoveToFirstLyric()
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
             var firstTimeTag = timeTags.FirstOrDefault(timeTagMovable);
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(firstTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveToLast()
+        public override TimeTagCaretPosition? MoveToLastLyric()
         {
             var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
             var lastTimeTag = timeTags.LastOrDefault(timeTagMovable);
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(lastTimeTag);
         }
 
-        public override TimeTagCaretPosition? MoveToTarget(Lyric lyric)
+        public override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric)
         {
             var targetTimeTag = lyric.TimeTags.FirstOrDefault(timeTagMovable);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
-    public class TimeTagIndexCaretPositionAlgorithm : CaretPositionAlgorithm<TimeTagIndexCaretPosition>
+    public class TimeTagIndexCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTagIndexCaretPosition>
     {
         public MovingTimeTagCaretMode Mode { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, new TextIndex(index, state));
         }
 
-        public override TimeTagIndexCaretPosition? MoveLeft(TimeTagIndexCaretPosition currentPosition)
+        public override TimeTagIndexCaretPosition? MoveToPreviousIndex(TimeTagIndexCaretPosition currentPosition)
         {
             // get previous caret and make a check is need to change line.
             var lyric = currentPosition.Lyric;
             var index = TextIndexUtils.GetPreviousIndex(currentPosition.Index);
 
             if (!textIndexMovable(index))
-                return MoveLeft(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
+                return MoveToPreviousIndex(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
                 return MoveToPreviousLyric(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MaxValue, index.State)));
@@ -69,14 +69,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(currentPosition.Lyric, index);
         }
 
-        public override TimeTagIndexCaretPosition? MoveRight(TimeTagIndexCaretPosition currentPosition)
+        public override TimeTagIndexCaretPosition? MoveToNextIndex(TimeTagIndexCaretPosition currentPosition)
         {
             // get next caret and make a check is need to change line.
             var lyric = currentPosition.Lyric;
             var index = TextIndexUtils.GetNextIndex(currentPosition.Index);
 
             if (!textIndexMovable(index))
-                return MoveRight(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
+                return MoveToNextIndex(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
                 return MoveToNextLyric(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MinValue, index.State)));

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return textIndexMovable(textIndex);
         }
 
-        public override TimeTagIndexCaretPosition? MoveUp(TimeTagIndexCaretPosition currentPosition)
+        public override TimeTagIndexCaretPosition? MoveToPreviousLyric(TimeTagIndexCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetPreviousMatch(currentPosition.Lyric, l => !string.IsNullOrEmpty(l.Text));
             if (lyric == null)
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, new TextIndex(index, state));
         }
 
-        public override TimeTagIndexCaretPosition? MoveDown(TimeTagIndexCaretPosition currentPosition)
+        public override TimeTagIndexCaretPosition? MoveToNextLyric(TimeTagIndexCaretPosition currentPosition)
         {
             var lyric = Lyrics.GetNextMatch(currentPosition.Lyric, l => !string.IsNullOrEmpty(l.Text));
             if (lyric == null)
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveLeft(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
-                return MoveUp(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MaxValue, index.State)));
+                return MoveToPreviousLyric(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MaxValue, index.State)));
 
             return new TimeTagIndexCaretPosition(currentPosition.Lyric, index);
         }
@@ -79,12 +79,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveRight(new TimeTagIndexCaretPosition(currentPosition.Lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
-                return MoveDown(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MinValue, index.State)));
+                return MoveToNextLyric(new TimeTagIndexCaretPosition(currentPosition.Lyric, new TextIndex(int.MinValue, index.State)));
 
             return new TimeTagIndexCaretPosition(currentPosition.Lyric, index);
         }
 
-        public override TimeTagIndexCaretPosition? MoveToFirst()
+        public override TimeTagIndexCaretPosition? MoveToFirstLyric()
         {
             var lyric = Lyrics.FirstOrDefault(l => !string.IsNullOrEmpty(l.Text));
             if (lyric == null)
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, index);
         }
 
-        public override TimeTagIndexCaretPosition? MoveToLast()
+        public override TimeTagIndexCaretPosition? MoveToLastLyric()
         {
             var lyric = Lyrics.LastOrDefault(l => !string.IsNullOrEmpty(l.Text));
             if (lyric == null)
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, index);
         }
 
-        public override TimeTagIndexCaretPosition? MoveToTarget(Lyric lyric)
+        public override TimeTagIndexCaretPosition? MoveToTargetLyric(Lyric lyric)
         {
             var index = new TextIndex(0, suitableState(TextIndex.IndexState.Start));
             return new TimeTagIndexCaretPosition(lyric, index, CaretGenerateType.TargetLyric);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/IIndexCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/IIndexCaretPosition.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
+{
+    public interface IIndexCaretPosition : ICaretPosition
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/ITextCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/ITextCaretPosition.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 
-public interface ITextCaretPosition : ICaretPosition
+public interface ITextCaretPosition : IIndexCaretPosition
 {
     public int Index { get; }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagCaretPosition.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public struct TimeTagCaretPosition : ICaretPosition
+    public struct TimeTagCaretPosition : IIndexCaretPosition
     {
         public TimeTagCaretPosition(Lyric lyric, TimeTag timeTag, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagIndexCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/TimeTagIndexCaretPosition.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition
 {
-    public struct TimeTagIndexCaretPosition : ICaretPosition
+    public struct TimeTagIndexCaretPosition : IIndexCaretPosition
     {
         public TimeTagIndexCaretPosition(Lyric lyric, TextIndex index, CaretGenerateType generateType = CaretGenerateType.Action)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -112,9 +112,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                     return null;
 
                 if (lyric == null)
-                    return algorithm.MoveToFirst();
+                    return algorithm.MoveToFirstLyric();
 
-                return algorithm.MoveToTarget(lyric);
+                return algorithm.MoveToTargetLyric(lyric);
             }
         }
 
@@ -202,12 +202,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             return action switch
             {
-                MovingCaretAction.Up => moveIfNotNull(currentPosition, algorithm.MoveUp),
-                MovingCaretAction.Down => moveIfNotNull(currentPosition, algorithm.MoveDown),
+                MovingCaretAction.Up => moveIfNotNull(currentPosition, algorithm.MoveToPreviousLyric),
+                MovingCaretAction.Down => moveIfNotNull(currentPosition, algorithm.MoveToNextLyric),
                 MovingCaretAction.Left => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveLeft) : null,
                 MovingCaretAction.Right => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveRight) : null,
-                MovingCaretAction.First => algorithm.MoveToFirst(),
-                MovingCaretAction.Last => algorithm.MoveToLast(),
+                MovingCaretAction.First => algorithm.MoveToFirstLyric(),
+                MovingCaretAction.Last => algorithm.MoveToLastLyric(),
                 _ => throw new InvalidEnumArgumentException(nameof(action))
             };
 
@@ -220,7 +220,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (lyric == null)
                 throw new ArgumentNullException(nameof(lyric));
 
-            var caretPosition = algorithm?.MoveToTarget(lyric);
+            var caretPosition = algorithm?.MoveToTargetLyric(lyric);
             if (caretPosition == null)
                 return;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -204,8 +204,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             {
                 MovingCaretAction.Up => moveIfNotNull(currentPosition, algorithm.MoveToPreviousLyric),
                 MovingCaretAction.Down => moveIfNotNull(currentPosition, algorithm.MoveToNextLyric),
-                MovingCaretAction.Left => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveLeft) : null,
-                MovingCaretAction.Right => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveRight) : null,
+                MovingCaretAction.Left => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveToPreviousIndex) : null,
+                MovingCaretAction.Right => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveToNextIndex) : null,
                 MovingCaretAction.First => algorithm.MoveToFirstLyric(),
                 MovingCaretAction.Last => algorithm.MoveToLastLyric(),
                 _ => throw new InvalidEnumArgumentException(nameof(action))

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -204,8 +204,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             {
                 MovingCaretAction.Up => moveIfNotNull(currentPosition, algorithm.MoveUp),
                 MovingCaretAction.Down => moveIfNotNull(currentPosition, algorithm.MoveDown),
-                MovingCaretAction.Left => moveIfNotNull(currentPosition, algorithm.MoveLeft),
-                MovingCaretAction.Right => moveIfNotNull(currentPosition, algorithm.MoveRight),
+                MovingCaretAction.Left => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveLeft) : null,
+                MovingCaretAction.Right => algorithm is IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm ? moveIfNotNull(currentPosition, indexCaretPositionAlgorithm.MoveRight) : null,
                 MovingCaretAction.First => algorithm.MoveToFirst(),
                 MovingCaretAction.Last => algorithm.MoveToLast(),
                 _ => throw new InvalidEnumArgumentException(nameof(action))


### PR DESCRIPTION
In this PR, we separate the caret into two main different part:
- ICaretPositionAlgorithm: the algorithm that caret can switch to different lyric.
- IIndexCaretPositionAlgorithm: the algorithm that caret can switch to different index in the lyric also.

And rename some of the class name:
- ICaretPositionAlgorithm
  - `PositionMovable`
  - MoveUp -> `MoveToPreviousLyric`
  - MoveDown -> `MoveToNextLyric`
  - MoveToFirst -> `MoveToFirstLyric`
  - MoveToLast -> `MoveToLastLyric`
  - MoveToTarget -> `MoveToTargetLyric`
- IIndexCaretPositionAlgorithm
  - MoveLeft -> `MoveToPreviousIndex`
  - MoveRight -> `MoveToNextIndex`

As method name, we can see that:
- first interface is focus on switching between "lyrics"
- second interface(child interface) is focus on switching between "index", such as time-tag index or lyric text index in a single lyric.

Also, mark as preparation of #1651