### PR TITLE
Remove initialize working time in the lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
@@ -51,7 +51,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                     TimeTags = TimeTagsUtils.Sort(lrcTimeTags.Concat(lrcRubyTimeTags)),
                     RubyTags = lrcRubies
                 };
-                lyric.InitialWorkingTime();
                 output.HitObjects.Add(lyric);
             }
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Patterns/LegacyLyricTimeGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Patterns/LegacyLyricTimeGenerator.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Patterns
@@ -25,9 +24,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Patterns
 
         private void assignLyricTime(IList<Lyric> lyrics)
         {
-            // Reset working time
-            lyrics.ForEach(h => h.InitialWorkingTime());
-
             // Apply start time
             for (int i = 0; i < lyrics.Count; i++)
             {
@@ -37,12 +33,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Patterns
                 if (lastLyric == null)
                     continue;
 
-                // Adjust start time and end time
-                double lyricEndTime = lyric.EndTime;
-                lyric.StartTime = lastLyric.EndTime + 1000;
+                double lyricEndTime = lyric.LyricEndTime;
+                double lyricStartTime = lastLyric.EndTime + 1000;
 
-                // Should re-assign duration here
-                lyric.Duration = lyricEndTime - lyric.StartTime;
+                // Adjust start time and end time
+                lyric.StartTime = lyricStartTime;
+                lyric.Duration = lyricEndTime - lyricStartTime;
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -266,16 +266,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
             // Add because it will cause error on exit then enter gameplay.
             StartTimeBindable.UnbindAll();
-
-            // Initial working start and end time.
-            // todo: should be removed eventually because start time and duration will be calculated by KaraokeBeatmapProcessor
-            InitialWorkingTime();
-        }
-
-        public void InitialWorkingTime()
-        {
-            StartTime = LyricStartTime;
-            Duration = LyricDuration;
         }
 
         protected override HitWindows CreateHitWindows() => new KaraokeLyricHitWindows();


### PR DESCRIPTION
Mark as part of #1755
Should initialize the lyric's hit-object start-time and duration in the processor.