### PR TITLE
Implement lyric editor check verifier.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -13,16 +13,18 @@ namespace osu.Game.Rulesets.Karaoke.Edit
     {
         private readonly List<ICheck> checks = new()
         {
-            new CheckLyricText(),
+            new CheckBeatmapAvailableTranslates(),
             new CheckLyricLanguage(),
             new CheckLyricReferenceLyric(),
-            new CheckLyricRubyTag(),
             new CheckLyricRomajiTag(),
+            new CheckLyricRubyTag(),
             new CheckLyricSinger(),
+            new CheckLyricText(),
+            new CheckLyricTime(),
+            new CheckLyricTimeTag(),
             new CheckLyricTranslate(),
             new CheckNoteReferenceLyric(),
             new CheckNoteText(),
-            new CheckBeatmapAvailableTranslates(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context) => checks.SelectMany(check => check.Run(context));

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
 {
     public class KaraokeBeatmapVerifier : IBeatmapVerifier
     {
-        private readonly List<ICheck> checks = new()
+        protected readonly List<ICheck> Checks = new()
         {
             new CheckBeatmapAvailableTranslates(),
             new CheckLyricLanguage(),
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             new CheckNoteText(),
         };
 
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context) => checks.SelectMany(check => check.Run(context));
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context) => AvailableChecks(Checks).SelectMany(check => check.Run(context));
+
+        protected virtual IEnumerable<ICheck> AvailableChecks(List<ICheck> checks) => checks;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorVerifier.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+
+public interface ILyricEditorVerifier
+{
+    IBindableList<Issue> GetBindable(KaraokeHitObject hitObject);
+
+    IBindableList<Issue> GetIssueByEditMode(LyricEditorMode editorMode);
+
+    void Refresh();
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -65,6 +65,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(ILyricEditorClipboard))]
         private readonly LyricEditorClipboard lyricEditorClipboard;
 
+        [Cached(typeof(ILyricEditorVerifier))]
+        private readonly LyricEditorVerifier lyricEditorVerifier;
+
         [Cached(typeof(IIssueNavigator))]
         private readonly IssueNavigator issueNavigator;
 
@@ -105,6 +108,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             // Separated feature.
             AddInternal(lyricEditorClipboard = new LyricEditorClipboard());
+            AddInternal(lyricEditorVerifier = new LyricEditorVerifier());
             AddInternal(issueNavigator = new IssueNavigator());
 
             Add(gridContainer = new GridContainer

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Caching;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics;
+
+public class LyricEditorVerifier : Component, ILyricEditorVerifier
+{
+    [Resolved, AllowNull]
+    private EditorBeatmap beatmap { get; set; }
+
+    [Resolved, AllowNull]
+    private IBindable<WorkingBeatmap> workingBeatmap { get; set; }
+
+    private readonly Dictionary<KaraokeHitObject, BindableList<Issue>> hitObjectIssues = new();
+
+    private readonly IDictionary<LyricEditorMode, BindableList<Issue>> editModeIssues = new Dictionary<LyricEditorMode, BindableList<Issue>>
+    {
+        { LyricEditorMode.Texting, new BindableList<Issue>() },
+        { LyricEditorMode.Reference, new BindableList<Issue>() },
+        { LyricEditorMode.Language, new BindableList<Issue>() },
+        { LyricEditorMode.EditRuby, new BindableList<Issue>() },
+        { LyricEditorMode.EditRomaji, new BindableList<Issue>() },
+        { LyricEditorMode.EditTimeTag, new BindableList<Issue>() },
+        { LyricEditorMode.EditNote, new BindableList<Issue>() },
+    };
+
+    private readonly Cached editModeCache = new();
+    private readonly KaraokeHitObjectVerifier verifier = new();
+
+    public IBindableList<Issue> GetBindable(KaraokeHitObject hitObject)
+        => hitObjectIssues[hitObject];
+
+    public IBindableList<Issue> GetIssueByEditMode(LyricEditorMode editorMode)
+        => editModeIssues[editorMode];
+
+    public void Refresh()
+        => recalculateIssues();
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        // need to check is there any lyric added or removed.
+        beatmap.HitObjectAdded += hitObjectAdded;
+        beatmap.HitObjectRemoved += hitObjectRemoved;
+        beatmap.HitObjectUpdated += hitObjectUpdated;
+
+        recalculateIssues();
+    }
+
+    [BackgroundDependencyLoader(true)]
+    private void load(KaraokeRulesetEditCheckerConfigManager? rulesetEditCheckerConfigManager)
+    {
+        // todo: adjust the config in the config.
+    }
+
+    private void recalculateIssues()
+    {
+        hitObjectIssues.Clear();
+
+        var hitObjects = beatmap.HitObjects.OfType<KaraokeHitObject>();
+
+        foreach (var hitObject in hitObjects)
+        {
+            hitObjectAdded(hitObject);
+        }
+
+        recalculateEditModeIssue();
+    }
+
+    private void hitObjectAdded(HitObject obj)
+    {
+        if (obj is not KaraokeHitObject karaokeHitObject)
+            return;
+
+        hitObjectIssues.Add(karaokeHitObject, new BindableList<Issue>());
+
+        editModeCache.Invalidate();
+    }
+
+    private void hitObjectRemoved(HitObject obj)
+    {
+        if (obj is not KaraokeHitObject karaokeHitObject)
+            return;
+
+        var bindableIssues = hitObjectIssues[karaokeHitObject];
+
+        var issues = getIssueByHitObject(karaokeHitObject).ToArray();
+        bindableIssues.Clear();
+        bindableIssues.AddRange(issues);
+
+        editModeCache.Invalidate();
+    }
+
+    private void hitObjectUpdated(HitObject obj)
+    {
+        if (obj is not KaraokeHitObject karaokeHitObject)
+            return;
+
+        hitObjectIssues[karaokeHitObject].Clear();
+        hitObjectIssues.Remove(karaokeHitObject);
+
+        editModeCache.Invalidate();
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        if (!editModeCache.IsValid)
+            recalculateEditModeIssue();
+    }
+
+    private void recalculateEditModeIssue()
+    {
+        var allIssues = hitObjectIssues.Values.SelectMany(x => x);
+        var groupByEditModeIssues = allIssues.GroupBy(x => getNavigateEditMode(x.Check)).ToDictionary(x => x.Key, x => x.ToArray());
+
+        foreach (var (editorMode, editModeBindableList) in editModeIssues)
+        {
+            editModeBindableList.Clear();
+
+            if (groupByEditModeIssues.TryGetValue(editorMode, out var issues))
+                editModeBindableList.AddRange(issues);
+        }
+
+        editModeCache.Validate();
+    }
+
+    private IEnumerable<Issue> getIssueByHitObject(KaraokeHitObject karaokeHitObject)
+    {
+        var context = new BeatmapVerifierContext(new Beatmap<HitObject>
+        {
+            HitObjects =
+            {
+                karaokeHitObject
+            }
+        }, workingBeatmap.Value);
+        return verifier.Run(context);
+    }
+
+    private static LyricEditorMode getNavigateEditMode(ICheck check)
+    {
+        switch (check)
+        {
+            case CheckLyricText:
+                return LyricEditorMode.Texting;
+
+            case CheckLyricReferenceLyric:
+                return LyricEditorMode.Reference;
+
+            case CheckLyricLanguage:
+                return LyricEditorMode.Language;
+
+            case CheckLyricRubyTag:
+                return LyricEditorMode.EditRuby;
+
+            case CheckLyricRomajiTag:
+                return LyricEditorMode.EditRomaji;
+
+            case CheckLyricTimeTag:
+                return LyricEditorMode.EditTimeTag;
+
+            case CheckNoteReferenceLyric:
+            case CheckNoteText:
+                return LyricEditorMode.EditNote;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+
+        beatmap.HitObjectAdded -= hitObjectAdded;
+        beatmap.HitObjectRemoved -= hitObjectRemoved;
+        beatmap.HitObjectUpdated -= hitObjectUpdated;
+    }
+
+    private class KaraokeHitObjectVerifier : KaraokeBeatmapVerifier
+    {
+        protected override IEnumerable<ICheck> AvailableChecks(List<ICheck> checks)
+            => Checks.Where(x => x is CheckHitObjectProperty<Lyric> or CheckHitObjectProperty<Note>);
+    }
+}


### PR DESCRIPTION
Implement the  check verifier for the lyric editor.
It will auto update the list if lyric is added/removed or updated.

First version of implementation of issue #1715.
Not the perfect one, but should be a good start.

Also, notice that because the change made for the #1669 in the hit-object related change handler, so update the lyric property might not being triggered.