### PR TITLE
Add some missing note checks.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
 using osu.Game.Rulesets.Objects;
 using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckNoteReferenceLyric;
 
@@ -12,13 +13,22 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
     [TestFixture]
     public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteReferenceLyric>
     {
-        [Test]
-        public void TestCheck()
+        [TestCase(0, new[] { "[0,start]:1000", "[3,end]:5000" })]
+        [TestCase(0, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        [TestCase(1, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        [TestCase(2, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        [TestCase(3, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        public void TestCheck(int referenceTimeTagIndex, string[] timeTags)
         {
-            var lyric = new Lyric();
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
             var note = new Note
             {
-                ReferenceLyric = lyric
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex
             };
 
             AssertOk(new HitObject[] { lyric, note });
@@ -38,13 +48,112 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
         [Test]
         public void TestCheckInvalidReferenceLyric()
         {
-            var lyric = new Lyric();
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[3,end]:5000" })
+            };
             var note = new Note
             {
-                ReferenceLyric = lyric // reference lyric should be in the beatmap.
+                ReferenceLyric = lyric, // reference lyric should be in the beatmap.
+                ReferenceTimeTagIndex = 0,
             };
 
             AssertNotOk<IssueTemplateInvalidReferenceLyric>(note);
+        }
+
+        [TestCase(0, new string[] { })]
+        [TestCase(0, new[] { "[0,start]:1000" })]
+        [TestCase(-1, new[] { "[0,start]:1000" })] // should not show other error if time-tag amount is not enough.
+        [TestCase(2, new[] { "[0,start]:1000" })]
+        public void TestCheckReferenceLyricHasLessThanTwoTimeTag(int referenceTimeTagIndex, string[] timeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+            var note = new Note
+            {
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex,
+            };
+
+            AssertNotOk<IssueTemplateReferenceLyricHasLessThanTwoTimeTag>(new HitObject[] { lyric, note });
+        }
+
+        [TestCase(-1, new[] { "[0,start]:1000", "[3,end]:5000" })]
+        [TestCase(-1, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        public void TestCheckMissingStartReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+            var note = new Note
+            {
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex
+            };
+
+            AssertNotOk<IssueTemplateMissingStartReferenceTimeTag>(new HitObject[] { lyric, note });
+        }
+
+        [TestCase(0, new[] { "[0,start]:", "[3,end]:5000" })]
+        [TestCase(0, new[] { "[0,start]:", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        [TestCase(1, new[] { "[0,start]:1000", "[1,start]:", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        public void TestCheckStartReferenceTimeTagMissingTime(int referenceTimeTagIndex, string[] timeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+            var note = new Note
+            {
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex
+            };
+
+            AssertNotOk<IssueTemplateStartReferenceTimeTagMissingTime>(new HitObject[] { lyric, note });
+        }
+
+        [TestCase(1, new[] { "[0,start]:1000", "[3,end]:5000" })]
+        [TestCase(4, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
+        public void TestCheckMissingEndReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+            var note = new Note
+            {
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex
+            };
+
+            AssertNotOk<IssueTemplateMissingEndReferenceTimeTag>(new HitObject[] { lyric, note });
+        }
+
+        [TestCase(0, new[] { "[0,start]:1000", "[3,end]:" })]
+        [TestCase(3, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:" })]
+        [TestCase(2, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:", "[3,end]:5000" })]
+        public void TestCheckEndReferenceTimeTagMissingTime(int referenceTimeTagIndex, string[] timeTags)
+        {
+            var lyric = new Lyric
+            {
+                Text = "カラオケ",
+                TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
+            };
+            var note = new Note
+            {
+                ReferenceLyric = lyric,
+                ReferenceTimeTagIndex = referenceTimeTagIndex
+            };
+
+            AssertNotOk<IssueTemplateEndReferenceTimeTagMissingTime>(new HitObject[] { lyric, note });
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteTextTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteTextTest.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Objects;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckNoteText;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
+{
+    public class CheckNoteTextTest : HitObjectCheckTest<Note, CheckNoteText>
+    {
+        [Test]
+        public void TestCheck()
+        {
+            var note = new Note
+            {
+                Text = "karaoke",
+                RubyText = null, // ruby text should be null or having the value.
+            };
+
+            AssertOk(new HitObject[] { note });
+        }
+
+        [TestCase(" ")] // but should not be empty or white space.
+        [TestCase("　")] // but should not be empty or white space.
+        [TestCase("")]
+        [TestCase(null)]
+        public void TestCheckNoText(string text)
+        {
+            var note = new Note
+            {
+                Text = text
+            };
+
+            AssertNotOk<IssueTemplateNoteNoText>(note);
+        }
+
+        [TestCase(" ")] // but should not be empty or white space.
+        [TestCase("　")] // but should not be empty or white space.
+        [TestCase("")]
+        public void TestCheckEmptyRubyText(string? rubyText)
+        {
+            var note = new Note
+            {
+                Text = "karaoke",
+                RubyText = rubyText
+            };
+
+            AssertNotOk<IssueTemplateNoteEmptyRubyText>(note);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checker/LyricCheckerManager.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checker
                     new CheckLyricSinger(),
                     new CheckLyricTranslate(),
                     new CheckNoteReferenceLyric(),
+                    new CheckNoteText(),
                     new CheckBeatmapAvailableTranslates(),
                 };
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteReferenceLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteReferenceLyric.cs
@@ -15,7 +15,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 
         public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
+            new IssueTemplateNullReferenceLyric(this),
             new IssueTemplateInvalidReferenceLyric(this),
+            new IssueTemplateReferenceLyricHasLessThanTwoTimeTag(this),
+            new IssueTemplateReferenceLyricHasLessThanTwoTimeTag(this),
+            new IssueTemplateMissingStartReferenceTimeTag(this),
+            new IssueTemplateStartReferenceTimeTagMissingTime(this),
+            new IssueTemplateMissingEndReferenceTimeTag(this),
+            new IssueTemplateEndReferenceTimeTagMissingTime(this),
         };
 
         protected override IEnumerable<Issue> Check(Note note)
@@ -31,10 +38,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
             foreach (var note in notes)
             {
                 if (note.ReferenceLyric == null)
+                {
                     yield return new IssueTemplateNullReferenceLyric(this).Create(note);
+
+                    continue;
+                }
 
                 if (note.ReferenceLyric != null && !lyrics.Contains(note.ReferenceLyric))
                     yield return new IssueTemplateInvalidReferenceLyric(this).Create(note);
+
+                if (note.ReferenceLyric?.TimeTags.Count < 2)
+                {
+                    yield return new IssueTemplateReferenceLyricHasLessThanTwoTimeTag(this).Create(note);
+
+                    continue;
+                }
+
+                var startTimeTag = note.StartReferenceTimeTag;
+                var endTimeTag = note.EndReferenceTimeTag;
+
+                if (startTimeTag == null)
+                    yield return new IssueTemplateMissingStartReferenceTimeTag(this).Create(note);
+
+                if (startTimeTag != null && startTimeTag.Time == null)
+                    yield return new IssueTemplateStartReferenceTimeTagMissingTime(this).Create(note);
+
+                if (endTimeTag == null)
+                    yield return new IssueTemplateMissingEndReferenceTimeTag(this).Create(note);
+
+                if (endTimeTag != null && endTimeTag.Time == null)
+                    yield return new IssueTemplateEndReferenceTimeTagMissingTime(this).Create(note);
             }
         }
 
@@ -53,6 +86,61 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
         {
             public IssueTemplateInvalidReferenceLyric(ICheck check)
                 : base(check, IssueType.Problem, "Note's reference lyric must in the beatmap.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateReferenceLyricHasLessThanTwoTimeTag : IssueTemplate
+        {
+            public IssueTemplateReferenceLyricHasLessThanTwoTimeTag(ICheck check)
+                : base(check, IssueType.Problem, "Note's reference lyric must have at least two time-tags.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateMissingStartReferenceTimeTag : IssueTemplate
+        {
+            public IssueTemplateMissingStartReferenceTimeTag(ICheck check)
+                : base(check, IssueType.Problem, "Note's start reference time-tag is missing.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateStartReferenceTimeTagMissingTime : IssueTemplate
+        {
+            public IssueTemplateStartReferenceTimeTagMissingTime(ICheck check)
+                : base(check, IssueType.Problem, "Note's start reference time-tag is found but missing time.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateMissingEndReferenceTimeTag : IssueTemplate
+        {
+            public IssueTemplateMissingEndReferenceTimeTag(ICheck check)
+                : base(check, IssueType.Problem, "Note's end reference time-tag is missing.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateEndReferenceTimeTagMissingTime : IssueTemplate
+        {
+            public IssueTemplateEndReferenceTimeTagMissingTime(ICheck check)
+                : base(check, IssueType.Problem, "Note's end reference time-tag is found but missing time.")
             {
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteText.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks
+{
+    public class CheckNoteText : CheckHitObjectProperty<Note>
+    {
+        protected override string Description => "Note with invalid text.";
+
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateNoteNoText(this),
+        };
+
+        protected override IEnumerable<Issue> Check(Note note)
+        {
+            if (string.IsNullOrWhiteSpace(note.Text))
+                yield return new IssueTemplateNoteNoText(this).Create(note);
+
+            if (note.RubyText != null && string.IsNullOrWhiteSpace(note.RubyText))
+                yield return new IssueTemplateNoteEmptyRubyText(this).Create(note);
+        }
+
+        public class IssueTemplateNoteNoText : IssueTemplate
+        {
+            public IssueTemplateNoteNoText(ICheck check)
+                : base(check, IssueType.Problem, "Note must have text.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+
+        public class IssueTemplateNoteEmptyRubyText : IssueTemplate
+        {
+            public IssueTemplateNoteEmptyRubyText(ICheck check)
+                : base(check, IssueType.Error, "Note's ruby text should be null or has the value.")
+            {
+            }
+
+            public Issue Create(Note note)
+                => new(note, this);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             new CheckLyricSinger(),
             new CheckLyricTranslate(),
             new CheckNoteReferenceLyric(),
+            new CheckNoteText(),
             new CheckBeatmapAvailableTranslates(),
         };
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -155,6 +155,10 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             set => ReferenceTimeTagIndexBindable.Value = value;
         }
 
+        public TimeTag? StartReferenceTimeTag => ReferenceLyric?.TimeTags.ElementAtOrDefault(ReferenceTimeTagIndex);
+
+        public TimeTag? EndReferenceTimeTag => ReferenceLyric?.TimeTags.ElementAtOrDefault(ReferenceTimeTagIndex + 1);
+
         public Note()
         {
             ReferenceLyricBindable.ValueChanged += e =>
@@ -176,15 +180,15 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
             void syncStartTimeAndDurationFromTimeTag()
             {
-                var currentTimeTag = ReferenceLyric?.TimeTags.ElementAtOrDefault(ReferenceTimeTagIndex);
-                var nextTimeTag = ReferenceLyric?.TimeTags.ElementAtOrDefault(ReferenceTimeTagIndex + 1);
+                var startTimeTag = StartReferenceTimeTag;
+                var endTimeTag = EndReferenceTimeTag;
 
-                double startTime = currentTimeTag?.Time ?? 0;
-                double endTime = nextTimeTag?.Time ?? 0;
+                double startTime = startTimeTag?.Time ?? 0;
+                double endTime = endTimeTag?.Time ?? 0;
                 double duration = endTime - startTime;
 
-                StartTimeBindable.Value = currentTimeTag == null ? 0 : startTime + StartTimeOffset;
-                DurationBindable.Value = nextTimeTag == null ? 0 : Math.Max(duration - StartTimeOffset + EndTimeOffset, 0);
+                StartTimeBindable.Value = startTimeTag == null ? 0 : startTime + StartTimeOffset;
+                DurationBindable.Value = endTimeTag == null ? 0 : Math.Max(duration - StartTimeOffset + EndTimeOffset, 0);
             }
         }
 


### PR DESCRIPTION
Part of issue #1679.

Add more checks about those properties in the note:
- Text(should not be empty)
- RubyText (should be empty or having the text)
- ReferenceTimeTagIndex (should be able to get the referenced time-tag and should have the time.)