### PR TITLE
Make edit state able to select target item.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/LabelledObjectFieldTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/LabelledObjectFieldTextBox.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
 {
     public abstract class LabelledObjectFieldTextBox<T> : LabelledTextBox where T : class
     {
-        protected readonly BindableList<T> SelectedItems = new();
+        protected readonly IBindableList<T> SelectedItems = new BindableList<T>();
 
         protected new ObjectFieldTextBox Component => (ObjectFieldTextBox)base.Component;
 
@@ -62,16 +63,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
             };
         }
 
-        protected void TriggerSelect()
-        {
-            // not trigger again if already focus.
-            if (SelectedItems.Contains(item) && SelectedItems.Count == 1)
-                return;
-
-            // trigger selected.
-            SelectedItems.Clear();
-            SelectedItems.Add(item);
-        }
+        protected abstract void TriggerSelect(T item);
 
         protected abstract string GetFieldValue(T item);
 
@@ -87,7 +79,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
             Selected = selected =>
             {
                 if (selected)
-                    TriggerSelect();
+                    TriggerSelect(item);
             }
         };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Notes/NoteEditPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Notes/NoteEditPropertySection.cs
@@ -108,10 +108,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Notes
             [Resolved]
             private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
 
+            [Resolved]
+            private IEditNoteModeState editNoteModeState { get; set; }
+
             public LabelledNoteTextTextBox(Note item)
                 : base(item)
             {
             }
+
+            protected override void TriggerSelect(Note item)
+                => editNoteModeState.Select(item);
 
             protected override string GetFieldValue(Note note)
                 => note.Text;
@@ -120,7 +126,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Notes
                 => notePropertyChangeHandler.ChangeText(value);
 
             [BackgroundDependencyLoader]
-            private void load(IEditNoteModeState editNoteModeState)
+            private void load()
             {
                 SelectedItems.BindTo(editNoteModeState.SelectedItems);
             }
@@ -131,10 +137,16 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Notes
             [Resolved]
             private INotePropertyChangeHandler notePropertyChangeHandler { get; set; }
 
+            [Resolved]
+            private IEditNoteModeState editNoteModeState { get; set; }
+
             public LabelledNoteRubyTextTextBox(Note item)
                 : base(item)
             {
             }
+
+            protected override void TriggerSelect(Note item)
+                => editNoteModeState.Select(item);
 
             protected override string GetFieldValue(Note note)
                 => note.RubyText;
@@ -143,7 +155,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Notes
                 => notePropertyChangeHandler.ChangeRubyText(value);
 
             [BackgroundDependencyLoader]
-            private void load(IEditNoteModeState editNoteModeState)
+            private void load()
             {
                 SelectedItems.BindTo(editNoteModeState.SelectedItems);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/Components/LabelledTextTagTextBox.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/Components/LabelledTextTagTextBox.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji.Components
                         if (hover)
                         {
                             // trigger selected if hover on delete button.
-                            TriggerSelect();
+                            TriggerSelect(textTag);
                         }
                     }
                 }
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji.Components
                     Selected = selected =>
                     {
                         if (selected)
-                            TriggerSelect();
+                            TriggerSelect(textTag);
                     },
                     Action = (indexType, action) =>
                     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/RomajiTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/RomajiTagEditSection.cs
@@ -65,11 +65,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji
             [Resolved]
             private ILyricRomajiTagsChangeHandler romajiTagsChangeHandler { get; set; }
 
+            [Resolved]
+            private IEditRomajiModeState editRomajiModeState { get; set; }
+
             public LabelledRomajiTagTextBox(Lyric lyric, RomajiTag textTag)
                 : base(lyric, textTag)
             {
                 Debug.Assert(lyric.RomajiTags.Contains(textTag));
             }
+
+            protected override void TriggerSelect(RomajiTag item)
+                => editRomajiModeState.Select(item);
 
             protected override void ApplyValue(RomajiTag item, string value)
                 => romajiTagsChangeHandler.SetText(item, value);
@@ -81,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji
                 => romajiTagsChangeHandler.Remove(textTag);
 
             [BackgroundDependencyLoader]
-            private void load(IEditRomajiModeState editRomajiModeState)
+            private void load()
             {
                 SelectedItems.BindTo(editRomajiModeState.SelectedItems);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/RubyTagEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/RubyRomaji/RubyTagEditSection.cs
@@ -65,11 +65,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji
             [Resolved]
             private ILyricRubyTagsChangeHandler rubyTagsChangeHandler { get; set; }
 
+            [Resolved]
+            private IEditRubyModeState editRubyModeState { get; set; }
+
             public LabelledRubyTagTextBox(Lyric lyric, RubyTag textTag)
                 : base(lyric, textTag)
             {
                 Debug.Assert(lyric.RubyTags.Contains(textTag));
             }
+
+            protected override void TriggerSelect(RubyTag item)
+                => editRubyModeState.Select(item);
 
             protected override void ApplyValue(RubyTag item, string value)
                 => rubyTagsChangeHandler.SetText(item, value);
@@ -81,7 +87,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.RubyRomaji
                 => rubyTagsChangeHandler.Remove(textTag);
 
             [BackgroundDependencyLoader]
-            private void load(IEditRubyModeState editRubyModeState)
+            private void load()
             {
                 SelectedItems.BindTo(editRubyModeState.SelectedItems);
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IHasBlueprintSelection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IHasBlueprintSelection.cs
@@ -8,5 +8,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
     public interface IHasBlueprintSelection<T> where T : class
     {
         BindableList<T> SelectedItems { get; }
+
+        void Select(T item);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ModeStateWithBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ModeStateWithBlueprintContainer.cs
@@ -81,6 +81,17 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
 
         protected abstract IEnumerable<TObject> SelectableProperties(Lyric lyric);
 
+        public void Select(TObject item)
+        {
+            // not trigger again if already focus.
+            if (SelectedItems.Contains(item) && SelectedItems.Count == 1)
+                return;
+
+            // trigger selected.
+            SelectedItems.Clear();
+            SelectedItems.Add(item);
+        }
+
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state, ILyricCaretState lyricCaretState)
         {


### PR DESCRIPTION
Before decide should implement the #1696 or not
It should be better to collect the logic for select the single blueprint item.

Where will use this method:
- labelled row.
- issue table.