### PR TITLE
To restrict the caret that cannot change the lyric by move left or right.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -105,9 +105,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         #region Lyric index
 
         [TestCase(nameof(singleLyric), 0, 1, null, null)]
-        [TestCase(nameof(twoLyricsWithText), 1, 1, 0, 3)]
-        [TestCase(nameof(threeLyricsWithSpacing), 2, 1, 0, 3)]
-        [TestCase(nameof(threeLyricsWithSpacing), 2, 2, 2, 1)]
+        [TestCase(nameof(singleLyric), 0, 2, 0, 1)]
         public void TestMoveToPreviousIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
@@ -119,9 +117,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         }
 
         [TestCase(nameof(singleLyric), 0, 3, null, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, 3, 1, 1)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, 3, 2, 1)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, 2, 0, 3)]
+        [TestCase(nameof(singleLyric), 0, 2, 0, 3)]
         public void TestMoveToNextIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -140,12 +140,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         #region Lyric index
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, null, null)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 1, 0, 0, 4)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyStartTag, 1, 0, 0, 3)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyEndTag, 1, 0, 0, 4)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, 0, 0, 4)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, 0, 0, 3)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, 0, 0, 4)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4, 0, 3)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 4, 0, 3)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 4, null, null)]
         public void TestMoveToPreviousIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
@@ -157,12 +154,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         }
 
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4, null, null)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 0, 4, 1, 0)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyStartTag, 0, 4, 1, 0)]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyEndTag, 0, 4, 1, 3)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, 4, 2, 0)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, 4, 2, 0)]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, 4, 2, 3)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0, 1)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, 0, 0, 1)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, 0, 0, 4)]
         public void TestMoveToNextIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int index, int? expectedLyricIndex, int? expectedTimeTagIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -131,12 +131,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[1,end]", 0, "[1,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, "[1,end]", 0, "[1,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, "[1,end]", 0, "[0,end]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 1, "[0,start]", 0, "[3,end]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyStartTag, 1, "[0,start]", 0, "[3,start]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyEndTag, 1, "[0,start]", 0, "[3,end]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 2, "[0,start]", 0, "[3,end]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 2, "[0,start]", 0, "[3,start]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 2, "[0,start]", 0, "[3,end]")]
         public void TestMoveToPreviousIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
@@ -154,12 +148,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[1,end]", 0, "[2,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, "[1,end]", 0, "[2,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, "[1,end]", 0, "[2,end]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.None, 0, "[3,end]", 1, "[0,start]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyStartTag, 0, "[3,end]", 1, "[0,start]")]
-        [TestCase(nameof(twoLyricsWithText), MovingTimeTagCaretMode.OnlyEndTag, 0, "[3,end]", 1, "[0,end]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.None, 0, "[3,end]", 2, "[0,start]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyStartTag, 0, "[3,end]", 2, "[0,start]")]
-        [TestCase(nameof(threeLyricsWithSpacing), MovingTimeTagCaretMode.OnlyEndTag, 0, "[3,end]", 2, "[0,end]")]
         public void TestMoveToNextIndex(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textTag, int? expectedLyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -104,10 +104,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         #region Lyric index
 
         [TestCase(nameof(singleLyric), 0, 0, null, null)]
+        [TestCase(nameof(singleLyric), 0, 1, 0, 0)]
         [TestCase(nameof(singleLyricWithNoText), 0, 0, null, null)]
-        [TestCase(nameof(twoLyricsWithText), 1, 0, 0, 4)]
-        [TestCase(nameof(threeLyricsWithSpacing), 2, 0, 1, 0)]
-        [TestCase(nameof(threeLyricsWithSpacing), 2, 3, 2, 2)]
         public void TestMoveToPreviousIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
@@ -119,10 +117,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         }
 
         [TestCase(nameof(singleLyric), 0, 4, null, null)]
+        [TestCase(nameof(singleLyric), 0, 3, 0, 4)]
         [TestCase(nameof(singleLyricWithNoText), 0, 0, null, null)]
-        [TestCase(nameof(twoLyricsWithText), 0, 4, 1, 0)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, 4, 1, 0)]
-        [TestCase(nameof(threeLyricsWithSpacing), 0, 3, 0, 4)]
         public void TestMoveToNextIndex(string sourceName, int lyricIndex, int index, int? expectedLyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             int previousIndex = currentPosition.Index - 1;
 
             if (!indexInTextRange(previousIndex, lyric))
-                return MoveToPreviousLyric(CreateCaretPosition(lyric, int.MaxValue));
+                return null;
 
             return CreateCaretPosition(lyric, previousIndex);
         }
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             int nextIndex = currentPosition.Index + 1;
 
             if (!indexInTextRange(nextIndex, lyric))
-                return MoveToNextLyric(CreateCaretPosition(lyric, int.MinValue));
+                return null;
 
             return CreateCaretPosition(lyric, nextIndex);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             if (upTimeTag == null)
                 return null;
 
-            return timeTagToPosition(upTimeTag);
+            return new TimeTagCaretPosition(previousLyric, upTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToNextLyric(TimeTagCaretPosition currentPosition)
@@ -71,27 +71,33 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             if (downTimeTag == null)
                 return null;
 
-            return timeTagToPosition(downTimeTag);
+            return new TimeTagCaretPosition(nextLyric, downTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToFirstLyric()
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            var firstTimeTag = timeTags.FirstOrDefault(timeTagMovable);
+            var firstLyric = Lyrics.FirstOrDefault(x => x.TimeTags.Any(timeTagMovable));
+            if (firstLyric == null)
+                return null;
+
+            var firstTimeTag = firstLyric.TimeTags.FirstOrDefault(timeTagMovable);
             if (firstTimeTag == null)
                 return null;
 
-            return timeTagToPosition(firstTimeTag);
+            return new TimeTagCaretPosition(firstLyric, firstTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToLastLyric()
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
-            var lastTimeTag = timeTags.LastOrDefault(timeTagMovable);
+            var lastLyric = Lyrics.LastOrDefault(x => x.TimeTags.Any(timeTagMovable));
+            if (lastLyric == null)
+                return null;
+
+            var lastTimeTag = lastLyric.TimeTags.LastOrDefault(timeTagMovable);
             if (lastTimeTag == null)
                 return null;
 
-            return timeTagToPosition(lastTimeTag);
+            return new TimeTagCaretPosition(lastLyric, lastTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric)
@@ -104,22 +110,24 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         protected override TimeTagCaretPosition? MoveToPreviousIndex(TimeTagCaretPosition currentPosition)
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var lyric = currentPosition.Lyric;
+            var timeTags = lyric.TimeTags;
             var previousTimeTag = timeTags.GetPreviousMatch(currentPosition.TimeTag, timeTagMovable);
             if (previousTimeTag == null)
                 return null;
 
-            return timeTagToPosition(previousTimeTag);
+            return new TimeTagCaretPosition(lyric, previousTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToNextIndex(TimeTagCaretPosition currentPosition)
         {
-            var timeTags = Lyrics.SelectMany(x => x.TimeTags).ToArray();
+            var lyric = currentPosition.Lyric;
+            var timeTags = lyric.TimeTags;
             var nextTimeTag = timeTags.GetNextMatch(currentPosition.TimeTag, timeTagMovable);
             if (nextTimeTag == null)
                 return null;
 
-            return timeTagToPosition(nextTimeTag);
+            return new TimeTagCaretPosition(lyric, nextTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToFirstIndex(Lyric lyric)
@@ -146,20 +154,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveToPreviousIndex(caret);
 
             return caret;
-        }
-
-        private TimeTagCaretPosition? timeTagToPosition(TimeTag timeTag)
-        {
-            var lyric = timeTagInLyric(timeTag);
-            if (lyric == null)
-                return null;
-
-            return new TimeTagCaretPosition(lyric, timeTag);
-        }
-
-        private Lyric? timeTagInLyric(TimeTag timeTag)
-        {
-            return Lyrics.FirstOrDefault(x => x.TimeTags.Contains(timeTag));
         }
 
         private bool timeTagMovable(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveToPreviousIndex(new TimeTagIndexCaretPosition(lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
-                return MoveToPreviousLyric(new TimeTagIndexCaretPosition(lyric, new TextIndex(int.MaxValue, index.State)));
+                return null;
 
             return new TimeTagIndexCaretPosition(lyric, index);
         }
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveToNextIndex(new TimeTagIndexCaretPosition(lyric, index));
 
             if (TextIndexUtils.OutOfRange(index, lyric.Text))
-                return MoveToNextLyric(new TimeTagIndexCaretPosition(lyric, new TextIndex(int.MinValue, index.State)));
+                return null;
 
             return new TimeTagIndexCaretPosition(lyric, index);
         }


### PR DESCRIPTION
Trying to close the issue #1651.
Because might have config to prevent changing the lyric by left or right click, so should remove all the change-lyric logic in the caret algorithm.

What's done in this PR:
- Remove the logic to switch to previous or next lyric if exceed the index.
- Move those logic into the caret state.