### PR TITLE
Implement move to target for algorithm.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
@@ -62,5 +62,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             AssertEqual(expected, actual);
             CheckCaretGenerateType(CaretGenerateType.Action, actual);
         }
+
+        protected void TestMoveToTargetLyric<TIndex>(Lyric[] lyrics, Lyric lyric, TIndex? index, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        {
+            var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
+            if (algorithm == null)
+                throw new ArgumentNullException();
+
+            invokeAlgorithm?.Invoke(algorithm);
+
+            var actual = algorithm.MoveToTargetLyric(lyric, index) as TCaret?;
+            AssertEqual(expected, actual);
+            CheckCaretGenerateType(CaretGenerateType.TargetLyric, actual);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -89,12 +89,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToLastLyric(lyrics, expected);
         }
 
-        [TestCase(nameof(singleLyric), 0)]
-        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex)
+        [TestCase(nameof(singleLyric), 0, 1)]
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
-            var lyric = lyrics[expectedLyricIndex];
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, 1);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedTextIndex);
 
             // Check move to target position.
             TestMoveToTargetLyric(lyrics, lyric, expected);
@@ -148,6 +148,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             // Check is movable
             TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 1, 1)]
+        [TestCase(nameof(singleLyric), 0, 3, 3)]
+        [TestCase(nameof(singleLyric), 0, 0, null)] // will check the invalid case.
+        [TestCase(nameof(singleLyric), 0, 4, null)]
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int textIndex, int? expectedTextIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedTextIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, textIndex, expected);
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NoteCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/NoteCaretPositionAlgorithmTest.cs
@@ -141,6 +141,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToLastIndex(lyrics, lyric, expected);
         }
 
+        [TestCase(nameof(singleLyric), 0, null, null)]
+        public void TestMoveToTarget(string sourceName, int expectedLyricIndex, int? expectedNoteIndex, int? noteIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[expectedLyricIndex];
+            var note = noteIndex != null ? new Note { ReferenceLyric = lyric } : null;
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, noteIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, note, expected);
+        }
+
         #endregion
 
         protected override void AssertEqual(NoteCaretPosition expected, NoteCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/RomajiTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/RomajiTagCaretPositionAlgorithmTest.cs
@@ -83,11 +83,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
         [TestCase(nameof(singleLyric), 0, 0)]
         [TestCase(nameof(singleLyricWithNoRomaji), 0, null)]
-        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex, int? romajiIndex)
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int? expectedRomajiIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
-            var lyric = lyrics[expectedLyricIndex];
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, romajiIndex);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedRomajiIndex);
 
             // Check move to target position.
             TestMoveToTargetLyric(lyrics, lyric, expected);
@@ -141,6 +141,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             // Check is movable
             TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 0, 0)]
+        [TestCase(nameof(singleLyric), 0, 3, 3)]
+        [TestCase(nameof(singleLyricWithNoRomaji), 0, -1, null)] // will check the invalid case.
+        [TestCase(nameof(singleLyricWithNoRomaji), 0, 4, null)]
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int romajiIndex, int? expectedRomajiIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var romaji = lyric.RomajiTags.ElementAtOrDefault(romajiIndex);
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedRomajiIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, romaji, expected);
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/RubyTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/RubyTagCaretPositionAlgorithmTest.cs
@@ -83,11 +83,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
         [TestCase(nameof(singleLyric), 0, 0)]
         [TestCase(nameof(singleLyricWithNoRuby), 0, null)]
-        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex, int? rubyIndex)
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int? rubyIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
-            var lyric = lyrics[expectedLyricIndex];
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, rubyIndex);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, rubyIndex);
 
             // Check move to target position.
             TestMoveToTargetLyric(lyrics, lyric, expected);
@@ -141,6 +141,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             // Check is movable
             TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 0, 0)]
+        [TestCase(nameof(singleLyric), 0, 3, 3)]
+        [TestCase(nameof(singleLyricWithNoRuby), 0, -1, null)] // will check the invalid case.
+        [TestCase(nameof(singleLyricWithNoRuby), 0, 4, null)]
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int rubyIndex, int? expectedRubyIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var ruby = lyric.RubyTags.ElementAtOrDefault(rubyIndex);
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedRubyIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, ruby, expected);
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -199,6 +199,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
             TestMoveToLastIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
         }
 
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0, 0)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4, 0, 4)]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, -1, null, null)] // will check the invalid case.
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 5, null, null)]
+        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int timeTagIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var timeTag = lyric.TimeTags.ElementAtOrDefault(timeTagIndex);
+            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, timeTag, expected, algorithms => algorithms.Mode = mode);
+        }
+
         #endregion
 
         protected override void AssertEqual(TimeTagCaretPosition expected, TimeTagCaretPosition actual)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithmTest.cs
@@ -110,11 +110,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyStartTag, 0, "[0,start]")]
         [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.OnlyEndTag, 0, "[0,end]")]
-        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int expectedLyricIndex, string? expectedTextIndex)
+        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string? expectedTextIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
-            var lyric = lyrics[expectedLyricIndex];
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTextIndex);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedTextIndex);
 
             // Check move to target position.
             TestMoveToTargetLyric(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
@@ -188,6 +188,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             // Check is movable
             TestMoveToLastIndex(lyrics, lyric, expected, algorithms => algorithms.Mode = mode);
+        }
+
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[0,start]", "[0,start]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[3,end]", "[3,end]")]
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[-1,end]", null)] // will check the invalid case.
+        [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, "[4,start]", null)]
+        public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, string textIndexText, string? expectedTextIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var textIndex = TestCaseTagHelper.ParseTextIndex(textIndexText);
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedTextIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, textIndex, expected, algorithms => algorithms.Mode = mode);
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -89,11 +89,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
         [TestCase(nameof(singleLyric), 0, 0)]
         [TestCase(nameof(singleLyricWithNoText), 0, 0)]
-        public void TestMoveToTargetLyric(string sourceName, int expectedLyricIndex, int? expectedIndex)
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int? expectedIndex)
         {
             var lyrics = GetLyricsByMethodName(sourceName);
-            var lyric = lyrics[expectedLyricIndex];
-            var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedIndex);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedIndex);
 
             // Check move to target position.
             TestMoveToTargetLyric(lyrics, lyric, expected);
@@ -151,6 +151,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             // Check is movable
             TestMoveToLastIndex(lyrics, lyric, expected);
+        }
+
+        [TestCase(nameof(singleLyric), 0, 0, 0)]
+        [TestCase(nameof(singleLyric), 0, 4, 4)]
+        [TestCase(nameof(singleLyric), 0, -1, null)] // will check the invalid case.
+        [TestCase(nameof(singleLyric), 0, 5, null)]
+        public void TestMoveToTargetLyric(string sourceName, int lyricIndex, int textIndex, int? expectedTextIndex)
+        {
+            var lyrics = GetLyricsByMethodName(sourceName);
+            var lyric = lyrics[lyricIndex];
+            var expected = createExpectedCaretPosition(lyrics, lyricIndex, expectedTextIndex);
+
+            // Check move to target position.
+            TestMoveToTargetLyric(lyrics, lyric, textIndex, expected);
         }
 
         #endregion

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -14,5 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         IIndexCaretPosition? MoveToFirstIndex(Lyric lyric);
 
         IIndexCaretPosition? MoveToLastIndex(Lyric lyric);
+
+        IIndexCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
@@ -21,6 +22,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         protected abstract TCaretPosition? MoveToFirstIndex(Lyric lyric);
 
         protected abstract TCaretPosition? MoveToLastIndex(Lyric lyric);
+
+        protected abstract TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index);
 
         public IIndexCaretPosition? MoveToPreviousIndex(IIndexCaretPosition currentPosition)
         {
@@ -64,6 +67,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             var movedCaretPosition = MoveToLastIndex(lyric);
             if (movedCaretPosition != null)
                 Validate(movedCaretPosition.Value);
+
+            return movedCaretPosition;
+        }
+
+        IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            var movedCaretPosition = MoveToTargetLyric(lyric, index);
+
+            if (movedCaretPosition == null)
+                return movedCaretPosition;
+
+            if (!PositionMovable(movedCaretPosition))
+                return null;
+
+            Validate(movedCaretPosition.Value);
+            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.TargetLyric);
 
             return movedCaretPosition;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NoteCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/NoteCaretPositionAlgorithm.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -69,10 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         }
 
         protected override NoteCaretPosition? MoveToTargetLyric(Lyric lyric)
-        {
-            // todo: get the first note.
-            return new NoteCaretPosition(lyric, null, CaretGenerateType.TargetLyric);
-        }
+            => MoveToTargetLyric<Note?>(lyric, null);
 
         protected override NoteCaretPosition? MoveToPreviousIndex(NoteCaretPosition currentPosition)
         {
@@ -92,6 +90,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         protected override NoteCaretPosition? MoveToLastIndex(Lyric lyric)
         {
             return null;
+        }
+
+        protected override NoteCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            if (index is null)
+                return new NoteCaretPosition(lyric, default, CaretGenerateType.TargetLyric);
+
+            if (index is not Note note)
+                throw new InvalidCastException();
+
+            return new NoteCaretPosition(lyric, note, CaretGenerateType.TargetLyric);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextCaretPositionAlgorithm.cs
@@ -66,7 +66,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             return CreateCaretPosition(lyric, GetMaxIndex(lyric.Text));
         }
 
-        protected sealed override TCaretPosition? MoveToTargetLyric(Lyric lyric) => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
+        protected sealed override TCaretPosition? MoveToTargetLyric(Lyric lyric)
+            => MoveToTargetLyric(lyric, GetMinIndex(lyric.Text));
 
         protected sealed override TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition)
         {
@@ -104,6 +105,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             int index = GetMaxIndex(lyric.Text);
 
             return CreateCaretPosition(lyric, index);
+        }
+
+        protected override TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            if (index is not int value)
+                throw new InvalidCastException();
+
+            return CreateCaretPosition(lyric, value, CaretGenerateType.TargetLyric);
         }
 
         private bool lyricMovable(Lyric lyric)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TextTagCaretPositionAlgorithm.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -80,7 +81,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         {
             var textTag = GetTextTagsByLyric(lyric).FirstOrDefault();
 
-            return GenerateCaretPosition(lyric, textTag, CaretGenerateType.TargetLyric);
+            return MoveToTargetLyric(lyric, textTag);
         }
 
         protected sealed override TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition)
@@ -101,6 +102,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         protected sealed override TCaretPosition? MoveToLastIndex(Lyric lyric)
         {
             return null;
+        }
+
+        protected override TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            if (index is null)
+                return GenerateCaretPosition(lyric, default, CaretGenerateType.TargetLyric);
+
+            if (index is not TTextTag textTag)
+                throw new InvalidCastException();
+
+            return GenerateCaretPosition(lyric, textTag, CaretGenerateType.TargetLyric);
         }
 
         protected abstract TTextTag? GetTextTagByCaret(TCaretPosition position);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -104,8 +104,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         {
             var targetTimeTag = lyric.TimeTags.FirstOrDefault(timeTagMovable);
 
-            // should not move to lyric if contains no time-tag.
-            return targetTimeTag == null ? null : new TimeTagCaretPosition(lyric, targetTimeTag, CaretGenerateType.TargetLyric);
+            return MoveToTargetLyric(lyric, targetTimeTag);
         }
 
         protected override TimeTagCaretPosition? MoveToPreviousIndex(TimeTagCaretPosition currentPosition)
@@ -154,6 +153,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveToPreviousIndex(caret);
 
             return caret;
+        }
+
+        protected override TimeTagCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            // should not move to lyric if contains no time-tag.
+            if (index is null)
+                return null;
+
+            if (index is not TimeTag timeTag)
+                throw new InvalidCastException();
+
+            return new TimeTagCaretPosition(lyric, timeTag, CaretGenerateType.TargetLyric);
         }
 
         private bool timeTagMovable(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
         protected override TimeTagIndexCaretPosition? MoveToTargetLyric(Lyric lyric)
         {
             var index = new TextIndex(0, suitableState(TextIndex.IndexState.Start));
-            return new TimeTagIndexCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
+            return MoveToTargetLyric(lyric, index);
         }
 
         protected override TimeTagIndexCaretPosition? MoveToPreviousIndex(TimeTagIndexCaretPosition currentPosition)
@@ -145,6 +145,14 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
                 return MoveToPreviousIndex(caret);
 
             return caret;
+        }
+
+        protected override TimeTagIndexCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+        {
+            if (index is not TextIndex textIndex)
+                throw new InvalidCastException();
+
+            return new TimeTagIndexCaretPosition(lyric, textIndex, CaretGenerateType.TargetLyric);
         }
 
         private bool textIndexMovable(TextIndex textIndex)


### PR DESCRIPTION
Implement property #1704
It should be better to make create caret position instance inside the algorithm.
And as if we have the `MoveToTargetLyric(lyric)` in the  `CaretPositionAlgorithm<T>`, maybe we can have the same interface for the `IndexCaretPositionAlgorithm<T>`.

And note that if we have something like `XXXCaretPosition(Lyric, index1, index2)` in the future, we need to convert to the  `XXXCaretPosition(Lyric, index1_2)`