### PR TITLE
Create a new folder and copy all reuleset needed dlls in release build.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         token: ${{ secrets.RELEASE_TOKEN }}
         files: |
           osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.dll
-          osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/Packed/osu.Game.Rulesets.Karaoke.zip
+          osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/osu.Game.Rulesets.Karaoke.zip
         draft: true
         body: |
           Thank you for showing interest in this ruleset. This is a tagged release (${{ env.CURRENT_TAG }}).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,9 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
     - name: Zip the dlls
-      run: zip -r ./osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/osu.Game.Rulesets.Karaoke.zip . -x "./osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/DLLs/*"
+      run: |
+        cd osu.Game.Rulesets.Karaoke/bin/Release/netstandard2.1/DLLs
+        zip -r ../osu.Game.Rulesets.Karaoke.zip ./
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1
       with:

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -42,5 +42,25 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.dll"/>
+    <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.Resources.dll"/>
+    <InputAssemblies Include="$(OutputPath)LanguageDetection.dll"/>
+    <InputAssemblies Include="$(OutputPath)LrcParser.dll"/>
+    <InputAssemblies Include="$(OutputPath)Octokit.dll"/>
+    <InputAssemblies Include="$(OutputPath)osu.Framework.KaraokeFont.dll"/>
+    <InputAssemblies Include="$(OutputPath)osu.Framework.Microphone.dll"/>
+    <InputAssemblies Include="$(OutputPath)NWaves.dll"/>
+    <InputAssemblies Include="$(OutputPath)NicoKaraParser.dll"/>
+    <InputAssemblies Include="$(OutputPath)SixLabors.Fonts.dll"/>
+    <InputAssemblies Include="$(OutputPath)SixLabors.ImageSharp.Drawing.dll"/>
+    <InputAssemblies Include="$(OutputPath)WanaKanaSharp.dll"/>
+    <InputAssemblies Include="$(OutputPath)Zipangu.dll"/>
+  </ItemGroup>
+
+  <Target Name="CopyCustomContent" Condition=" '$(Configuration)'=='Release' " AfterTargets="AfterBuild">
+    <Copy SourceFiles="@(InputAssemblies)" DestinationFolder="$(OutDir)/DLLs" SkipUnchangedFiles="true" />
+  </Target>
   
 </Project>


### PR DESCRIPTION
Because packing tools might have some issues that hard to control(see: #1672)
So we need an alternative way to let user able to download all dlls and placing them into the folder.

See the config in the https://stackoverflow.com/a/44378406/4105113.