### PR TITLE
Add button to set and clear the time tag time in the composer.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
@@ -58,6 +58,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Lyrics
         }
 
         [Test]
+        public void TestClearAllTimeTagTime()
+        {
+            PrepareHitObject(new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = new[]
+                {
+                    new TimeTag(new TextIndex()), // without time.
+                    new TimeTag(new TextIndex(), 1000),
+                    new TimeTag(new TextIndex(3, TextIndex.IndexState.End), 3000),
+                }
+            });
+
+            TriggerHandlerChanged(c => c.ClearAllTimeTagTime());
+
+            AssertSelectedHitObject(h =>
+            {
+                Assert.IsTrue(h.TimeTags.All(x => x.Time == null));
+            });
+        }
+
+        [Test]
         public void TestAdd()
         {
             PrepareHitObject(new Lyric

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricTimeTagsChangeHandler.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
         void ClearTimeTagTime(TimeTag timeTag);
 
+        void ClearAllTimeTagTime();
+
         void AddByPosition(TextIndex index);
 
         void RemoveByPosition(TextIndex index);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
@@ -41,6 +41,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
+        public void ClearAllTimeTagTime()
+        {
+            PerformOnSelection(lyric =>
+            {
+                foreach (var timeTag in lyric.TimeTags)
+                {
+                    timeTag.Time = null;
+                }
+            });
+        }
+
         public void Add(TimeTag timeTag)
         {
             CheckExactlySelectedOneHitObject();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
@@ -127,7 +127,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                         new CreateTimeTagButton(),
                         new RemoveTimeTagButton(),
                     },
-                    TimeTagEditMode.Recording => Array.Empty<Drawable>(),
+                    TimeTagEditMode.Recording => new Drawable[]
+                    {
+                        new MoveToFirstIndexButton(),
+                        new MoveToPreviousIndexButton(),
+                        new MoveToNextIndexButton(),
+                        new MoveToLastIndexButton(),
+                        new SetTimeTagTimeButton(),
+                        new ClearTimeTagTimeButton(),
+                    },
                     TimeTagEditMode.Adjust => Array.Empty<Drawable>(),
                     _ => throw new ArgumentOutOfRangeException(nameof(timeTagEditMode), timeTagEditMode, null)
                 };

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                         new MoveToLastIndexButton(),
                         new SetTimeTagTimeButton(),
                         new ClearTimeTagTimeButton(),
+                        new ClearAllTimeTagTimeButton(),
                     },
                     TimeTagEditMode.Adjust => Array.Empty<Drawable>(),
                     _ => throw new ArgumentOutOfRangeException(nameof(timeTagEditMode), timeTagEditMode, null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/ClearAllTimeTagTimeButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/ClearAllTimeTagTimeButton.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
+{
+    public class ClearAllTimeTagTimeButton : ActionButton
+    {
+        [Resolved, AllowNull]
+        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
+
+        public ClearAllTimeTagTimeButton()
+        {
+            SetIcon(FontAwesome.Solid.Redo);
+
+            Action = () =>
+            {
+                lyricTimeTagsChangeHandler.ClearAllTimeTagTime();
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/ClearTimeTagTimeButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/ClearTimeTagTimeButton.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
+{
+    public class ClearTimeTagTimeButton : KeyActionButton
+    {
+        protected override KaraokeEditAction EditAction => KaraokeEditAction.ClearTime;
+
+        [Resolved, AllowNull]
+        private ILyricCaretState lyricCaretState { get; set; }
+
+        [Resolved, AllowNull]
+        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
+
+        public ClearTimeTagTimeButton()
+        {
+            SetIcon(FontAwesome.Solid.Eraser);
+
+            Action = () =>
+            {
+                if (lyricCaretState.BindableCaretPosition.Value is not TimeTagCaretPosition timeTagCaretPosition)
+                    throw new InvalidOperationException();
+
+                var timeTag = timeTagCaretPosition.TimeTag;
+                lyricTimeTagsChangeHandler.ClearTimeTagTime(timeTag);
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/CreateTimeTagButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/CreateTimeTagButton.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
-using TagLib;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
 {
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
             Action = () =>
             {
                 if (lyricCaretState.BindableCaretPosition.Value is not TimeTagIndexCaretPosition timeTagIndexCaretPosition)
-                    throw new UnsupportedFormatException();
+                    throw new InvalidOperationException();
 
                 var index = timeTagIndexCaretPosition.Index;
                 lyricTimeTagsChangeHandler.AddByPosition(index);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/RemoveTimeTagButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/RemoveTimeTagButton.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
-using TagLib;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
 {
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
             Action = () =>
             {
                 if (lyricCaretState.BindableCaretPosition.Value is not TimeTagIndexCaretPosition timeTagIndexCaretPosition)
-                    throw new UnsupportedFormatException();
+                    throw new InvalidOperationException();
 
                 var index = timeTagIndexCaretPosition.Index;
                 lyricTimeTagsChangeHandler.RemoveByPosition(index);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/SetTimeTagTimeButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/TimeTags/SetTimeTagTimeButton.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags
+{
+    public class SetTimeTagTimeButton : KeyActionButton
+    {
+        protected override KaraokeEditAction EditAction => KaraokeEditAction.SetTime;
+
+        [Resolved, AllowNull]
+        private ILyricCaretState lyricCaretState { get; set; }
+
+        [Resolved, AllowNull]
+        private ILyricTimeTagsChangeHandler lyricTimeTagsChangeHandler { get; set; }
+
+        [Resolved, AllowNull]
+        private EditorClock editorClock { get; set; }
+
+        public SetTimeTagTimeButton()
+        {
+            SetIcon(FontAwesome.Solid.Stopwatch);
+
+            Action = () =>
+            {
+                if (lyricCaretState.BindableCaretPosition.Value is not TimeTagCaretPosition timeTagCaretPosition)
+                    throw new InvalidOperationException();
+
+                var timeTag = timeTagCaretPosition.TimeTag;
+                double currentTime = editorClock.CurrentTime;
+                lyricTimeTagsChangeHandler.SetTimeTagTime(timeTag, currentTime);
+            };
+        }
+    }
+}


### PR DESCRIPTION
Part of #1610.

![image](https://user-images.githubusercontent.com/9100368/196017425-827d9b0d-2cb1-4b16-9b6e-4f23f24b5994.png)
What's done in this PR:
- Create button to set the time-tag time and clear the time-tag time.
- Should be able to clear all the time-tag time by the change-handler.
- Create button to clear the time-tag time.
- Apply those damn buttons into the toolbar.