### PR TITLE
Switch to another packing tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-    - name: Create release
+    - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       with:
         token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,14 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+    - name: Create release
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.dll
-        asset_name: osu.Game.Rulesets.Karaoke.dll
-        asset_content_type: application/vnd.microsoft.portable-executable
+        token: ${{ secrets.RELEASE_TOKEN }}
+        files: |
+          osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.dll
+        body: |
+          Thank you for showing interest in this ruleset. This is a tagged release (${{ env.CURRENT_TAG }}).
     - name: Generate changelog
       run: |
         sudo npm install github-release-notes -g

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         token: ${{ secrets.RELEASE_TOKEN }}
         files: |
           osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.dll
+        draft: true
         body: |
           Thank you for showing interest in this ruleset. This is a tagged release (${{ env.CURRENT_TAG }}).
     - name: Generate changelog


### PR DESCRIPTION
Switch the upload file from the "actions/upload-release-asset@master" into "softprops/action-gh-release@v1" because the github action is not maintained anymore.

See the latest change in the https://github.com/LumpBloom7/sentakki/blob/master/.github/workflows/release.yml