### PR TITLE
Implement invalid issue display in panel area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/LyricComposer.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.BottomEditor;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Utils;

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panel.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -9,6 +10,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Containers;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
 {
@@ -22,12 +25,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         protected virtual string PopInSampleName => "UI/overlay-pop-in";
         protected virtual string PopOutSampleName => "UI/overlay-pop-out";
 
-        protected override Container<Drawable> Content => content;
-
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
 
         private readonly Box background;
-        private readonly Container content;
 
         protected Panel()
         {
@@ -40,13 +40,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                     Name = "Background",
                     RelativeSizeAxes = Axes.Both,
                 },
-                content = new Container
+                new OsuScrollContainer
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(10),
+                        Children = CreateSections()
+                    },
                 }
             };
         }
+
+        protected abstract IReadOnlyList<Drawable> CreateSections();
 
         [BackgroundDependencyLoader(true)]
         private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider, AudioManager audio)

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
 {
     public class InvalidPanel : Panel
@@ -8,6 +11,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
         public InvalidPanel()
         {
             Width = 200;
+        }
+
+        protected override IReadOnlyList<Drawable> CreateSections()
+        {
+            return new Drawable[] { };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
 {
-    public class PropertyPanel : Panel
+    public class InvalidPanel : Panel
     {
-        public PropertyPanel()
+        public InvalidPanel()
         {
             Width = 200;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/InvalidPanel.cs
@@ -13,9 +13,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
             Width = 200;
         }
 
-        protected override IReadOnlyList<Drawable> CreateSections()
-        {
-            return new Drawable[] { };
-        }
+        protected override IReadOnlyList<Drawable> CreateSections() =>
+            new Drawable[]
+            {
+                new IssueSection()
+            };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/IssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/IssueSection.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Issues;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels;
+
+public class IssueSection : PanelSection
+{
+    protected override LocalisableString Title => "Issues";
+
+    private readonly IBindableList<Issue> bindableIssues = new BindableList<Issue>();
+
+    [Resolved, AllowNull]
+    private ILyricEditorVerifier verifier { get; set; }
+
+    public IssueSection()
+    {
+        EmptyIssue emptyIssue;
+
+        IssueTable issueTable;
+
+        Children = new Drawable[]
+        {
+            emptyIssue = new EmptyIssue
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding(10),
+            },
+            issueTable = new SingleLyricIssueTable()
+        };
+
+        bindableIssues.BindCollectionChanged((_, _) =>
+        {
+            bool hasIssue = bindableIssues.Any();
+
+            emptyIssue.Alpha = hasIssue ? 0 : 1;
+
+            issueTable.Alpha = hasIssue ? 1 : 0;
+            issueTable.Issues = bindableIssues.Take(100);
+        }, true);
+    }
+
+    protected override void OnLyricChanged(Lyric? lyric)
+    {
+        bindableIssues.UnbindBindings();
+        if (lyric == null)
+            return;
+
+        bindableIssues.BindTo(verifier.GetBindable(lyric));
+    }
+
+    // todo: change the style.
+    private class EmptyIssue : ClickableContainer
+    {
+        [BackgroundDependencyLoader]
+        private void load(LyricEditorColourProvider colourProvider, ILyricEditorState state, ILyricEditorVerifier verifier, OsuColour colours)
+        {
+            Action = verifier.Refresh;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Padding = new MarginPadding(20),
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new SpriteIcon
+                    {
+                        Icon = FontAwesome.Solid.CheckCircle,
+                        Colour = colours.Green,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Size = new Vector2(36),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Text = "No issue here!",
+                        Colour = colourProvider.Colour1(state.Mode),
+                        Font = OsuFont.GetFont(size: 24),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Text = "Click this area to re-check again.",
+                        Font = OsuFont.GetFont(size: 14),
+                    },
+                }
+            };
+
+            AddInternal(new HoverClickSounds(HoverSampleSet.Button));
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            Content.ScaleTo(0.9f, 4000, Easing.OutQuint);
+            return base.OnMouseDown(e);
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            Content.ScaleTo(1, 1000, Easing.OutElastic);
+            base.OnMouseUp(e);
+        }
+    }
+
+    private class SingleLyricIssueTable : IssueTable
+    {
+        public SingleLyricIssueTable()
+        {
+            ShowHeaders = false;
+        }
+
+        protected override TableColumn[] CreateHeaders() => new[]
+        {
+            new TableColumn(string.Empty, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize, minSize: 30)),
+            new TableColumn("Message", Anchor.CentreLeft),
+        };
+
+        protected override Drawable[] CreateContent(Issue issue) =>
+            new Drawable[]
+            {
+                new IssueIcon
+                {
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(10),
+                    Margin = new MarginPadding { Left = 10 },
+                    Issue = issue
+                },
+                new OsuSpriteText
+                {
+                    Text = issue.ToString(),
+                    Truncate = true,
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Medium)
+                },
+            };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PanelSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PanelSection.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels;
+
+public abstract class PanelSection : Section
+{
+    private readonly IBindable<Lyric?> bindableFocusedLyric = new Bindable<Lyric?>();
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        bindableFocusedLyric.BindValueChanged(x =>
+        {
+            var lyric = x.NewValue;
+
+            OnLyricChanged(lyric);
+        }, true);
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(ILyricCaretState lyricCaretState)
+    {
+        bindableFocusedLyric.BindTo(lyricCaretState.BindableFocusedLyric);
+    }
+
+    protected abstract void OnLyricChanged(Lyric? lyric);
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PropertyPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PropertyPanel.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
 {
-    public class InvalidPanel : Panel
+    public class PropertyPanel : Panel
     {
-        public InvalidPanel()
+        public PropertyPanel()
         {
             Width = 200;
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PropertyPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PropertyPanel.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
 {
     public class PropertyPanel : Panel
@@ -8,6 +11,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose.Panels
         public PropertyPanel()
         {
             Width = 200;
+        }
+
+        protected override IReadOnlyList<Drawable> CreateSections()
+        {
+            return new Drawable[] { };
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorTable.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorTable.cs
@@ -48,6 +48,16 @@ public abstract class LyricEditorTable : TableContainer
 
     protected override Drawable CreateHeader(int index, TableColumn column) => new HeaderText(column?.Header ?? default);
 
+    public new bool ShowHeaders
+    {
+        get => base.ShowHeaders;
+        set
+        {
+            base.ShowHeaders = value;
+            BackgroundFlow.Margin = new MarginPadding { Top = value ? ROW_HEIGHT : 0 };
+        }
+    }
+
     private class HeaderText : OsuSpriteText
     {
         public HeaderText(LocalisableString text)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/202880913-dbf2b645-7f7b-4d57-a38b-05c58f95ccf9.png)
![image](https://user-images.githubusercontent.com/9100368/202880916-660cc04f-3d8b-4631-b05e-98f190cf90fc.png)

Main part of issue #1728

What's done in this PR:
- Able to hide the header in the issue table.
- Implement section for the panel class.
- Refactor the panel class for able to accept list of sections, like how `EditorRoundedScreenSettings` did.
- Implement the table.