### PR TITLE
Rename and separate the lyric-related checks.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckInvalidPropertyLyricsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckInvalidPropertyLyricsTest.cs
@@ -45,32 +45,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
         {
         }
 
-        [TestCase("karaoke")]
-        [TestCase("k")] // not limit min size for now.
-        [TestCase("カラオケ")] // not limit language.
-        public void TestCheckText(string text)
-        {
-            var lyric = new Lyric
-            {
-                Text = text
-            };
-
-            AssertOk(lyric);
-        }
-
-        [TestCase(" ")] // but should not be empty or white space.
-        [TestCase("")]
-        [TestCase(null)]
-        public void TestCheckInvalidText(string text)
-        {
-            var lyric = new Lyric
-            {
-                Text = text
-            };
-
-            AssertNotOk<IssueTemplateNoText>(lyric);
-        }
-
         [TestCase(new[] { 1, 2, 3 })]
         [TestCase(new[] { 1 })]
         [TestCase(new[] { 100 })] // although singer is not exist, but should not check in this test case.

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckInvalidPropertyLyricsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckInvalidPropertyLyricsTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Globalization;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -12,29 +11,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
     [TestFixture]
     public class CheckInvalidPropertyLyricsTest : HitObjectCheckTest<Lyric, CheckInvalidPropertyLyrics>
     {
-        [TestCase("Ja-jp")]
-        [TestCase("")] // should not have issue if CultureInfo accept it.
-        public void TestCheckLanguage(string language)
-        {
-            var lyric = new Lyric
-            {
-                Language = new CultureInfo(language),
-            };
-
-            AssertOk(lyric);
-        }
-
-        [TestCase(null)]
-        public void TestCheckInvalidLanguage(string? language)
-        {
-            var lyric = new Lyric
-            {
-                Language = language != null ? new CultureInfo(language) : null,
-            };
-
-            AssertNotOk<IssueTemplateNotFillLanguage>(lyric);
-        }
-
         [Ignore("Not implement.")]
         [TestCase(0, true)]
         [TestCase(1, false)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricLanguageTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricLanguageTest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Objects;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricLanguage;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
+{
+    public class CheckLyricLanguageTest : HitObjectCheckTest<Lyric, CheckLyricLanguage>
+    {
+        [TestCase("Ja-jp")]
+        [TestCase("")] // should not have issue if CultureInfo accept it.
+        public void TestCheckLanguage(string language)
+        {
+            var lyric = new Lyric
+            {
+                Language = new CultureInfo(language),
+            };
+
+            AssertOk(lyric);
+        }
+
+        [TestCase(null)]
+        public void TestCheckInvalidLanguage(string? language)
+        {
+            var lyric = new Lyric
+            {
+                Language = language != null ? new CultureInfo(language) : null,
+            };
+
+            AssertNotOk<IssueTemplateNotFillLanguage>(lyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricSingerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricSingerTest.cs
@@ -4,23 +4,13 @@
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckInvalidPropertyLyrics;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricSinger;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
     [TestFixture]
-    public class CheckInvalidPropertyLyricsTest : HitObjectCheckTest<Lyric, CheckInvalidPropertyLyrics>
+    public class CheckLyricSingerTest : HitObjectCheckTest<Lyric, CheckLyricSinger>
     {
-        [Ignore("Not implement.")]
-        [TestCase(0, true)]
-        [TestCase(1, false)]
-        [TestCase(-1, false)]
-        [TestCase(-2, false)] // in here, not check is layout actually exist.
-        [TestCase(null, true)]
-        public void TestCheckLayout(int? layout, bool hasIssue)
-        {
-        }
-
         [TestCase(new[] { 1, 2, 3 })]
         [TestCase(new[] { 1 })]
         [TestCase(new[] { 100 })] // although singer is not exist, but should not check in this test case.
@@ -43,11 +33,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
             };
 
             AssertNotOk<IssueTemplateNoSinger>(lyric);
-        }
-
-        [Ignore("Not implement.")]
-        public void TestCheckSingerInBeatmap(int[] singers, bool hasIssue)
-        {
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTextTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTextTest.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Objects;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricText;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
+{
+    [TestFixture]
+    public class CheckLyricTextTest : HitObjectCheckTest<Lyric, CheckLyricText>
+    {
+        [TestCase("karaoke")]
+        [TestCase("k")] // not limit min size for now.
+        [TestCase("カラオケ")] // not limit language.
+        public void TestCheckText(string text)
+        {
+            var lyric = new Lyric
+            {
+                Text = text
+            };
+
+            AssertOk(lyric);
+        }
+
+        [TestCase(" ")] // but should not be empty or white space.
+        [TestCase("　")] // but should not be empty or white space.
+        [TestCase("")]
+        [TestCase(null)]
+        public void TestCheckInvalidText(string text)
+        {
+            var lyric = new Lyric
+            {
+                Text = text
+            };
+
+            AssertNotOk<IssueTemplateNoText>(lyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTranslateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTranslateTest.cs
@@ -12,12 +12,12 @@ using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Beatmaps;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckTranslate;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricTranslate;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
     [TestFixture]
-    public class CheckTranslateTest : BaseCheckTest<CheckTranslate>
+    public class CheckLyricTranslateTest : BaseCheckTest<CheckLyricTranslate>
     {
         [Test]
         public void TestNoLyricAndNoLanguage()

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker
             {
                 checks = new List<ICheck>
                 {
-                    new CheckInvalidPropertyLyrics(),
+                    new CheckLyricSinger(),
                     new CheckInvalidRubyRomajiLyrics
                     {
                         Config = config

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
@@ -94,6 +94,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker
             {
                 checks = new List<ICheck>
                 {
+                    new CheckLyricText(),
+                    new CheckLyricLanguage(),
                     new CheckLyricSinger(),
                     new CheckInvalidRubyRomajiLyrics
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckHitObjectProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckHitObjectProperty.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks
+{
+    public abstract class CheckHitObjectProperty<THitObject> : ICheck where THitObject : KaraokeHitObject
+    {
+        public CheckMetadata Metadata => new(CheckCategory.HitObjects, Description);
+
+        protected abstract string Description { get; }
+
+        public abstract IEnumerable<IssueTemplate> PossibleTemplates { get; }
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+            => context.Beatmap.HitObjects.OfType<THitObject>().Select(Check).SelectMany(x => x);
+
+        public abstract IEnumerable<Issue> Check(THitObject hitObject);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckInvalidPropertyLyrics.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckInvalidPropertyLyrics.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateNotFillLanguage(this),
-            new IssueTemplateNoText(this),
             new IssueTemplateNoSinger(this),
         };
 
@@ -29,9 +28,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 
                 // todo : check lyric layout.
 
-                if (string.IsNullOrWhiteSpace(lyric.Text))
-                    yield return new IssueTemplateNoText(this).Create(lyric);
-
                 if (!lyric.Singers.Any())
                     yield return new IssueTemplateNoSinger(this).Create(lyric);
 
@@ -43,17 +39,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
         {
             public IssueTemplateNotFillLanguage(ICheck check)
                 : base(check, IssueType.Problem, "Lyric must have assign language.")
-            {
-            }
-
-            public Issue Create(Lyric lyric)
-                => new(lyric, this);
-        }
-
-        public class IssueTemplateNoText : IssueTemplate
-        {
-            public IssueTemplateNoText(ICheck check)
-                : base(check, IssueType.Problem, "Lyric must have text.")
             {
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
@@ -2,29 +2,24 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckLyricLanguage : ICheck
+    public class CheckLyricLanguage : CheckHitObjectProperty<Lyric>
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid language.");
+        protected override string Description => "Lyrics with invalid language.";
 
-        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateNotFillLanguage(this),
         };
 
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        public override IEnumerable<Issue> Check(Lyric lyric)
         {
-            foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
-            {
-                if (lyric.Language == null)
-                    yield return new IssueTemplateNotFillLanguage(this).Create(lyric);
-            }
+            if (lyric.Language == null)
+                yield return new IssueTemplateNotFillLanguage(this).Create(lyric);
         }
 
         public class IssueTemplateNotFillLanguage : IssueTemplate

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
@@ -9,32 +9,28 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckInvalidPropertyLyrics : ICheck
+    public class CheckLyricLanguage : ICheck
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid property.");
+        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid language.");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
-            new IssueTemplateNoSinger(this),
+            new IssueTemplateNotFillLanguage(this),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
             foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
             {
-                // todo : check lyric layout.
-
-                if (!lyric.Singers.Any())
-                    yield return new IssueTemplateNoSinger(this).Create(lyric);
-
-                // todo : check is singer in singer list.
+                if (lyric.Language == null)
+                    yield return new IssueTemplateNotFillLanguage(this).Create(lyric);
             }
         }
 
-        public class IssueTemplateNoSinger : IssueTemplate
+        public class IssueTemplateNotFillLanguage : IssueTemplate
         {
-            public IssueTemplateNoSinger(ICheck check)
-                : base(check, IssueType.Problem, "Lyric must have at least one singer.")
+            public IssueTemplateNotFillLanguage(ICheck check)
+                : base(check, IssueType.Problem, "Lyric must have assign language.")
             {
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricSinger.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricSinger.cs
@@ -3,28 +3,24 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckLyricSinger : ICheck
+    public class CheckLyricSinger : CheckHitObjectProperty<Lyric>
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid property.");
+        protected override string Description => "Lyric with invalid singer.";
 
-        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateNoSinger(this),
         };
 
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        public override IEnumerable<Issue> Check(Lyric lyric)
         {
-            foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
-            {
-                if (!lyric.Singers.Any())
-                    yield return new IssueTemplateNoSinger(this).Create(lyric);
-            }
+            if (!lyric.Singers.Any())
+                yield return new IssueTemplateNoSinger(this).Create(lyric);
         }
 
         public class IssueTemplateNoSinger : IssueTemplate

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricSinger.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricSinger.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckInvalidPropertyLyrics : ICheck
+    public class CheckLyricSinger : ICheck
     {
         public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid property.");
 
@@ -22,12 +22,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
         {
             foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
             {
-                // todo : check lyric layout.
-
                 if (!lyric.Singers.Any())
                     yield return new IssueTemplateNoSinger(this).Create(lyric);
-
-                // todo : check is singer in singer list.
             }
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricText.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks
+{
+    public class CheckLyricText : ICheck
+    {
+        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid text.");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateNoText(this),
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
+            {
+                if (string.IsNullOrWhiteSpace(lyric.Text))
+                    yield return new IssueTemplateNoText(this).Create(lyric);
+            }
+        }
+
+        public class IssueTemplateNoText : IssueTemplate
+        {
+            public IssueTemplateNoText(ICheck check)
+                : base(check, IssueType.Problem, "Lyric must have text.")
+            {
+            }
+
+            public Issue Create(Lyric lyric)
+                => new(lyric, this);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricText.cs
@@ -2,29 +2,24 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckLyricText : ICheck
+    public class CheckLyricText : CheckHitObjectProperty<Lyric>
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid text.");
+        protected override string Description => "Lyric with invalid text.";
 
-        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateNoText(this),
         };
 
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        public override IEnumerable<Issue> Check(Lyric lyric)
         {
-            foreach (var lyric in context.Beatmap.HitObjects.OfType<Lyric>())
-            {
-                if (string.IsNullOrWhiteSpace(lyric.Text))
-                    yield return new IssueTemplateNoText(this).Create(lyric);
-            }
+            if (string.IsNullOrWhiteSpace(lyric.Text))
+                yield return new IssueTemplateNoText(this).Create(lyric);
         }
 
         public class IssueTemplateNoText : IssueTemplate

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricTranslate.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricTranslate.cs
@@ -15,9 +15,9 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckTranslate : ICheck
+    public class CheckLyricTranslate : ICheck
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Unfinished translate language.");
+        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid translations.");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             new CheckInvalidRubyRomajiLyrics(),
             new CheckInvalidTimeLyrics(),
             new CheckInvalidPropertyNotes(),
-            new CheckTranslate(),
+            new CheckLyricTranslate(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context) => checks.SelectMany(check => check.Run(context));

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
     {
         private readonly List<ICheck> checks = new()
         {
+            new CheckLyricText(),
+            new CheckLyricLanguage(),
             new CheckLyricSinger(),
             new CheckInvalidRubyRomajiLyrics(),
             new CheckInvalidTimeLyrics(),

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
     {
         private readonly List<ICheck> checks = new()
         {
-            new CheckInvalidPropertyLyrics(),
+            new CheckLyricSinger(),
             new CheckInvalidRubyRomajiLyrics(),
             new CheckInvalidTimeLyrics(),
             new CheckInvalidPropertyNotes(),

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Language/LanguageMissingSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Language/LanguageMissingSection.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Language
             bindableReports.BindCollectionChanged((_, _) =>
             {
                 var issues = bindableReports.Values.SelectMany(x => x);
-                table.Issues = issues.Where(x => x.Template is CheckInvalidPropertyLyrics.IssueTemplateNotFillLanguage);
+                table.Issues = issues.Where(x => x.Template is CheckLyricLanguage.IssueTemplateNotFillLanguage);
             }, true);
         }
 


### PR DESCRIPTION
Part of issue #1679.

What's done in this RP:
- Separate the checks
- Make the base class for the hit-object related checks.