### PR TITLE
Implement pages metadata in the beatmap.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps.Metadatas;
+
+public class PageInfoTest
+{
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 999, null)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1000, 1000)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1001, 1000)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4001, 4000)]
+    [TestCase(new double[] { }, 0, null)]
+    [TestCase(new double[] { 4000, 3000, 2000, 1000 }, 1000, 1000)] // should works even not sorting.
+    public void TestGetPageAt(double[] times, double time, double? expectedTime)
+    {
+        var pageInfo = new PageInfo();
+        pageInfo.Pages.AddRange(getPages(times));
+
+        var actualPage = pageInfo.GetPageAt(time);
+
+        Assert.AreEqual(expectedTime, actualPage?.Time);
+    }
+
+    private static IEnumerable<Page> getPages(double[] pages)
+        => pages.Select(x => new Page { Time = x });
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
         public IList<Singer> Singers { get; set; } = new List<Singer>();
 
+        public PageInfo PageInfo { get; set; } = new();
+
         public bool Scorable { get; set; }
 
         public int TotalColumns { get; set; } = 9;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Patterns;
@@ -20,6 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
             base.PreProcess();
 
             applyReferenceObject(Beatmap);
+            applyPage(Beatmap);
         }
 
         public override void PostProcess()
@@ -59,6 +61,28 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
             Lyric findLyricById(int id) =>
                 beatmap.HitObjects.OfType<Lyric>().Single(x => x.ID == id);
+        }
+
+        private void applyPage(IBeatmap beatmap)
+        {
+            if (beatmap is not KaraokeBeatmap karaokeBeatmap)
+                throw new InvalidCastException();
+
+            var pageIndo = karaokeBeatmap.PageInfo;
+
+            foreach (var obj in beatmap.HitObjects.OfType<KaraokeHitObject>())
+            {
+                switch (obj)
+                {
+                    case Lyric lyric:
+                        lyric.Page = pageIndo.GetPageAt(lyric.LyricStartTime);
+                        break;
+
+                    case Note note:
+                        note.Page = pageIndo.GetPageAt(note.StartTime);
+                        break;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Page.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/Page.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Newtonsoft.Json;
+using osu.Framework.Bindables;
+using osu.Game.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+public class Page : IDeepCloneable<Page>, IComparable<Page>
+{
+    [JsonIgnore]
+    public readonly Bindable<double> TimeBindable = new();
+
+    public double Time
+    {
+        get => TimeBindable.Value;
+        set => TimeBindable.Value = value;
+    }
+
+    public Page DeepClone()
+    {
+        return new Page
+        {
+            Time = Time
+        };
+    }
+
+    public int CompareTo(Page other) => Time.CompareTo(other.Time);
+
+    public override int GetHashCode() => Time.GetHashCode();
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Lists;
+using osu.Game.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+public class PageInfo : IDeepCloneable<PageInfo>
+{
+    public SortedList<Page> Pages = new(Comparer<Page>.Default);
+
+    public Page? GetPageAt(double time)
+    {
+        return Pages.LastOrDefault(x => x.Time <= time);
+    }
+
+    public PageInfo DeepClone()
+    {
+        var controlPointInfo = (PageInfo)Activator.CreateInstance(GetType());
+
+        return controlPointInfo;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.IO.Serialization;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Properties;
@@ -21,7 +22,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public partial class Lyric : KaraokeHitObject, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey, IDeepCloneable<Lyric>
+    public partial class Lyric : KaraokeHitObject, IHasPage, IHasDuration, IHasSingers, IHasOrder, IHasLock, IHasPrimaryKey, IDeepCloneable<Lyric>
     {
         /// <summary>
         /// Primary key.
@@ -182,6 +183,19 @@ namespace osu.Game.Rulesets.Karaoke.Objects
         {
             get => OrderBindable.Value;
             set => OrderBindable.Value = value;
+        }
+
+        [JsonIgnore]
+        public readonly Bindable<Page?> PageBindable = new();
+
+        /// <summary>
+        /// Order
+        /// </summary>
+        [JsonIgnore]
+        public Page? Page
+        {
+            get => PageBindable.Value;
+            set => PageBindable.Value = value;
         }
 
         [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
@@ -17,8 +18,21 @@ using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
-    public class Note : KaraokeHitObject, IHasDuration, IHasText, IDeepCloneable<Note>
+    public class Note : KaraokeHitObject, IHasPage, IHasDuration, IHasText, IDeepCloneable<Note>
     {
+        [JsonIgnore]
+        public readonly Bindable<Page?> PageBindable = new();
+
+        /// <summary>
+        /// Order
+        /// </summary>
+        [JsonIgnore]
+        public Page? Page
+        {
+            get => PageBindable.Value;
+            set => PageBindable.Value = value;
+        }
+
         [JsonIgnore]
         public readonly Bindable<string> TextBindable = new();
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/IHasPage.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/IHasPage.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Types;
+
+public interface IHasPage
+{
+    Page? Page { get; set; }
+}


### PR DESCRIPTION
Beatmap format part of issue #1766.

What's done in this PR:
- [x] Create the metadata class.
- [x] Add the property into the beatmap.
- [x] Add the page property into the hit-object and mark as json ignore.
- [x] Use beatmap processor to update the property.

Note that the structure is follow how `ControlPointInfo` did in the osu.game.