### PR TITLE
Refactor the caret state for handling more generic event.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/States/LyricCaretStateTest.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
             changeMode(LyricEditorMode.View);
 
             var targetLyric = getLyricFromBeatmap(1);
-            movingCaretByLyric(new NavigateCaretPosition(targetLyric));
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric, CaretGenerateType.TargetLyric));
 
             // should not change the caret position if algorithm is null.
             assertCaretPosition(Assert.IsNull);
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
             changeMode(LyricEditorMode.Singer);
 
             var targetLyric = getLyricFromBeatmap(1);
-            movingCaretByLyric(new NavigateCaretPosition(targetLyric));
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric, CaretGenerateType.TargetLyric));
 
             // yes, should change the position if contains algorithm.
             assertCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);
@@ -207,7 +207,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
             var targetLyric = getLyricFromBeatmap(1);
 
             // should throw the exception if caret position type not match.
-            movingCaretByLyric(new NavigateCaretPosition(targetLyric), false);
+            movingCaretByLyric(new NavigateCaretPosition(targetLyric, CaretGenerateType.TargetLyric), false);
         }
 
         #endregion
@@ -220,7 +220,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
             changeMode(LyricEditorMode.View);
 
             var targetLyric = getLyricFromBeatmap(1);
-            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric));
+            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric, CaretGenerateType.TargetLyric));
 
             // should not change the caret position if algorithm is null.
             assertCaretPosition(Assert.IsNull);
@@ -234,7 +234,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.States
 
             var firstLyric = getLyricFromBeatmap(0);
             var targetLyric = getLyricFromBeatmap(1);
-            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric));
+            movingHoverCaretByLyric(new NavigateCaretPosition(targetLyric, CaretGenerateType.TargetLyric));
 
             // because switch to the singer lyric, so current caret position will at the first lyric.
             assertCaretPosition(Assert.IsInstanceOf<NavigateCaretPosition>);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/Carets/DrawableLyricInputCaret.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics.Carets
                 // calculate new caret position.
                 var lyric = caretPosition.Value.Lyric;
                 int index = caretPosition.Value.Index + offset;
-                caretPosition = new TypingCaretPosition(lyric, index);
+                caretPosition = new TypingCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
                 lyricCaretState.MoveCaretToTargetPosition(caretPosition);
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -124,17 +124,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (!lyricCaretState.CaretEnabled)
-                return false;
-
-            // place hover caret to target position.
-            var position = lyricCaretState.BindableHoverCaretPosition.Value;
-            if (position == null)
-                return false;
-
-            lyricCaretState.MoveCaretToTargetPosition(position);
-
-            return true;
+            return lyricCaretState.ConfirmHoverCaretPosition();
         }
 
         private void triggerWritableVersionChanged()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -114,12 +114,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
+            base.OnHoverLost(e);
+
             if (!lyricCaretState.CaretEnabled)
                 return;
 
             // lost hover caret and time-tag caret
             lyricCaretState.ClearHoverCaretPosition();
-            base.OnHoverLost(e);
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -86,26 +86,26 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Components.Lyrics
             {
                 case CuttingCaretPosition:
                     int cuttingLyricStringIndex = Math.Clamp(TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position)), 0, lyric.Text.Length - 1);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new CuttingCaretPosition(lyric, cuttingLyricStringIndex));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new CuttingCaretPosition(lyric, cuttingLyricStringIndex, CaretGenerateType.TargetLyric));
                     break;
 
                 case TypingCaretPosition:
                     int typingStringIndex = TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position));
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TypingCaretPosition(lyric, typingStringIndex));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TypingCaretPosition(lyric, typingStringIndex, CaretGenerateType.TargetLyric));
                     break;
 
                 case NavigateCaretPosition:
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(lyric));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new NavigateCaretPosition(lyric, CaretGenerateType.TargetLyric));
                     break;
 
                 case TimeTagIndexCaretPosition:
                     var textIndex = karaokeSpriteText.GetHoverIndex(position);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(lyric, textIndex));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagIndexCaretPosition(lyric, textIndex, CaretGenerateType.TargetLyric));
                     break;
 
                 case TimeTagCaretPosition:
                     var timeTag = karaokeSpriteText.GetHoverTimeTag(position);
-                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagCaretPosition(lyric, timeTag));
+                    lyricCaretState.MoveHoverCaretToTargetPosition(new TimeTagCaretPosition(lyric, timeTag, CaretGenerateType.TargetLyric));
                     break;
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor.RecordingTi
 
             protected override bool OnClick(ClickEvent e)
             {
-                lyricCaretState.MoveCaretToTargetPosition(new TimeTagCaretPosition(lyric, timeTag));
+                lyricCaretState.MoveCaretToTargetPosition(new TimeTagCaretPosition(lyric, timeTag, CaretGenerateType.TargetLyric));
 
                 return base.OnClick(e);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/TimeTags/CreateTimeTagActionReceiver.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/TimeTags/CreateTimeTagActionReceiver.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.TimeTags
                         return false;
 
                     var newTimeTag = lyricTimeTagsChangeHandler.Shifting(timeTagCaretPosition.TimeTag, tuple.Item1, tuple.Item2);
-                    lyricCaretState.MoveCaretToTargetPosition(new TimeTagCaretPosition(timeTagCaretPosition.Lyric, newTimeTag));
+                    lyricCaretState.MoveCaretToTargetPosition(new TimeTagCaretPosition(timeTagCaretPosition.Lyric, newTimeTag, CaretGenerateType.TargetLyric));
                     return true;
             }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         void ClearHoverCaretPosition();
 
-        bool CaretPositionMovable(ICaretPosition position);
-
         void SyncSelectedHitObjectWithCaret();
 
         bool CaretEnabled { get; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         void MoveHoverCaretToTargetPosition(ICaretPosition position);
 
+        bool ConfirmHoverCaretPosition();
+
         void ClearHoverCaretPosition();
 
         void SyncSelectedHitObjectWithCaret();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/ILyricCaretState.cs
@@ -19,15 +19,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         ICaretPosition? GetCaretPositionByAction(MovingCaretAction action);
 
-        void MoveCaretToTargetPosition(Lyric lyric);
+        bool MoveCaretToTargetPosition(Lyric lyric);
 
-        void MoveCaretToTargetPosition(ICaretPosition position);
+        bool MoveCaretToTargetPosition(ICaretPosition position);
 
-        void MoveHoverCaretToTargetPosition(ICaretPosition position);
+        bool MoveHoverCaretToTargetPosition(ICaretPosition position);
 
         bool ConfirmHoverCaretPosition();
 
-        void ClearHoverCaretPosition();
+        bool ClearHoverCaretPosition();
 
         void SyncSelectedHitObjectWithCaret();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -306,6 +306,21 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             bindableHoverCaretPosition.Value = position;
         }
 
+        public bool ConfirmHoverCaretPosition()
+        {
+            if (!CaretEnabled)
+                return false;
+
+            // place hover caret to target position.
+            var position = BindableHoverCaretPosition.Value;
+            if (position == null)
+                return false;
+
+            MoveCaretToTargetPosition(position);
+
+            return true;
+        }
+
         public void ClearHoverCaretPosition()
         {
             bindableHoverCaretPosition.Value = null;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -282,7 +283,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 throw new ArgumentNullException(nameof(position));
 
-            bool movable = CaretPositionMovable(position);
+            bool movable = caretPositionMovable(position);
 
             // stop moving the caret if forbidden by algorithm calculation.
             if (!movable)
@@ -299,7 +300,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 throw new ArgumentNullException(nameof(position));
 
-            if (!CaretPositionMovable(position))
+            if (!caretPositionMovable(position))
                 return;
 
             bindableHoverCaretPosition.Value = position;
@@ -310,7 +311,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             bindableHoverCaretPosition.Value = null;
         }
 
-        public bool CaretPositionMovable(ICaretPosition position)
+        private bool caretPositionMovable(ICaretPosition position)
             => algorithm?.PositionMovable(position) ?? false;
 
         public void SyncSelectedHitObjectWithCaret()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -311,9 +311,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
         public bool ConfirmHoverCaretPosition()
         {
-            if (!CaretEnabled)
-                return false;
-
             // place hover caret to target position.
             var position = BindableHoverCaretPosition.Value;
             if (position == null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -191,8 +191,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 return false;
 
-            MoveCaretToTargetPosition(position);
-            return true;
+            return MoveCaretToTargetPosition(position);
         }
 
         public ICaretPosition? GetCaretPositionByAction(MovingCaretAction action)
@@ -266,19 +265,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             }
         }
 
-        public void MoveCaretToTargetPosition(Lyric lyric)
+        public bool MoveCaretToTargetPosition(Lyric lyric)
         {
             if (lyric == null)
                 throw new ArgumentNullException(nameof(lyric));
 
             var caretPosition = algorithm?.MoveToTargetLyric(lyric);
             if (caretPosition == null)
-                return;
+                return false;
 
-            MoveCaretToTargetPosition(caretPosition);
+            return MoveCaretToTargetPosition(caretPosition);
         }
 
-        public void MoveCaretToTargetPosition(ICaretPosition position)
+        public bool MoveCaretToTargetPosition(ICaretPosition position)
         {
             if (position == null)
                 throw new ArgumentNullException(nameof(position));
@@ -287,23 +286,27 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             // stop moving the caret if forbidden by algorithm calculation.
             if (!movable)
-                return;
+                return false;
 
             bindableHoverCaretPosition.Value = null;
             bindableCaretPosition.Value = position;
 
             postProcess();
+
+            return true;
         }
 
-        public void MoveHoverCaretToTargetPosition(ICaretPosition position)
+        public bool MoveHoverCaretToTargetPosition(ICaretPosition position)
         {
             if (position == null)
                 throw new ArgumentNullException(nameof(position));
 
             if (!caretPositionMovable(position))
-                return;
+                return false;
 
             bindableHoverCaretPosition.Value = position;
+
+            return true;
         }
 
         public bool ConfirmHoverCaretPosition()
@@ -316,14 +319,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 return false;
 
-            MoveCaretToTargetPosition(position);
-
-            return true;
+            return MoveCaretToTargetPosition(position);
         }
 
-        public void ClearHoverCaretPosition()
+        public bool ClearHoverCaretPosition()
         {
             bindableHoverCaretPosition.Value = null;
+
+            return true;
         }
 
         private bool caretPositionMovable(ICaretPosition position)


### PR DESCRIPTION
Maybe it's the preparation of issue #1696.
~~We should make sure that all the caret create outside of the caret algorithm should have the right generated type.~~
Cannot add the generate type check because will cause error if use the keyboard to change the caret.
Need to adjust the code.

This PR is focused on:
- Making caret create outside of the caret algorithm should have the right generated type.
- Handling more generic event in the caret state.
- Other small refactor.