### PR TITLE
Add refresh button for single lyric issue table.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/LyricEditorVerifierTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Lyrics/LyricEditorVerifierTest.cs
@@ -121,6 +121,19 @@ public class LyricEditorVerifierTest : EditorClockTestScene
         assertEditModeIssueAmount(LyricEditorMode.Language, 0);
     }
 
+    [Test]
+    public void TestRefreshByHitObject()
+    {
+        AddStep("Fix the language issue and refresh.", () =>
+        {
+            internalLyric.Language = new CultureInfo("ja-JP");
+            verifier.RefreshByHitObject(internalLyric);
+        });
+
+        assertHitObjectIssueAmount(internalLyric, 0);
+        assertEditModeIssueAmount(LyricEditorMode.Language, 0);
+    }
+
     #region Tool
 
     private static Lyric createLyricWithLanguageIssueOnly()

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panel.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panel.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
         private readonly IBindable<LyricEditorMode> bindableMode = new Bindable<LyricEditorMode>();
 
         private readonly Box background;
+        private readonly FillFlowContainer fillFlowContainer;
 
         protected Panel()
         {
@@ -43,13 +44,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
                 new OsuScrollContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = new FillFlowContainer
+                    Child = fillFlowContainer = new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(10),
-                        Children = CreateSections()
                     },
                 }
             };
@@ -113,6 +113,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
             // todo: adjust the effect.
             this.MoveToX(0, transition_length, Easing.OutQuint);
             this.FadeTo(1, transition_length, Easing.OutQuint);
+
+            // should load the content after opened.
+            fillFlowContainer.Children = CreateSections();
         }
 
         protected override void PopOut()
@@ -122,7 +125,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Compose
 
             float width = getHideXPosition();
             this.MoveToX(width, transition_length, Easing.OutQuint);
-            this.FadeTo(0, transition_length, Easing.OutQuint);
+            this.FadeTo(0, transition_length, Easing.OutQuint).OnComplete(_ =>
+            {
+                // should clear the content if close.
+                fillFlowContainer.Clear();
+            });
         }
 
         private float getHideXPosition() =>

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/IssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/IssueSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -33,6 +34,7 @@ public class IssueSection : PanelSection
     {
         EmptyIssue emptyIssue;
 
+        IconButton reloadButton;
         IssueTable issueTable;
 
         Children = new Drawable[]
@@ -48,12 +50,28 @@ public class IssueSection : PanelSection
             issueTable = new SingleLyricIssueTable()
         };
 
+        AddInternal(reloadButton = new IconButton
+        {
+            Anchor = Anchor.TopRight,
+            Origin = Anchor.TopRight,
+            Icon = FontAwesome.Solid.Redo,
+            Scale = new Vector2(0.7f),
+            Action = () =>
+            {
+                if (Lyric == null)
+                    throw new ArgumentNullException(nameof(Lyric));
+
+                verifier.RefreshByHitObject(Lyric);
+            }
+        });
+
         bindableIssues.BindCollectionChanged((_, _) =>
         {
             bool hasIssue = bindableIssues.Any();
 
             emptyIssue.Alpha = hasIssue ? 0 : 1;
 
+            reloadButton.Alpha = hasIssue ? 1 : 0;
             issueTable.Alpha = hasIssue ? 1 : 0;
             issueTable.Issues = bindableIssues.Take(100);
         }, true);

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PanelSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Compose/Panels/PanelSection.cs
@@ -13,15 +13,17 @@ public abstract class PanelSection : Section
 {
     private readonly IBindable<Lyric?> bindableFocusedLyric = new Bindable<Lyric?>();
 
+    protected Lyric? Lyric;
+
     protected override void LoadComplete()
     {
         base.LoadComplete();
 
         bindableFocusedLyric.BindValueChanged(x =>
         {
-            var lyric = x.NewValue;
+            Lyric = x.NewValue;
 
-            OnLyricChanged(lyric);
+            OnLyricChanged(Lyric);
         }, true);
     }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/ILyricEditorVerifier.cs
@@ -14,4 +14,6 @@ public interface ILyricEditorVerifier
     IBindableList<Issue> GetIssueByEditMode(LyricEditorMode editorMode);
 
     void Refresh();
+
+    void RefreshByHitObject(KaraokeHitObject hitObject);
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
@@ -53,6 +53,9 @@ public class LyricEditorVerifier : Component, ILyricEditorVerifier
     public void Refresh()
         => recalculateIssues();
 
+    public void RefreshByHitObject(KaraokeHitObject hitObject)
+        => hitObjectUpdated(hitObject);
+
     protected override void LoadComplete()
     {
         base.LoadComplete();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorVerifier.cs
@@ -54,7 +54,16 @@ public class LyricEditorVerifier : Component, ILyricEditorVerifier
         => recalculateIssues();
 
     public void RefreshByHitObject(KaraokeHitObject hitObject)
-        => hitObjectUpdated(hitObject);
+    {
+        if (hitObjectIssues.ContainsKey(hitObject))
+        {
+            hitObjectUpdated(hitObject);
+        }
+        else
+        {
+            hitObjectAdded(hitObject);
+        }
+    }
 
     protected override void LoadComplete()
     {


### PR DESCRIPTION
Implement part of #1728

![image](https://user-images.githubusercontent.com/9100368/202896646-c07de48c-2286-405a-9f12-254abb00f6dc.png)
What's done in this PR:
- Let the verifier able to refresh the issue by hit-object.
- Add that damn button.
- [Performance] Should load the table only if panel is opened.