### PR TITLE
Apply the singer info into the karaoke beatmap

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapSingersChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapSingersChangeHandlerTest.cs
@@ -16,22 +16,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps
         [Ignore("Not working because singer in karaoke beatmap only sync to change handler once.")]
         public void TestChangeOrder()
         {
-            var firstSinger = new Singer(0)
-            {
-                Order = 1
-            };
-            var secondSinger = new Singer(1)
-            {
-                Order = 2
-            };
+            Singer firstSinger = null!;
+            Singer secondSinger = null!;
 
             SetUpKaraokeBeatmap(karaokeBeatmap =>
             {
-                karaokeBeatmap.Singers = new List<Singer>
-                {
-                    firstSinger,
-                    secondSinger,
-                };
+                firstSinger = karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 1);
+                secondSinger = karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 2);
             });
 
             TriggerHandlerChanged(c =>
@@ -61,27 +52,18 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps
         {
             SetUpKaraokeBeatmap(karaokeBeatmap =>
             {
-                karaokeBeatmap.Singers = new List<Singer>
-                {
-                    new(0)
-                    {
-                        Order = 1
-                    },
-                    new(1)
-                    {
-                        Order = 2
-                    },
-                };
+                karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 1);
+                karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 2);
             });
 
             TriggerHandlerChanged(c =>
             {
-                c.Add(new Singer(2));
+                c.Add();
             });
 
             AssertKaraokeBeatmap(karaokeBeatmap =>
             {
-                var singers = karaokeBeatmap.Singers;
+                var singers = karaokeBeatmap.SingerInfo.Singers;
                 Assert.AreEqual(3, singers.Count);
 
                 var lastSinger = singers.Last();
@@ -94,22 +76,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps
         [Ignore("Not working because singer in karaoke beatmap only sync to change handler once.")]
         public void TestRemove()
         {
-            var firstSinger = new Singer(0)
-            {
-                Order = 1
-            };
-            var secondSinger = new Singer(1)
-            {
-                Order = 2
-            };
+            Singer firstSinger = null!;
+            Singer secondSinger = null!;
 
             SetUpKaraokeBeatmap(karaokeBeatmap =>
             {
-                karaokeBeatmap.Singers = new List<Singer>
-                {
-                    firstSinger,
-                    secondSinger
-                };
+                firstSinger = karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 1);
+                secondSinger = karaokeBeatmap.SingerInfo.AddSinger(s => s.Order = 2);
 
                 karaokeBeatmap.HitObjects = new List<KaraokeHitObject>
                 {
@@ -127,7 +100,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps
 
             AssertKaraokeBeatmap(karaokeBeatmap =>
             {
-                var singers = karaokeBeatmap.Singers;
+                var singers = karaokeBeatmap.SingerInfo.Singers;
                 Assert.AreEqual(1, singers.Count);
 
                 Assert.AreEqual(1, secondSinger.ID);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/TestSceneSingerScreen.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -9,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Singers;
 using osu.Game.Screens.Edit;
@@ -27,37 +25,37 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor
         {
             var karaokeBeatmap = base.CreateBeatmap();
 
-            // todo : insert singers
-            karaokeBeatmap.Singers = new List<Singer>
+            var singerInfo = karaokeBeatmap.SingerInfo;
+
+            singerInfo.AddSinger(s =>
             {
-                new(1)
-                {
-                    Order = 1,
-                    Name = "初音ミク",
-                    RomajiName = "Hatsune Miku",
-                    EnglishName = "Miku",
-                    Description = "International superstar vocaloid Hatsune Miku.",
-                    Hue = 189 / 360f,
-                },
-                new(2)
-                {
-                    Order = 2,
-                    Name = "ハク",
-                    RomajiName = "haku",
-                    EnglishName = "andy840119",
-                    Description = "Creator of this ruleset.",
-                    Hue = 46 / 360f,
-                },
-                new(3)
-                {
-                    Order = 3,
-                    Name = "ゴミパソコン",
-                    RomajiName = "gomi-pasokonn",
-                    EnglishName = "garbage desktop",
-                    Description = "My fucking slow desktop.",
-                    Hue = 290 / 360f,
-                }
-            };
+                s.Order = 1;
+                s.Name = "初音ミク";
+                s.RomajiName = "Hatsune Miku";
+                s.EnglishName = "Miku";
+                s.Description = "International superstar vocaloid Hatsune Miku.";
+                s.Hue = 189 / 360f;
+            });
+
+            singerInfo.AddSinger(s =>
+            {
+                s.Order = 2;
+                s.Name = "ハク";
+                s.RomajiName = "haku";
+                s.EnglishName = "andy840119";
+                s.Description = "Creator of this ruleset.";
+                s.Hue = 46 / 360f;
+            });
+
+            singerInfo.AddSinger(s =>
+            {
+                s.Order = 3;
+                s.Name = "ゴミパソコン";
+                s.RomajiName = "gomi-pasokonn";
+                s.EnglishName = "Miku";
+                s.Description = "My fucking slow desktop.";
+                s.Hue = 290 / 360f;
+            });
 
             return karaokeBeatmap;
         }

--- a/osu.Game.Rulesets.Karaoke.Tests/Ranking/TestSceneBeatmapMetadataGraph.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Ranking/TestSceneBeatmapMetadataGraph.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -29,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Ranking
             if (new KaraokeBeatmapConverter(originBeatmap, new KaraokeRuleset()).Convert() is not KaraokeBeatmap karaokeBeatmap)
                 throw new InvalidCastException(nameof(karaokeBeatmap));
 
-            karaokeBeatmap.Singers = createDefaultSinger();
+            karaokeBeatmap.SingerInfo = createSingerInfo();
             createTest(new ScoreInfo(), karaokeBeatmap);
         }
 
@@ -51,21 +49,22 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Ranking
             };
         });
 
-        private static List<Singer> createDefaultSinger()
+        private static SingerInfo createSingerInfo()
         {
-            var metadata = new List<Singer>();
+            var singerInfo = new SingerInfo();
 
             for (int i = 0; i < 10; i++)
             {
-                metadata.Add(new Singer(i)
+                int singerIndex = i;
+                singerInfo.AddSinger(s =>
                 {
-                    Name = $"Singer{i}",
-                    RomajiName = $"[Romaji]Singer{i}",
-                    EnglishName = $"[English]Singer{i}",
+                    s.Name = $"Singer{singerIndex}";
+                    s.RomajiName = $"[Romaji]Singer{singerIndex}";
+                    s.EnglishName = $"[English]Singer{singerIndex}";
                 });
             }
 
-            return metadata.ToList();
+            return singerInfo;
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
     {
         public IList<CultureInfo> AvailableTranslates { get; set; } = new List<CultureInfo>();
 
-        public IList<Singer> Singers { get; set; } = new List<Singer>();
+        public SingerInfo SingerInfo { get; set; } = new();
 
         public PageInfo PageInfo { get; set; } = new();
 
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
-            int singers = Singers.Count;
+            int singers = SingerInfo.GetAllSingers().Count();
             int lyrics = HitObjects.Count(s => s is Lyric);
 
             var defaultStatistic = new List<BeatmapStatistic>

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapExtension.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps
 {
@@ -31,7 +30,5 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
         {
             return pitch / 20 - 7;
         }
-
-        public static IList<Singer> GetSingers(this IBeatmap beatmap) => (beatmap as KaraokeBeatmap)?.Singers ?? new List<Singer>();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
@@ -16,6 +19,8 @@ public class BeatmapPropertyChangeHandler : Component
     private EditorBeatmap beatmap { get; set; }
 
     protected KaraokeBeatmap KaraokeBeatmap => (KaraokeBeatmap)beatmap.PlayableBeatmap;
+
+    protected IEnumerable<Lyric> Lyrics => KaraokeBeatmap.HitObjects.OfType<Lyric>();
 
     protected void PerformBeatmapChanged(Action<KaraokeBeatmap> action)
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapSingersChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapSingersChangeHandler.cs
@@ -4,19 +4,20 @@
 using System.IO;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps
 {
     public interface IBeatmapSingersChangeHandler
     {
         // todo: should use IBindableList eventually, but cannot do that because it's bind to selection item.
-        BindableList<Singer> Singers { get; }
+        BindableList<ISinger> Singers { get; }
 
-        void ChangeOrder(Singer singer, int newIndex);
+        void ChangeOrder(ISinger singer, int newIndex);
 
         bool ChangeSingerAvatar(Singer singer, FileInfo fileInfo);
 
-        void Add(Singer singer);
+        Singer Add();
 
         void Remove(Singer singer);
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricSingerChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/ILyricSingerChangeHandler.cs
@@ -1,11 +1,11 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
-    public interface ILyricSingerChangeHandler : ILyricListPropertyChangeHandler<Singer>
+    public interface ILyricSingerChangeHandler : ILyricListPropertyChangeHandler<ISinger>
     {
         void Clear();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
 
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 {
     public class LyricSingerChangeHandler : LyricPropertyChangeHandler, ILyricSingerChangeHandler
     {
-        public void Add(Singer singer)
+        public void Add(ISinger singer)
         {
             PerformOnSelection(lyric =>
             {
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
-        public void AddRange(IEnumerable<Singer> singers)
+        public void AddRange(IEnumerable<ISinger> singers)
         {
             PerformOnSelection(lyric =>
             {
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
-        public void Remove(Singer singer)
+        public void Remove(ISinger singer)
         {
             PerformOnSelection(lyric =>
             {
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             });
         }
 
-        public void RemoveRange(IEnumerable<Singer> singers)
+        public void RemoveRange(IEnumerable<ISinger> singers)
         {
             PerformOnSelection(lyric =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/ContextMenu/SingerContextMenu.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/ContextMenu/SingerContextMenu.cs
@@ -21,7 +21,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Components.ContextMenu
             : base(name)
         {
             var lyrics = beatmap.SelectedHitObjects.OfType<Lyric>().ToArray();
-            var singers = (beatmap.PlayableBeatmap as KaraokeBeatmap)?.Singers;
+
+            // todo: should be able to support the sub-singer.
+            var singers = (beatmap.PlayableBeatmap as KaraokeBeatmap)?.SingerInfo.GetAllSingers();
 
             Items = singers?.Select(singer => new OsuMenuItem(singer.Name, anySingerInLyric(singer) ? MenuItemType.Highlighted : MenuItemType.Standard, () =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricEditorClipboard.cs
@@ -12,7 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Lyrics.States;
@@ -402,7 +402,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics
             }
         }
 
-        private IEnumerable<Singer> getMatchedSinges(IEnumerable<int> singerIds)
+        private IEnumerable<ISinger> getMatchedSinges(IEnumerable<int> singerIds)
         {
             return singersChangeHandler == null ? throw new NullDependencyException($"Missing {nameof(singersChangeHandler)}") : singersChangeHandler.Singers.Where(x => singerIds.Contains(x.ID));
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/Rows/Info/Badge/SingerInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/LyricList/Rows/Info/Badge/SingerInfo.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.LyricList.Rows.Info.Badge
                 if (beatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
                     return;
 
-                var singers = karaokeBeatmap.Singers.Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
+                // todo: should get the singer directly from the lyric eventually.
+                var singers = karaokeBeatmap.SingerInfo.GetAllSingers().Where(singer => LyricUtils.ContainsSinger(lyric, singer)).ToList();
                 singerDisplay.Current.Value = singers;
             }, true);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Singers/SingerEditSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Lyrics/Settings/Singers/SingerEditSection.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Singers
 {
     public class SingerEditSection : LyricPropertySection
     {
-        private readonly IBindableList<Singer> bindableSingers = new BindableList<Singer>();
+        private readonly IBindableList<ISinger> bindableSingers = new BindableList<ISinger>();
         private readonly IBindableList<int> singerIndexes = new BindableList<int>();
         protected override LocalisableString Title => "Singer";
 
@@ -110,19 +111,22 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Singers
                 _ => throw new ArgumentOutOfRangeException(nameof(lockLyricPropertyBy), lockLyricPropertyBy, null)
             };
 
-        public class LabelledSingerSwitchButton : LabelledSwitchButton, IHasCustomTooltip<Singer>
+        public class LabelledSingerSwitchButton : LabelledSwitchButton, IHasCustomTooltip<ISinger>
         {
             private const float avatar_size = 48f;
 
             private readonly IBindable<string> bindableName = new Bindable<string>();
             private readonly IBindable<string> bindableEnglishName = new Bindable<string>();
 
-            public LabelledSingerSwitchButton(Singer singer)
+            public LabelledSingerSwitchButton(ISinger singer)
             {
                 TooltipContent = singer;
 
-                bindableName.BindTo(singer.NameBindable);
-                bindableEnglishName.BindTo(singer.EnglishNameBindable);
+                if (singer is Singer mainSinger)
+                {
+                    bindableName.BindTo(mainSinger.NameBindable);
+                    bindableEnglishName.BindTo(mainSinger.EnglishNameBindable);
+                }
 
                 if (InternalChildren[1] is FillFlowContainer fillFlowContainer)
                 {
@@ -152,9 +156,9 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Lyrics.Settings.Singers
                 bindableEnglishName.BindValueChanged(e => Description = string.IsNullOrEmpty(e.NewValue) ? "<No english name>" : e.NewValue, true);
             }
 
-            public ITooltip<Singer> GetCustomTooltip() => new SingerToolTip();
+            public ITooltip<ISinger> GetCustomTooltip() => new SingerToolTip();
 
-            public Singer TooltipContent { get; }
+            public ISinger TooltipContent { get; }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/CreateNewLyricPlacementRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/Rows/CreateNewLyricPlacementRow.cs
@@ -37,11 +37,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers.Rows
                     TooltipText = "Click to add new singer",
                     Action = () =>
                     {
-                        int singerId = beatmapSingersChangeHandler.Singers.Count + 1;
-                        beatmapSingersChangeHandler.Add(new Singer(singerId)
-                        {
-                            Name = "New singer"
-                        });
+                        beatmapSingersChangeHandler.Add();
                     }
                 }
             };

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerRearrangeableList.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerRearrangeableList.cs
@@ -1,19 +1,17 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.Singers.Rows;
 using osu.Game.Rulesets.Karaoke.Graphics.Containers;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {
-    public class SingerRearrangeableList : OrderRearrangeableListContainer<Singer>
+    public class SingerRearrangeableList : OrderRearrangeableListContainer<ISinger>
     {
         protected override Vector2 Spacing => new(0, 5);
 
@@ -26,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
             };
         }
 
-        protected override OsuRearrangeableListItem<Singer> CreateOsuDrawable(Singer item)
+        protected override OsuRearrangeableListItem<ISinger> CreateOsuDrawable(ISinger item)
             => new SingerRearrangeableListItem(item);
 
         protected override Drawable CreateBottomDrawable()

--- a/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerRearrangeableListItem.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Singers/SingerRearrangeableListItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -11,15 +9,16 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas.Types;
 using osu.Game.Rulesets.Karaoke.Edit.Singers.Rows;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Singers
 {
-    public class SingerRearrangeableListItem : OsuRearrangeableListItem<Singer>
+    public class SingerRearrangeableListItem : OsuRearrangeableListItem<ISinger>
     {
-        private Box dragAlert;
+        private Box dragAlert = null!;
 
-        public SingerRearrangeableListItem(Singer item)
+        public SingerRearrangeableListItem(ISinger item)
             : base(item)
         {
         }
@@ -39,7 +38,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Singers
                         RelativeSizeAxes = Axes.Both,
                         Alpha = 0
                     },
-                    new SingerLyricPlacementColumn(Model)
+                    new SingerLyricPlacementColumn(Model as Singer)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }

--- a/osu.Game.Rulesets.Karaoke/Statistics/BeatmapMetadataGraph.cs
+++ b/osu.Game.Rulesets.Karaoke/Statistics/BeatmapMetadataGraph.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Karaoke.Statistics
                             },
                             new SingerMetadataSection("Singer")
                             {
-                                Singers = karaokeBeatmap?.Singers.ToArray()
+                                Singers = karaokeBeatmap?.SingerInfo.GetAllSingers().ToArray()
                             }
                         },
                     },

--- a/osu.Game.Rulesets.Karaoke/Utils/OrderUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/OrderUtils.cs
@@ -30,11 +30,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <typeparam name="T">IHasOrder</typeparam>
         /// <param name="objects">objects</param>
         /// <returns>min order number.</returns>
-        public static int GetMinOrderNumber<T>(T[] objects) where T : IHasOrder
+        public static int GetMinOrderNumber<T>(IEnumerable<T> objects) where T : IHasOrder
         {
-            if (objects == null)
-                throw new ArgumentNullException(nameof(objects));
-
             return objects.OrderBy(x => x.Order).FirstOrDefault()?.Order ?? 0;
         }
 
@@ -44,11 +41,8 @@ namespace osu.Game.Rulesets.Karaoke.Utils
         /// <typeparam name="T">IHasOrder</typeparam>
         /// <param name="objects">objects</param>
         /// <returns>max order number.</returns>
-        public static int GetMaxOrderNumber<T>(T[] objects) where T : IHasOrder
+        public static int GetMaxOrderNumber<T>(IEnumerable<T> objects) where T : IHasOrder
         {
-            if (objects == null)
-                throw new ArgumentNullException(nameof(objects));
-
             return objects.OrderByDescending(x => x.Order).FirstOrDefault()?.Order ?? 0;
         }
 


### PR DESCRIPTION
Implement part of #1769

What's done in this PR:
- Apply the singer info into the karaoke beatmap.
- Fix the api broken.
- Adjust the change handler for able to add or move the singer in the singer info.
- Fix remaining api broken in the test project.