### PR TITLE
Able to switch different layout in the composer if bottom editor changed.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTagBottomEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTagBottomEditor.cs
@@ -19,13 +19,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
             return new Container();
         }
 
-        protected override Drawable CreateContent()
-        {
-            return new AdjustTimeTagScrollContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 100,
-            };
-        }
+        protected override Drawable CreateContent() => new AdjustTimeTagScrollContainer();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/BaseBottomEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/BaseBottomEditor.cs
@@ -32,25 +32,28 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
                 },
                 new GridContainer
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.Both,
                     ColumnDimensions = new[]
                     {
                         new Dimension(GridSizeMode.Absolute, info_part_spacing),
                         new Dimension()
                     },
-                    RowDimensions = new[] { new Dimension(GridSizeMode.Relative) },
                     Content = new[]
                     {
                         new[]
                         {
-                            CreateInfo(),
+                            CreateInfo().With(x =>
+                            {
+                                x.RelativeSizeAxes = Axes.Both;
+                            }),
                             new Container
                             {
                                 Masking = true,
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                Child = CreateContent(),
+                                RelativeSizeAxes = Axes.Both,
+                                Child = CreateContent().With(x =>
+                                {
+                                    x.RelativeSizeAxes = Axes.Both;
+                                }),
                             }
                         }
                     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/NoteBottomEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/NoteBottomEditor.cs
@@ -19,13 +19,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
             return new Container();
         }
 
-        protected override Drawable CreateContent()
-        {
-            return new NoteEditor
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 150,
-            };
-        }
+        protected override Drawable CreateContent() => new NoteEditor();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTagBottomEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTagBottomEditor.cs
@@ -19,13 +19,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
             return new Container();
         }
 
-        protected override Drawable CreateContent()
-        {
-            return new RecordingTimeTagScrollContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 60,
-            };
-        }
+        protected override Drawable CreateContent() => new RecordingTimeTagScrollContainer();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
@@ -42,7 +42,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         private readonly Container centerEditArea;
         private readonly Container mainEditorArea;
 
-        private readonly Container bottomEditArea;
         private readonly Container<BaseBottomEditor> bottomEditorContainer;
 
         public LyricComposer()
@@ -50,56 +49,71 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
             Box centerEditorBackground;
             Box bottomEditorBackground;
 
-            InternalChildren = new Drawable[]
+            InternalChild = new GridContainer
             {
-                centerEditArea = new Container
+                RelativeSizeAxes = Axes.Both,
+                RowDimensions = new[]
                 {
-                    Name = "Edit area and action buttons",
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    new Dimension(),
+                    new Dimension(GridSizeMode.AutoSize)
+                },
+                Content = new[]
+                {
+                    new Drawable[]
                     {
-                        centerEditorBackground = new Box
+                        centerEditArea = new Container
                         {
-                            Name = "Background",
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        mainEditorArea = new Container
-                        {
+                            Name = "Edit area and action buttons",
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                new LyricEditor(),
-                                new SpecialActionToolbar
+                                centerEditorBackground = new Box
                                 {
-                                    Name = "Toolbar",
-                                    Anchor = Anchor.BottomCentre,
-                                    Origin = Anchor.BottomCentre,
+                                    Name = "Background",
+                                    RelativeSizeAxes = Axes.Both,
                                 },
+                                mainEditorArea = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new Drawable[]
+                                    {
+                                        new LyricEditor(),
+                                        new SpecialActionToolbar
+                                        {
+                                            Name = "Toolbar",
+                                            Anchor = Anchor.BottomCentre,
+                                            Origin = Anchor.BottomCentre,
+                                        },
+                                    }
+                                }
                             }
-                        }
-                    }
-                },
-                bottomEditArea = new Container
-                {
-                    Name = "Edit area and action buttons",
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
-                    Children = new Drawable[]
-                    {
-                        bottomEditorBackground = new Box
-                        {
-                            Name = "Background",
-                            RelativeSizeAxes = Axes.Both,
                         },
-                        bottomEditorContainer = new Container<BaseBottomEditor>
+                    },
+                    new Drawable[]
+                    {
+                        new Container
                         {
+                            Name = "Edit area and action buttons",
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                        }
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            Children = new Drawable[]
+                            {
+                                bottomEditorBackground = new Box
+                                {
+                                    Name = "Background",
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                                bottomEditorContainer = new Container<BaseBottomEditor>
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                }
+                            }
+                        },
                     }
-                },
+                }
             };
 
             bindableModeAndSubMode.BindValueChanged(e =>
@@ -298,8 +312,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
             if (bottomEditor != null)
                 bottomEditorContainer.Add(bottomEditor);
 
-            calculateBottomEditAreaSize(bottomEditor);
-
             static BaseBottomEditor? createBottomEditor(BottomEditorType? bottomEditorType) =>
                 bottomEditorType switch
                 {
@@ -308,11 +320,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                     BottomEditorType.Note => new NoteBottomEditor(),
                     _ => null
                 };
-        }
-
-        private void calculateBottomEditAreaSize(BaseBottomEditor? bottomEditor)
-        {
-            float bottomEditorHeight = bottomEditor?.ContentHeight ?? 0;
         }
 
         #endregion


### PR DESCRIPTION
Mark as part of #1609.

What's done in this PR:
- Should use the relative size in the bottom editor.
- Implement switch bottom lyric with animation effect in the lyric composer.