### PR TITLE
Add more dlls into list

### DIFF
--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -46,6 +46,8 @@
   <ItemGroup>
     <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.dll"/>
     <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.Resources.dll"/>
+    <InputAssemblies Include="$(OutputPath)**/osu.Game.Rulesets.Karaoke.Resources.resources.dll"
+                     Exclude="$(OutputPath)Dlls/osu.Game.Rulesets.Karaoke.Resources.resources.dll"/>
     <InputAssemblies Include="$(OutputPath)LanguageDetection.dll"/>
     <InputAssemblies Include="$(OutputPath)LrcParser.dll"/>
     <InputAssemblies Include="$(OutputPath)Octokit.dll"/>
@@ -64,7 +66,7 @@
   </ItemGroup>
 
   <Target Name="CopyCustomContent" Condition=" '$(Configuration)'=='Release' " AfterTargets="AfterBuild">
-    <Copy SourceFiles="@(InputAssemblies)" DestinationFolder="$(OutDir)/DLLs" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(InputAssemblies)" DestinationFiles="$(OutDir)/Dlls/%(RecursiveDir)%(Filename)%(Extension)"/>
   </Target>
   
 </Project>

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -52,6 +52,10 @@
     <InputAssemblies Include="$(OutputPath)osu.Framework.KaraokeFont.dll"/>
     <InputAssemblies Include="$(OutputPath)osu.Framework.Microphone.dll"/>
     <InputAssemblies Include="$(OutputPath)NWaves.dll"/>
+    <InputAssemblies Include="$(OutputPath)Lucene.Net.dll"/>
+    <InputAssemblies Include="$(OutputPath)Lucene.Net.Analysis.Common.dll"/>
+    <InputAssemblies Include="$(OutputPath)Lucene.Net.Analysis.Kuromoji.dll"/>
+    <InputAssemblies Include="$(OutputPath)J2N.dll"/>
     <InputAssemblies Include="$(OutputPath)NicoKaraParser.dll"/>
     <InputAssemblies Include="$(OutputPath)SixLabors.Fonts.dll"/>
     <InputAssemblies Include="$(OutputPath)SixLabors.ImageSharp.Drawing.dll"/>


### PR DESCRIPTION
Add some dlls to fix:
- Auto-generate ruby/romaji not working in the editor.
- Localization not showing up.

If need to make the file with folder, then should use `DestinationFiles` to assign the path for each files instead of `DestinationFolder`.

See the document:
https://github.com/MicrosoftDocs/visualstudio-docs/blob/main/docs/msbuild/copy-task.md