### PR TITLE
Add method to move to first or last index in the lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 {
     public abstract class BaseIndexCaretPositionAlgorithmTest<TAlgorithm, TCaret> : BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret>
-        where TAlgorithm : IndexCaretPositionAlgorithm<TCaret> where TCaret : struct, IIndexCaretPosition
+        where TAlgorithm : IIndexCaretPositionAlgorithm where TCaret : struct, IIndexCaretPosition
     {
         protected void TestMoveToPreviousIndex(Lyric[] lyrics, TCaret caret, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
         {
@@ -33,6 +33,32 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             invokeAlgorithm?.Invoke(algorithm);
 
             var actual = algorithm.MoveToNextIndex(caret) as TCaret?;
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
+        }
+
+        protected void TestMoveToFirstIndex(Lyric[] lyrics, Lyric lyric, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        {
+            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
+            if (algorithm == null)
+                throw new ArgumentNullException();
+
+            invokeAlgorithm?.Invoke(algorithm);
+
+            var actual = algorithm.MoveToFirstIndex(lyric) as TCaret?;
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.Action, actual);
+        }
+
+        protected void TestMoveToLastIndex(Lyric[] lyrics, Lyric lyric, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        {
+            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
+            if (algorithm == null)
+                throw new ArgumentNullException();
+
+            invokeAlgorithm?.Invoke(algorithm);
+
+            var actual = algorithm.MoveToLastIndex(lyric) as TCaret?;
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -132,6 +132,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToNextIndex(lyrics, caret, expected);
         }
 
+        [TestCase(nameof(singleLyric), 0, 0, 1)]
+        public void TestMoveToFirstIndex(string sourceName, int lyricIndex, int? expectedLyricIndex, int? expectedIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
+
+            // Check is movable
+            TestMoveToFirstIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 0, 3)]
+        public void TestMoveToLastIndex(string sourceName, int lyricIndex, int? expectedLyricIndex, int? expectedIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
+
+            // Check is movable
+            TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
         #endregion
 
         protected override void AssertEqual(CuttingCaretPosition expected, CuttingCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -173,6 +173,38 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToNextIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, 0)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, 4)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyStartTag, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyEndTag, 0, null, null)]
+        public void TestMoveToFirstIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
+
+            // Check is movable
+            TestMoveToFirstIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+        }
+
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 4)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, 3)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, 4)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyStartTag, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyEndTag, 0, null, null)]
+        public void TestMoveToLastIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
+
+            // Check is movable
+            TestMoveToLastIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+        }
+
         #endregion
 
         protected override void AssertEqual(TimeTagCaretPosition expected, TimeTagCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -170,6 +170,38 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToNextIndex(lyrics, caret, expected, algorithms => algorithms.Mode = mode);
         }
 
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, "[0,start]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, "[0,start]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, "[0,end]")]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyStartTag, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyEndTag, 0, null, null)]
+        public void TestMoveToFirstIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, string? expectedTextIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
+
+            // Check is movable
+            TestMoveToFirstIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+        }
+
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, "[3,end]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, "[3,start]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, "[3,end]")]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.None, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyStartTag, 0, null, null)]
+        [TestCase(nameof(singleLyricWithNoText), MovingTimeTagCaretMode.OnlyEndTag, 0, null, null)]
+        public void TestMoveToLastIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int? expectedLyricIndex, string? expectedTextIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
+
+            // Check is movable
+            TestMoveToLastIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+        }
+
         #endregion
 
         protected override void AssertEqual(TimeTagIndexCaretPosition expected, TimeTagIndexCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -133,6 +133,30 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToNextIndex(lyrics, caret, expected);
         }
 
+        [TestCase(nameof(singleLyric), 0, 0, 0)]
+        [TestCase(nameof(singleLyricWithNoText), 0, 0, 0)]
+        public void TestMoveToFirstIndex(string sourceName, int lyricIndex, int? expectedLyricIndex, int? expectedIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
+
+            // Check is movable
+            TestMoveToFirstIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 0, 4)]
+        [TestCase(nameof(singleLyricWithNoText), 0, 0, 0)]
+        public void TestMoveToLastIndex(string sourceName, int lyricIndex, int? expectedLyricIndex, int? expectedIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
+
+            // Check is movable
+            TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
         #endregion
 
         protected override void AssertEqual(TypingCaretPosition expected, TypingCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Objects;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
     public interface IIndexCaretPositionAlgorithm : ICaretPositionAlgorithm
@@ -8,5 +10,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         IIndexCaretPosition? MoveToPreviousIndex(IIndexCaretPosition currentPosition);
 
         IIndexCaretPosition? MoveToNextIndex(IIndexCaretPosition currentPosition);
+
+        IIndexCaretPosition? MoveToFirstIndex(Lyric lyric);
+
+        IIndexCaretPosition? MoveToLastIndex(Lyric lyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -18,6 +18,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         protected abstract TCaretPosition? MoveToNextIndex(TCaretPosition currentPosition);
 
+        protected abstract TCaretPosition? MoveToFirstIndex(Lyric lyric);
+
+        protected abstract TCaretPosition? MoveToLastIndex(Lyric lyric);
+
         public IIndexCaretPosition? MoveToPreviousIndex(IIndexCaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)
@@ -40,6 +44,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Validate(tCaretPosition);
 
             var movedCaretPosition = MoveToNextIndex(tCaretPosition);
+            if (movedCaretPosition != null)
+                Validate(movedCaretPosition.Value);
+
+            return movedCaretPosition;
+        }
+
+        IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToFirstIndex(Lyric lyric)
+        {
+            var movedCaretPosition = MoveToFirstIndex(lyric);
+            if (movedCaretPosition != null)
+                Validate(movedCaretPosition.Value);
+
+            return movedCaretPosition;
+        }
+
+        IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToLastIndex(Lyric lyric)
+        {
+            var movedCaretPosition = MoveToLastIndex(lyric);
             if (movedCaretPosition != null)
                 Validate(movedCaretPosition.Value);
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -92,6 +92,20 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, nextIndex);
         }
 
+        protected override TCaretPosition? MoveToFirstIndex(Lyric lyric)
+        {
+            int index = GetMinIndex(lyric.Text);
+
+            return CreateCaretPosition(lyric, index);
+        }
+
+        protected override TCaretPosition? MoveToLastIndex(Lyric lyric)
+        {
+            int index = GetMaxIndex(lyric.Text);
+
+            return CreateCaretPosition(lyric, index);
+        }
+
         private bool lyricMovable(Lyric lyric)
         {
             int minIndex = GetMinIndex(lyric.Text);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -122,6 +122,32 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return timeTagToPosition(nextTimeTag);
         }
 
+        protected override TimeTagCaretPosition? MoveToFirstIndex(Lyric lyric)
+        {
+            var firstTimeTag = lyric.TimeTags.FirstOrDefault();
+            if (firstTimeTag == null)
+                return null;
+
+            var caret = new TimeTagCaretPosition(lyric, firstTimeTag);
+            if (!timeTagMovable(firstTimeTag))
+                return MoveToNextIndex(caret);
+
+            return caret;
+        }
+
+        protected override TimeTagCaretPosition? MoveToLastIndex(Lyric lyric)
+        {
+            var lastTimeTag = lyric.TimeTags.LastOrDefault();
+            if (lastTimeTag == null)
+                return null;
+
+            var caret = new TimeTagCaretPosition(lyric, lastTimeTag);
+            if (!timeTagMovable(lastTimeTag))
+                return MoveToPreviousIndex(caret);
+
+            return caret;
+        }
+
         private TimeTagCaretPosition? timeTagToPosition(TimeTag timeTag)
         {
             var lyric = timeTagInLyric(timeTag);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -119,6 +119,34 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return new TimeTagIndexCaretPosition(lyric, index);
         }
 
+        protected override TimeTagIndexCaretPosition? MoveToFirstIndex(Lyric lyric)
+        {
+            var index = new TextIndex(0);
+
+            if (TextIndexUtils.OutOfRange(index, lyric.Text))
+                return null;
+
+            var caret = new TimeTagIndexCaretPosition(lyric, index);
+            if (!textIndexMovable(index))
+                return MoveToNextIndex(caret);
+
+            return caret;
+        }
+
+        protected override TimeTagIndexCaretPosition? MoveToLastIndex(Lyric lyric)
+        {
+            var index = new TextIndex(lyric.Text.Length - 1, TextIndex.IndexState.End);
+
+            if (TextIndexUtils.OutOfRange(index, lyric.Text))
+                return null;
+
+            var caret = new TimeTagIndexCaretPosition(lyric, index);
+            if (!textIndexMovable(index))
+                return MoveToPreviousIndex(caret);
+
+            return caret;
+        }
+
         private bool textIndexMovable(TextIndex textIndex)
             => suitableState(textIndex) == textIndex.State;
 


### PR DESCRIPTION
Extend the algorithm that able to move to the fist or last index in the same lyric.

Mark as part of #1651 because `move left` can be replaced into `move up` and `move to last`.