### PR TITLE
Refactor the lyric translation.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
@@ -12,12 +12,12 @@ using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Beatmaps;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricTranslate;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapAvailableTranslates;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
     [TestFixture]
-    public class CheckLyricTranslateTest : BaseCheckTest<CheckLyricTranslate>
+    public class CheckBeatmapAvailableTranslatesTest : BaseCheckTest<CheckBeatmapAvailableTranslates>
     {
         [Test]
         public void TestNoLyricAndNoLanguage()

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTranslateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTranslateTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using J2N.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Objects;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckLyricTranslate;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
+{
+    public class CheckLyricTranslateTest : HitObjectCheckTest<Lyric, CheckLyricTranslate>
+    {
+        [TestCase("translate")]
+        [TestCase("k")] // not limit min size for now.
+        [TestCase("翻譯")] // not limit language.
+        public void TestCheckText(string text)
+        {
+            var lyric = new Lyric
+            {
+                Translates = new Dictionary<CultureInfo, string>
+                {
+                    { new CultureInfo("Ja-jp"), text }
+                }
+            };
+
+            AssertOk(lyric);
+        }
+
+        [TestCase(" ")] // but should not be empty or white space.
+        [TestCase("　")] // but should not be empty or white space.
+        [TestCase("")]
+        [TestCase(null)]
+        public void TestCheckInvalidText(string text)
+        {
+            var lyric = new Lyric
+            {
+                Translates = new Dictionary<CultureInfo, string>
+                {
+                    { new CultureInfo("Ja-jp"), text }
+                }
+            };
+
+            AssertNotOk<IssueTemplateLyricEmptyTranslate>(lyric);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
@@ -105,6 +105,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker
                     {
                         Config = config
                     },
+                    new CheckInvalidPropertyNotes(),
+                    new CheckBeatmapAvailableTranslates(),
                 };
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker
                 {
                     new CheckLyricText(),
                     new CheckLyricLanguage(),
+                    new CheckLyricTranslate(),
                     new CheckLyricSinger(),
                     new CheckInvalidRubyRomajiLyrics
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
@@ -15,7 +15,7 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckLyricTranslate : ICheck
+    public class CheckBeatmapAvailableTranslates : ICheck
     {
         public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid translations.");
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricLanguage.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
     public class CheckLyricLanguage : CheckHitObjectProperty<Lyric>
     {
-        protected override string Description => "Lyrics with invalid language.";
+        protected override string Description => "Lyric with invalid language.";
 
         public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricTranslate.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckLyricTranslate.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Globalization;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks
+{
+    public class CheckLyricTranslate : CheckHitObjectProperty<Lyric>
+    {
+        protected override string Description => "Lyric with invalid translations.";
+
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateLyricEmptyTranslate(this),
+        };
+
+        public override IEnumerable<Issue> Check(Lyric lyric)
+        {
+            var translates = lyric.Translates;
+
+            foreach ((var language, string translate) in translates)
+            {
+                if (string.IsNullOrWhiteSpace(translate))
+                    yield return new IssueTemplateLyricEmptyTranslate(this).Create(lyric, language);
+            }
+        }
+
+        public class IssueTemplateLyricEmptyTranslate : IssueTemplate
+        {
+            public IssueTemplateLyricEmptyTranslate(ICheck check)
+                : base(check, IssueType.Problem, "Seems some translation string is empty.")
+            {
+            }
+
+            public Issue Create(Lyric lyric, CultureInfo language)
+                => new(lyric, this, language);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             new CheckLyricText(),
             new CheckLyricLanguage(),
             new CheckLyricSinger(),
+            new CheckLyricTranslate(),
             new CheckInvalidRubyRomajiLyrics(),
             new CheckInvalidTimeLyrics(),
             new CheckInvalidPropertyNotes(),

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             new CheckInvalidRubyRomajiLyrics(),
             new CheckInvalidTimeLyrics(),
             new CheckInvalidPropertyNotes(),
-            new CheckLyricTranslate(),
+            new CheckBeatmapAvailableTranslates(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context) => checks.SelectMany(check => check.Run(context));


### PR DESCRIPTION
Mark as part of issue #1679.
What's done in this PR:
- Rename the check for beatmap.
- Implement the check for checking the translation text.