### PR TITLE
Fix the wrong position calculation in scroll container.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/BindableBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/BindableBlueprintContainer.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Bindables;
@@ -14,10 +15,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 {
     public abstract class BindableBlueprintContainer<T> : BlueprintContainer<T> where T : class
     {
-        private readonly BindableList<T> bindableList = new();
+        private BindableList<T> bindableList;
 
-        protected BindableBlueprintContainer()
+        protected void RegisterBindable(BindableList<T> bindable)
         {
+            if (bindableList != null)
+                throw new Exception();
+
+            bindableList = bindable;
+
+            // Add time-tag into blueprint container
             bindableList.BindCollectionChanged((_, args) =>
             {
                 switch (args.Action)
@@ -34,13 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
                         break;
                 }
-            });
-        }
-
-        protected void RegisterBindable(BindableList<T> bindable)
-        {
-            bindableList.UnbindBindings();
-            bindableList.BindTo(bindable);
+            }, true);
         }
 
         protected override bool OnDragStart(DragStartEvent e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Blueprints/TimeTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Blueprints/TimeTagBlueprintContainer.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Blueprints
         }
 
         [BackgroundDependencyLoader]
-        private void load(ITimeTagModeState timeTagModeState)
+        private void load()
         {
             // Add time tag into blueprint container
             RegisterBindable(timeTags);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
@@ -25,9 +25,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.AdjustTimeT
         [Resolved]
         private EditorClock editorClock { get; set; }
 
-        [Resolved]
-        private IBeatSnapProvider beatSnapProvider { get; set; }
-
         private CurrentTimeMarker currentTimeMarker;
 
         public AdjustTimeTagScrollContainer()
@@ -89,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.AdjustTimeT
         public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);
-            return new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(time));
+            return new SnapResult(screenSpacePosition, time);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
@@ -86,16 +86,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.AdjustTimeT
             currentTimeMarker.MoveToX(position);
         }
 
-        public double TimeAtPosition(float x)
-        {
-            return x / Content.DrawWidth * editorClock.TrackLength;
-        }
-
-        public float PositionAtTime(double time)
-        {
-            return (float)(time / editorClock.TrackLength * Content.DrawWidth);
-        }
-
         public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTi
 
         private void seekTrackToCurrent()
         {
-            double target = Current / Content.DrawWidth * editorClock.TrackLength;
+            double target = TimeAtPosition(Current);
             editorClock.Seek(Math.Min(editorClock.TrackLength, target));
         }
 
@@ -159,7 +159,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTi
             if (handlingDragInput)
                 editorClock.Stop();
 
-            ScrollTo((float)(editorClock.CurrentTime / editorClock.TrackLength) * Content.DrawWidth, false);
+            float position = PositionAtTime(editorClock.CurrentTime);
+            ScrollTo(position, false);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
@@ -145,16 +145,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTi
 
         private void seekTrackToCurrent()
         {
-            if (!Track.IsLoaded)
-                return;
-
-            double target = Current / Content.DrawWidth * Track.Length;
-            editorClock.Seek(Math.Min(Track.Length, target));
+            double target = Current / Content.DrawWidth * editorClock.TrackLength;
+            editorClock.Seek(Math.Min(editorClock.TrackLength, target));
         }
 
         private void scrollToTrackTime()
         {
-            if (!Track.IsLoaded || Track.Length == 0)
+            if (editorClock.TrackLength == 0)
                 return;
 
             // covers the case where the user starts playback after a drag is in progress.

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTagScrollContainer.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -39,8 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
 
         [Resolved, AllowNull]
         private EditorClock editorClock { get; set; }
-
-        protected Track Track { get; private set; } = null!;
 
         protected TimeTagScrollContainer()
         {
@@ -121,7 +118,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
             this.beatmap.BindValueChanged(b =>
             {
                 waveform.Waveform = b.NewValue.Waveform;
-                Track = b.NewValue.Track;
             }, true);
 
             ShowWaveformGraph.BindValueChanged(e => updateWaveformOpacity());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/TimeTagScrollContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -15,6 +16,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
@@ -34,6 +36,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
         protected readonly IBindable<float> WaveformOpacity = new BindableFloat();
         protected readonly IBindable<bool> ShowTick = new BindableBool();
         protected readonly IBindable<float> TickOpacity = new BindableFloat();
+
+        [Resolved, AllowNull]
+        private EditorClock editorClock { get; set; }
 
         protected Track Track { get; private set; } = null!;
 
@@ -161,6 +166,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor
 
             // will goes in here if all time-tag are no time.
             return index * preempt_time;
+        }
+
+        public double TimeAtPosition(float x)
+        {
+            return x / Content.DrawWidth * editorClock.TrackLength;
+        }
+
+        public float PositionAtTime(double time)
+        {
+            return (float)(time / editorClock.TrackLength * Content.DrawWidth);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.dll" />
     <InputAssemblies Include="$(OutputPath)osu.Game.Rulesets.Karaoke.Resources.dll" />
-    <InputAssemblies Include="$(OutputPath)**/osu.Game.Rulesets.Karaoke.Resources.resources.dll" Exclude="$(OutputPath)Dlls/osu.Game.Rulesets.Karaoke.Resources.resources.dll" />
+    <InputAssemblies Include="$(OutputPath)**/osu.Game.Rulesets.Karaoke.Resources.resources.dll" Exclude="$(OutputPath)DLLs/osu.Game.Rulesets.Karaoke.Resources.resources.dll" />
     <InputAssemblies Include="$(OutputPath)LanguageDetection.dll" />
     <InputAssemblies Include="$(OutputPath)LrcParser.dll" />
     <InputAssemblies Include="$(OutputPath)Octokit.dll" />
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <Target Name="CopyCustomContent" Condition=" '$(Configuration)'=='Release' " AfterTargets="AfterBuild">
-    <Copy SourceFiles="@(InputAssemblies)" DestinationFiles="$(OutDir)/Dlls/%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(InputAssemblies)" DestinationFiles="$(OutDir)/DLLs/%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
   
 </Project>


### PR DESCRIPTION
Continuous of #1677.

What's done in this PR:
- Adjust the method location in the `AdjustTimeTagScrollContainer`
- Remove the `Track` instance in the `TimeTagScrollContainer` by following how `Timeline` did in lazer.
- Fix get the wrong snap time in the `AdjustTimeTagScrollContainer`.
- Fix time-tag not blueprint not update well in the `BindableBlueprintContainer<T>`
- Fix release build broken. see: https://github.com/karaoke-dev/karaoke/actions/runs/3305977988