### PR TITLE
Implement adjust font size toolbar button in the composer.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Configuration
 {
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
 
             // General
             SetDefault(KaraokeRulesetLyricEditorSetting.LyricEditorPreferLayout, LyricEditorLayout.Preview);
-            SetDefault(KaraokeRulesetLyricEditorSetting.LyricEditorFontSize, 28f);
+            SetDefault(KaraokeRulesetLyricEditorSetting.LyricEditorFontSize, FontUtils.DEFAULT_FONT_SIZE);
             SetDefault(KaraokeRulesetLyricEditorSetting.AutoFocusToEditLyric, true);
             SetDefault(KaraokeRulesetLyricEditorSetting.AutoFocusToEditLyricSkipRows, 1, 0, 4);
             SetDefault(KaraokeRulesetLyricEditorSetting.ClickToLockLyricState, LockState.Partial);

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetLyricEditorConfigManager.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             // Composer
             SetDefault(KaraokeRulesetLyricEditorSetting.ShowPropertyPanelInComposer, true);
             SetDefault(KaraokeRulesetLyricEditorSetting.ShowInvalidInfoInComposer, true);
+            SetDefault(KaraokeRulesetLyricEditorSetting.FontSizeInComposer, FontUtils.DEFAULT_FONT_SIZE_IN_COMPOSER);
 
             // Create time-tag.
             SetDefault(KaraokeRulesetLyricEditorSetting.CreateTimeTagEditMode, CreateTimeTagEditMode.Create);
@@ -66,6 +67,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
         // Composer
         ShowPropertyPanelInComposer,
         ShowInvalidInfoInComposer,
+        FontSizeInComposer,
 
         // Create time-tag.
         CreateTimeTagEditMode,

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricEditor.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -15,6 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
     public class LyricEditor : CompositeDrawable
     {
         private readonly IBindable<Lyric?> bindableFocusedLyric = new Bindable<Lyric?>();
+        private readonly IBindable<float> bindableFontSize = new Bindable<float>();
 
         private readonly LyricEditorSkin skin;
         private readonly SkinProvidingContainer skinProvidingContainer;
@@ -43,12 +45,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                     Origin = Anchor.CentreLeft,
                 });
             });
+
+            bindableFontSize.BindValueChanged(e =>
+            {
+                skin.FontSize = e.NewValue;
+            });
         }
 
         [BackgroundDependencyLoader]
-        private void load(ILyricCaretState lyricCaretState)
+        private void load(ILyricCaretState lyricCaretState, KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
         {
             bindableFocusedLyric.BindTo(lyricCaretState.BindableFocusedLyric);
+
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.FontSizeInComposer, bindableFontSize);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
@@ -75,6 +75,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         {
             buttonContainer.Clear();
 
+            buttonContainer.AddRange(createAdjustLyricSizeItem());
+
+            buttonContainer.Add(new Separator());
+
             buttonContainer.AddRange(createPanelItems());
 
             buttonContainer.Add(new Separator());
@@ -83,11 +87,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
 
             buttonContainer.Add(new Separator());
 
-            buttonContainer.AddRange(createAdjustLyricSizeItem());
-
             var modeWithSubMode = bindableModeAndSubMode.Value;
             buttonContainer.AddRange(createItemForEditMode(modeWithSubMode));
         }
+
+        private static IEnumerable<Drawable> createAdjustLyricSizeItem() => new Drawable[]
+        {
+            new AdjustFontSizeButton(),
+        };
 
         private static IEnumerable<Drawable> createPanelItems() => new Drawable[]
         {
@@ -99,11 +106,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         {
             new MoveToPreviousLyricButton(),
             new MoveToNextLyricButton(),
-        };
-
-        private static IEnumerable<Drawable> createAdjustLyricSizeItem() => new Drawable[]
-        {
-            new AdjustFontSizeButton(),
         };
 
         private static IEnumerable<Drawable> createItemForEditMode(ModeWithSubMode modeWithSubMode)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/SpecialActionToolbar.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.Carets;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.Panels;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.Playback;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.TimeTags;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.View;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osuTK;
@@ -100,7 +101,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
             new MoveToNextLyricButton(),
         };
 
-        private static IEnumerable<Drawable> createAdjustLyricSizeItem() => Array.Empty<Drawable>();
+        private static IEnumerable<Drawable> createAdjustLyricSizeItem() => new Drawable[]
+        {
+            new AdjustFontSizeButton(),
+        };
 
         private static IEnumerable<Drawable> createItemForEditMode(ModeWithSubMode modeWithSubMode)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/View/AdjustFontSizeButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Toolbar/View/AdjustFontSizeButton.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Toolbar.View
+{
+    public class AdjustFontSizeButton : CompositeDrawable
+    {
+        private readonly Bindable<float> bindableFontSize = new();
+
+        public AdjustFontSizeButton()
+        {
+            IconButton previousSizeButton;
+            OsuSpriteText fontSizeSpriteText;
+            IconButton nextSizeButton;
+            float[] sizes = FontUtils.ComposerFontSize();
+
+            Height = SpecialActionToolbar.HEIGHT;
+            AutoSizeAxes = Axes.X;
+            InternalChild = new FillFlowContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Children = new Drawable[]
+                {
+                    previousSizeButton = new IconButton
+                    {
+                        Size = new Vector2(SpecialActionToolbar.ICON_SIZE),
+                        Icon = FontAwesome.Solid.Minus,
+                        Action = () =>
+                        {
+                            float previousSize = sizes.GetPrevious(bindableFontSize.Value);
+                            if (previousSize == default)
+                                return;
+
+                            bindableFontSize.Value = previousSize;
+                        }
+                    },
+                    new Container
+                    {
+                        Width = 48,
+                        Height = SpecialActionToolbar.ICON_SIZE,
+                        Child = fontSizeSpriteText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    },
+                    nextSizeButton = new IconButton
+                    {
+                        Size = new Vector2(SpecialActionToolbar.ICON_SIZE),
+                        Icon = FontAwesome.Solid.Plus,
+                        Action = () =>
+                        {
+                            float nextSize = sizes.GetNext(bindableFontSize.Value);
+                            if (nextSize == default)
+                                return;
+
+                            bindableFontSize.Value = nextSize;
+                        }
+                    }
+                }
+            };
+
+            bindableFontSize.BindValueChanged(e =>
+            {
+                fontSizeSpriteText.Text = FontUtils.GetText(e.NewValue);
+                previousSizeButton.Enabled.Value = sizes.GetPrevious(e.NewValue) != default;
+                nextSizeButton.Enabled.Value = sizes.GetNext(e.NewValue) != default;
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager)
+        {
+            lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.FontSizeInComposer, bindableFontSize);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Utils/FontUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/FontUtils.cs
@@ -8,6 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Utils
     public static class FontUtils
     {
         public const float DEFAULT_FONT_SIZE = 28;
+        public const float DEFAULT_FONT_SIZE_IN_COMPOSER = 36;
 
         /// <summary>
         /// For selecting size
@@ -34,6 +35,13 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <returns></returns>
         public static float[] DefaultPreviewFontSize()
             => new float[] { 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 48 };
+
+        /// <summary>
+        /// For selecting preview size in editor.
+        /// </summary>
+        /// <returns></returns>
+        public static float[] ComposerFontSize()
+            => new float[] { 20, 24, 28, 32, 36, 40, 48, 64, 72 };
 
         public static string GetText(float fontSize)
             => $"{fontSize} px";

--- a/osu.Game.Rulesets.Karaoke/Utils/FontUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/FontUtils.cs
@@ -7,6 +7,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 {
     public static class FontUtils
     {
+        public const float DEFAULT_FONT_SIZE = 28;
+
         /// <summary>
         /// For selecting size
         /// </summary>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/196211906-28c96263-6e45-476b-b577-302a55ccb544.png)
Implement part of #1610.

What's done in this PR:
- Define the default font size and available font size for the composer.
- Add the config for able to remember last font size in the composer.
- Implement the font size selector component and apply in to the compsoer.
- Lyric editor should display the font with correct size.