### PR TITLE
Add missing issue table in texting and reference edit mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ImportLyric/EditLyric/EditLyricNavigation.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ImportLyric.EditLyric
                     {
                         TextingEditMode.Typing => $"Cool! Try switching to [{split_mode}] if you want to cut or combine lyric.",
                         TextingEditMode.Split => $"Cool! Try switching to [{typing_mode}] if you want to edit lyric.",
+                        TextingEditMode.Verify => $"Cool! Try switching to [{split_mode}] or [{typing_mode}] if you want to fix the issue.",
                         _ => throw new InvalidEnumArgumentException(nameof(mode))
                     };
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditor.cs
@@ -47,6 +47,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
         [Cached(typeof(ITextingModeState))]
         private readonly TextingModeState textingModeState;
 
+        [Cached(typeof(IEditReferenceLyricModeState))]
+        private readonly EditReferenceLyricModeState editReferenceLyricModeState;
+
         [Cached(typeof(ILanguageModeState))]
         private readonly LanguageModeState languageModeState;
 
@@ -100,6 +103,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
             // state for target mode only.
             AddInternal(textingModeState = new TextingModeState());
+            AddInternal(editReferenceLyricModeState = new EditReferenceLyricModeState());
             AddInternal(languageModeState = new LanguageModeState());
             AddInternal(editRubyModeState = new EditRubyModeState());
             AddInternal(editRomajiModeState = new EditRomajiModeState());

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
@@ -161,6 +161,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                             lyricsChangeHandler.Remove();
                             return true;
 
+                        case TextingEditMode.Verify:
+                            // cut, copy or paste event should be handled in the caret.
+                            return false;
+
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
@@ -241,6 +245,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
                             copyObjectToClipboard(lyric.Text);
                             return true;
 
+                        case TextingEditMode.Verify:
+                            // cut, copy or paste event should be handled in the caret.
+                            return false;
+
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
@@ -318,6 +326,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
 
                             lyricsChangeHandler.AddBelowToSelection(pasteLyric);
                             return true;
+
+                        case TextingEditMode.Verify:
+                            // cut, copy or paste event should be handled in the caret.
+                            return false;
 
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Components.Markdown;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Reference;
+
+public class ReferenceLyricEditModeSection : EditModeSection<IEditReferenceLyricModeState, ReferenceLyricEditMode>
+{
+    protected override OverlayColourScheme CreateColourScheme()
+        => OverlayColourScheme.Pink;
+
+    protected override Selection CreateSelection(ReferenceLyricEditMode mode) =>
+        mode switch
+        {
+            ReferenceLyricEditMode.Edit => new Selection(),
+            ReferenceLyricEditMode.Verify => new ReferenceLyricVerifySelection(),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override LocalisableString GetSelectionText(ReferenceLyricEditMode mode) =>
+        mode switch
+        {
+            ReferenceLyricEditMode.Edit => "Edit",
+            ReferenceLyricEditMode.Verify => "Verify",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override Color4 GetSelectionColour(OsuColour colours, ReferenceLyricEditMode mode, bool active) =>
+        mode switch
+        {
+            ReferenceLyricEditMode.Edit => active ? colours.Blue : colours.BlueDarker,
+            ReferenceLyricEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override DescriptionFormat GetSelectionDescription(ReferenceLyricEditMode mode) =>
+        mode switch
+        {
+            ReferenceLyricEditMode.Edit => "Assign the reference lyrics.",
+            ReferenceLyricEditMode.Verify => "Check any invalid reference lyric issue.",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    private class ReferenceLyricVerifySelection : VerifySelection
+    {
+        protected override LyricEditorMode EditMode => LyricEditorMode.Reference;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Reference/ReferenceLyricIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Reference/ReferenceLyricIssueSection.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Checks.Issues;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Issues;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Reference;
+
+public class ReferenceLyricIssueSection : IssueSection
+{
+    protected override LyricEditorMode EditMode => LyricEditorMode.Reference;
+
+    protected override LyricsIssueTable CreateIssueTable() => new ReferenceLyricIssueTable();
+
+    private class ReferenceLyricIssueTable : LyricsIssueTable
+    {
+        protected override TableColumn[] CreateHeaders() => new[]
+        {
+            new TableColumn(string.Empty, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize, minSize: 30)),
+            new TableColumn("Lyric", Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize, minSize: 40)),
+            new TableColumn("Message", Anchor.CentreLeft),
+        };
+
+        protected override Drawable[] CreateContent(Issue issue)
+        {
+            var lyric = getInvalidByIssue(issue);
+
+            return new Drawable[]
+            {
+                new IssueIcon
+                {
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(10),
+                    Margin = new MarginPadding { Left = 10 },
+                    Issue = issue
+                },
+                new OsuSpriteText
+                {
+                    Text = $"#{lyric.Order}",
+                    Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Bold),
+                    Margin = new MarginPadding { Right = 10 },
+                },
+                new OsuSpriteText
+                {
+                    Text = issue.ToString(),
+                    Truncate = true,
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Medium)
+                },
+            };
+        }
+
+        private Lyric getInvalidByIssue(Issue issue)
+        {
+            if (issue is not LyricIssue lyricIssue)
+                throw new InvalidCastException();
+
+            return lyricIssue.Lyric;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/ReferenceSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/ReferenceSettings.cs
@@ -1,9 +1,13 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Reference;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
 {
@@ -13,11 +17,33 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
 
         public override float SettingsWidth => 300;
 
-        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
+        private readonly IBindable<ReferenceLyricEditMode> bindableMode = new Bindable<ReferenceLyricEditMode>();
+
+        [BackgroundDependencyLoader]
+        private void load(IEditReferenceLyricModeState editReferenceLyricModeState)
         {
-            new ReferenceLyricAutoGenerateSection(),
-            new ReferenceLyricSection(),
-            new ReferenceLyricConfigSection()
+            bindableMode.BindTo(editReferenceLyricModeState.BindableEditMode);
+            bindableMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
+        }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+        {
+            ReferenceLyricEditMode.Edit => new Drawable[]
+            {
+                new ReferenceLyricEditModeSection(),
+                new ReferenceLyricAutoGenerateSection(),
+                new ReferenceLyricSection(),
+                new ReferenceLyricConfigSection()
+            },
+            ReferenceLyricEditMode.Verify => new Drawable[]
+            {
+                new ReferenceLyricEditModeSection(),
+                new ReferenceLyricIssueSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
         };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Texting/TextingEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Texting/TextingEditModeSection.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting
             {
                 TextingEditMode.Typing => new Selection(),
                 TextingEditMode.Split => new Selection(),
+                TextingEditMode.Verify => new TextingVerifySelection(),
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
@@ -29,6 +30,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting
             {
                 TextingEditMode.Typing => "Typing",
                 TextingEditMode.Split => "Split",
+                TextingEditMode.Verify => "Verify",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
@@ -36,7 +38,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting
             mode switch
             {
                 TextingEditMode.Typing => active ? colours.Blue : colours.BlueDarker,
-                TextingEditMode.Split => active ? colours.Yellow : colours.YellowDarker,
+                TextingEditMode.Split => active ? colours.Red : colours.RedDarker,
+                TextingEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
@@ -45,7 +48,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting
             {
                 TextingEditMode.Typing => "Edit the lyric text.",
                 TextingEditMode.Split => "Create/delete or split/combine the lyric.",
+                TextingEditMode.Verify => "Check if have lyric with no text.",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
+
+        private class TextingVerifySelection : VerifySelection
+        {
+            protected override LyricEditorMode EditMode => LyricEditorMode.Texting;
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Texting/TextingIssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Texting/TextingIssueSection.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Edit.Checks.Issues;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Issues;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting;
+
+public class TextingIssueSection : IssueSection
+{
+    protected override LyricEditorMode EditMode => LyricEditorMode.Texting;
+
+    protected override LyricsIssueTable CreateIssueTable() => new TextingIssueTable();
+
+    private class TextingIssueTable : LyricsIssueTable
+    {
+        protected override TableColumn[] CreateHeaders() => new[]
+        {
+            new TableColumn(string.Empty, Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize, minSize: 30)),
+            new TableColumn("Lyric", Anchor.CentreLeft, new Dimension(GridSizeMode.AutoSize, minSize: 40)),
+            new TableColumn("Message", Anchor.CentreLeft),
+        };
+
+        protected override Drawable[] CreateContent(Issue issue)
+        {
+            var lyric = getInvalidByIssue(issue);
+
+            return new Drawable[]
+            {
+                new IssueIcon
+                {
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(10),
+                    Margin = new MarginPadding { Left = 10 },
+                    Issue = issue,
+                },
+                new OsuSpriteText
+                {
+                    Text = $"#{lyric.Order}",
+                    Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Bold),
+                    Margin = new MarginPadding { Right = 10 },
+                },
+                new OsuSpriteText
+                {
+                    Text = issue.ToString(),
+                    Truncate = true,
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: TEXT_SIZE, weight: FontWeight.Medium)
+                },
+            };
+        }
+
+        private Lyric getInvalidByIssue(Issue issue)
+        {
+            if (issue is not LyricIssue lyricIssue)
+                throw new InvalidCastException();
+
+            return lyricIssue.Lyric;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/TextingSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/TextingSettings.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Texting;
+using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
 {
@@ -13,10 +17,36 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings
 
         public override float SettingsWidth => 300;
 
-        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
+        private readonly IBindable<TextingEditMode> bindableMode = new Bindable<TextingEditMode>();
+
+        [BackgroundDependencyLoader]
+        private void load(ITextingModeState textingModeState)
         {
-            new TextingEditModeSection(),
-            new TextingSwitchSpecialActionSection()
+            bindableMode.BindTo(textingModeState.BindableEditMode);
+            bindableMode.BindValueChanged(e =>
+            {
+                ReloadSections();
+            }, true);
+        }
+
+        protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+        {
+            TextingEditMode.Typing => new Drawable[]
+            {
+                new TextingEditModeSection(),
+                new TextingSwitchSpecialActionSection(),
+            },
+            TextingEditMode.Split => new Drawable[]
+            {
+                new TextingEditModeSection(),
+                new TextingSwitchSpecialActionSection(),
+            },
+            TextingEditMode.Verify => new Drawable[]
+            {
+                new TextingEditModeSection(),
+                new TextingIssueSection(),
+            },
+            _ => throw new ArgumentOutOfRangeException()
         };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/LyricCaretState.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States
                 {
                     TextingEditMode.Typing => new TypingCaretPositionAlgorithm(lyrics),
                     TextingEditMode.Split => new CuttingCaretPositionAlgorithm(lyrics),
+                    TextingEditMode.Verify => new NavigateCaretPositionAlgorithm(lyrics),
                     _ => throw new InvalidOperationException(nameof(textingEditMode))
                 };
             }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditReferenceLyricModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/EditReferenceLyricModeState.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+
+public class EditReferenceLyricModeState : Component, IEditReferenceLyricModeState
+{
+    private readonly Bindable<ReferenceLyricEditMode> bindableEditMode = new();
+
+    public IBindable<ReferenceLyricEditMode> BindableEditMode => bindableEditMode;
+
+    public void ChangeEditMode(ReferenceLyricEditMode mode)
+        => bindableEditMode.Value = mode;
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditReferenceLyricModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/IEditReferenceLyricModeState.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+
+public interface IEditReferenceLyricModeState : IHasEditModeState<ReferenceLyricEditMode>
+{
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ReferenceLyricEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/ReferenceLyricEditMode.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes;
+
+public enum ReferenceLyricEditMode
+{
+    Edit,
+
+    Verify
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/States/Modes/TextingEditMode.cs
@@ -7,6 +7,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.States.Modes
     {
         Typing,
 
-        Split
+        Split,
+
+        Verify
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/203082602-55e540fb-7cb5-417e-9da0-702cb2a613bb.png)
![image](https://user-images.githubusercontent.com/9100368/203082641-97dac4e0-309b-451b-b1a5-88b60afdd846.png)
Implement the verify section and the issue table for the texting mode and the reference lyric mode.