### PR TITLE
Let change handler able to handle the dragging case.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
             };
             var editorBeatmap = new EditorBeatmap(beatmap);
             Dependencies.Cache(editorBeatmap);
+            Dependencies.CacheAs<IEditorChangeHandler>(new MockEditorChangeHandler());
             editorBeatmap.TransactionEnded += () =>
             {
                 transactionCount++;
@@ -112,6 +113,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
             {
                 Assert.AreEqual(1, transactionCount);
             });
+        }
+
+        private class MockEditorChangeHandler : TransactionalCommitComponent, IEditorChangeHandler
+        {
+            public event Action? OnStateChange;
+
+            protected override void UpdateState()
+            {
+                OnStateChange?.Invoke();
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
 
             try
             {
+                // todo: follow-up the discussion in the https://github.com/karaoke-dev/karaoke/pull/1669 after support the change handler for customized ruleset.
                 if (changeHandler is TransactionalCommitComponent transactionalCommitComponent && !transactionalCommitComponent.TransactionActive)
                 {
                     // should trigger the UpdateState() in the editor beatmap only if there's no active state.


### PR DESCRIPTION
Because dragging to change the property might call the change handler method every frame, which might cause `UpdateState()` called frequently in the `EditorBeatmap`.

So maybe:
- Use the `PerformOnSelection()` in the `EditorBeatmap` for most cases.
- Just change the `SelectedHitObjects` in the `EditorBeatmap` if the state is between `BeginChange()` and `EndChange()` in the `EditorChangeHandler`.