### PR TITLE
Make position movable protected.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -20,7 +20,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Lyrics.CaretPosition.Algorithms
 
             invokeAlgorithm?.Invoke(algorithm);
 
-            bool actual = algorithm.PositionMovable(caret);
+            // because we made the position movable into the protected, so use another way to test it.
+            var method = algorithm.GetType().GetMethod("PositionMovable", BindingFlags.Instance | BindingFlags.NonPublic);
+            object? result = method?.Invoke(algorithm, new object[] { caret });
+            if (result is not bool actual)
+                throw new InvalidCastException();
+
             Assert.AreEqual(expected, actual);
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -31,14 +31,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 
         protected abstract TCaretPosition? MoveToTargetLyric(Lyric lyric);
 
-        public bool PositionMovable(ICaretPosition position)
-        {
-            if (position is not TCaretPosition tCaretPosition)
-                throw new InvalidCastException(nameof(position));
-
-            return PositionMovable(tCaretPosition);
-        }
-
         public ICaretPosition? MoveToPreviousLyric(ICaretPosition currentPosition)
         {
             if (currentPosition is not TCaretPosition tCaretPosition)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -39,13 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Validate(tCaretPosition);
 
             var movedCaretPosition = MoveToPreviousLyric(tCaretPosition);
-            if (movedCaretPosition == null)
-                return movedCaretPosition;
-
-            Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.Action);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         public ICaretPosition? MoveToNextLyric(ICaretPosition currentPosition)
@@ -56,48 +50,37 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Validate(tCaretPosition);
 
             var movedCaretPosition = MoveToNextLyric(tCaretPosition);
-            if (movedCaretPosition == null)
-                return movedCaretPosition;
-
-            Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.Action);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         ICaretPosition? ICaretPositionAlgorithm.MoveToFirstLyric()
         {
             var movedCaretPosition = MoveToFirstLyric();
-            if (movedCaretPosition == null)
-                return movedCaretPosition;
-
-            Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.Action);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         ICaretPosition? ICaretPositionAlgorithm.MoveToLastLyric()
         {
             var movedCaretPosition = MoveToLastLyric();
-            if (movedCaretPosition == null)
-                return movedCaretPosition;
-
-            Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.Action);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         ICaretPosition? ICaretPositionAlgorithm.MoveToTargetLyric(Lyric lyric)
         {
             var movedCaretPosition = MoveToTargetLyric(lyric);
+            return PostValidate(movedCaretPosition, CaretGenerateType.TargetLyric);
+        }
 
+        protected TCaretPosition? PostValidate(TCaretPosition? movedCaretPosition, CaretGenerateType generateType)
+        {
             if (movedCaretPosition == null)
-                return movedCaretPosition;
+                return null;
+
+            if (!PositionMovable(movedCaretPosition.Value))
+                return null;
 
             Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.TargetLyric);
+            Debug.Assert(movedCaretPosition.Value.GenerateType == generateType);
 
             return movedCaretPosition;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/ICaretPositionAlgorithm.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
 {
     public interface ICaretPositionAlgorithm
     {
-        bool PositionMovable(ICaretPosition position);
-
         ICaretPosition? MoveToPreviousLyric(ICaretPosition currentPosition);
 
         ICaretPosition? MoveToNextLyric(ICaretPosition currentPosition);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             if (movedCaretPosition == null)
                 return movedCaretPosition;
 
-            if (!PositionMovable(movedCaretPosition))
+            if (!PositionMovable(movedCaretPosition.Value))
                 return null;
 
             Validate(movedCaretPosition.Value);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
@@ -33,10 +32,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Validate(tCaretPosition);
 
             var movedCaretPosition = MoveToPreviousIndex(tCaretPosition);
-            if (movedCaretPosition != null)
-                Validate(movedCaretPosition.Value);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         public IIndexCaretPosition? MoveToNextIndex(IIndexCaretPosition currentPosition)
@@ -47,44 +43,25 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.CaretPosition.Algorithms
             Validate(tCaretPosition);
 
             var movedCaretPosition = MoveToNextIndex(tCaretPosition);
-            if (movedCaretPosition != null)
-                Validate(movedCaretPosition.Value);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToFirstIndex(Lyric lyric)
         {
             var movedCaretPosition = MoveToFirstIndex(lyric);
-            if (movedCaretPosition != null)
-                Validate(movedCaretPosition.Value);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToLastIndex(Lyric lyric)
         {
             var movedCaretPosition = MoveToLastIndex(lyric);
-            if (movedCaretPosition != null)
-                Validate(movedCaretPosition.Value);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.Action);
         }
 
         IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
         {
             var movedCaretPosition = MoveToTargetLyric(lyric, index);
-
-            if (movedCaretPosition == null)
-                return movedCaretPosition;
-
-            if (!PositionMovable(movedCaretPosition.Value))
-                return null;
-
-            Validate(movedCaretPosition.Value);
-            Debug.Assert(movedCaretPosition.Value.GenerateType == CaretGenerateType.TargetLyric);
-
-            return movedCaretPosition;
+            return PostValidate(movedCaretPosition, CaretGenerateType.TargetLyric);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -281,9 +281,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 return false;
 
-            if (!caretPositionMovable(position))
-                return false;
-
             bindableHoverCaretPosition.Value = null;
             bindableCaretPosition.Value = position;
 
@@ -312,9 +309,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
             if (position == null)
                 return false;
 
-            if (!caretPositionMovable(position))
-                return false;
-
             bindableHoverCaretPosition.Value = position;
 
             return true;
@@ -333,9 +327,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
 
             return true;
         }
-
-        private bool caretPositionMovable(ICaretPosition position)
-            => algorithm?.PositionMovable(position) ?? false;
 
         public void SyncSelectedHitObjectWithCaret()
         {


### PR DESCRIPTION
Implement part of #1704.
Because technically all the caret position generate from the algorithm should be movable, so there's no need to expose the check method.