### PR TITLE
Implement beatmap page change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Visual;
 
@@ -47,6 +48,24 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
                 editorBeatmap,
                 changeHandler = new TChangeHandler()
             };
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            AddStep("Setup", () =>
+            {
+                var editorBeatmap = Dependencies.Get<EditorBeatmap>();
+                editorBeatmap.Clear();
+                editorBeatmap.SelectedHitObjects.Clear();
+
+                if (editorBeatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
+                    throw new InvalidCastException();
+
+                karaokeBeatmap.AvailableTranslates.Clear();
+                karaokeBeatmap.SingerInfo = new SingerInfo();
+                karaokeBeatmap.PageInfo = new PageInfo();
+            });
         }
 
         protected void SetUpEditorBeatmap(Action<EditorBeatmap> action)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Visual;
 
@@ -129,6 +132,50 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
                 assert.Invoke(karaokeBeatmap);
             });
+        }
+
+        protected void PrepareHitObject(HitObject hitObject, bool selected = true)
+            => PrepareHitObjects(new[] { hitObject }, selected);
+
+        protected void PrepareHitObjects(IEnumerable<HitObject> selectedHitObjects, bool selected = true)
+        {
+            AddStep("Prepare testing hit objects", () =>
+            {
+                var hitobjects = selectedHitObjects.ToList();
+                var editorBeatmap = Dependencies.Get<EditorBeatmap>();
+
+                editorBeatmap.AddRange(hitobjects);
+
+                if (selected)
+                {
+                    editorBeatmap.SelectedHitObjects.AddRange(hitobjects);
+                }
+            });
+        }
+
+        protected void AssertHitObject<THitObject>(Action<THitObject> assert) where THitObject : HitObject
+        {
+            AssertHitObjects<THitObject>(hitObjects =>
+            {
+                foreach (var hitObject in hitObjects)
+                {
+                    assert(hitObject);
+                }
+            });
+        }
+
+        protected void AssertHitObjects<THitObject>(Action<IEnumerable<THitObject>> assert) where THitObject : HitObject
+        {
+            AddStep("Is result matched", () =>
+            {
+                var editorBeatmap = Dependencies.Get<EditorBeatmap>();
+                assert(editorBeatmap.HitObjects.OfType<THitObject>());
+            });
+
+            // even if there's no property changed in the lyric editor, should still trigger the change handler.
+            // because every change handler call should cause one undo step.
+            // also, technically should not call the change handler if there's no possible to change the properties.
+            AssertTransactionOnlyTriggerOnce();
         }
 
         protected void AssertTransactionOnlyTriggerOnce()

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 using osu.Game.Rulesets.Objects;
@@ -21,16 +20,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
         private void load()
         {
             editorBeatmap = Dependencies.Get<EditorBeatmap>();
-        }
-
-        [SetUp]
-        public virtual void SetUp()
-        {
-            AddStep("Setup", () =>
-            {
-                editorBeatmap.Clear();
-                editorBeatmap.SelectedHitObjects.Clear();
-            });
         }
 
         protected void PrepareHitObject(HitObject hitObject, bool selected = true)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -14,53 +14,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
     public abstract class BaseHitObjectChangeHandlerTest<TChangeHandler, THitObject> : BaseChangeHandlerTest<TChangeHandler>
         where TChangeHandler : HitObjectChangeHandler<THitObject>, new() where THitObject : HitObject
     {
-        private EditorBeatmap editorBeatmap = null!;
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            editorBeatmap = Dependencies.Get<EditorBeatmap>();
-        }
-
-        protected void PrepareHitObject(HitObject hitObject, bool selected = true)
-            => PrepareHitObjects(new[] { hitObject }, selected);
-
-        protected void PrepareHitObjects(IEnumerable<HitObject> selectedHitObjects, bool selected = true)
-        {
-            AddStep("Prepare testing hit objects", () =>
-            {
-                var hitobjects = selectedHitObjects.ToList();
-                editorBeatmap.AddRange(hitobjects);
-
-                if (selected)
-                {
-                    editorBeatmap.SelectedHitObjects.AddRange(hitobjects);
-                }
-            });
-        }
-
         protected void AssertHitObject(Action<THitObject> assert)
         {
-            AssertHitObjects(hitObjects =>
-            {
-                foreach (var hitObject in hitObjects)
-                {
-                    assert(hitObject);
-                }
-            });
+            AssertHitObject<THitObject>(assert);
         }
 
         protected void AssertHitObjects(Action<IEnumerable<THitObject>> assert)
         {
-            AddStep("Is result matched", () =>
-            {
-                assert(editorBeatmap.HitObjects.OfType<THitObject>());
-            });
-
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
+            AssertHitObjects<THitObject>(assert);
         }
 
         protected void AssertSelectedHitObject(Action<THitObject> assert)
@@ -78,6 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
         {
             AddStep("Is result matched", () =>
             {
+                var editorBeatmap = Dependencies.Get<EditorBeatmap>();
                 assert(editorBeatmap.SelectedHitObjects.OfType<THitObject>());
             });
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -41,18 +41,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
         protected void AssertHitObject(Action<THitObject> assert)
         {
-            AddStep("Is result matched", () =>
+            AssertHitObjects(hitObjects =>
             {
-                foreach (var hitObject in editorBeatmap.HitObjects.OfType<THitObject>())
+                foreach (var hitObject in hitObjects)
                 {
                     assert(hitObject);
                 }
             });
-
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
         }
 
         protected void AssertHitObjects(Action<IEnumerable<THitObject>> assert)
@@ -70,18 +65,13 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
         protected void AssertSelectedHitObject(Action<THitObject> assert)
         {
-            AddStep("Is result matched", () =>
+            AssertSelectedHitObjects(hitObjects =>
             {
-                foreach (var hitObject in editorBeatmap.SelectedHitObjects.OfType<THitObject>())
+                foreach (var hitObject in hitObjects)
                 {
                     assert(hitObject);
                 }
             });
-
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
         }
 
         protected void AssertSelectedHitObjects(Action<IEnumerable<THitObject>> assert)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapLanguagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapLanguagesChangeHandlerTest.cs
@@ -69,19 +69,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps
                     new("zh-TW"),
                     new("Ja-jp")
                 };
+            });
 
-                karaokeBeatmap.HitObjects = new List<KaraokeHitObject>
+            PrepareHitObject(new Lyric
+            {
+                Translates = new Dictionary<CultureInfo, string>
                 {
-                    new Lyric
                     {
-                        Translates = new Dictionary<CultureInfo, string>
-                        {
-                            {
-                                new("zh-TW"), "卡拉 OK"
-                            }
-                        }
+                        new("zh-TW"), "卡拉 OK"
                     }
-                };
+                }
             });
 
             TriggerHandlerChanged(c =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandlerTest.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps;
+
+public class BeatmapPagesChangeHandlerTest : BaseChangeHandlerTest<BeatmapPagesChangeHandler>
+{
+    [Test]
+    public void TestAdd()
+    {
+        Page page = new Page();
+
+        TriggerHandlerChanged(c =>
+        {
+            c.Add(page);
+        });
+
+        AssertKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            Assert.AreEqual(1, pages.Count);
+            Assert.AreEqual(page, pages[0]);
+        });
+    }
+
+    [Test]
+    public void TestRemove()
+    {
+        Page firstPage = new Page { Time = 1000 };
+        Page secondPage = new Page { Time = 2000 };
+
+        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            pages.Add(firstPage);
+            pages.Add(secondPage);
+        });
+
+        TriggerHandlerChanged(c =>
+        {
+            c.Remove(firstPage);
+        });
+
+        AssertKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            Assert.AreEqual(1, pages.Count);
+
+            Assert.AreEqual(secondPage, pages[0]);
+        });
+    }
+
+    [Test]
+    public void TestRemoveRange()
+    {
+        Page firstPage = new Page { Time = 1000 };
+        Page secondPage = new Page { Time = 2000 };
+
+        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            pages.Add(firstPage);
+            pages.Add(secondPage);
+        });
+
+        TriggerHandlerChanged(c =>
+        {
+            c.RemoveRange(new[] { firstPage });
+        });
+
+        AssertKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            Assert.AreEqual(1, pages.Count);
+
+            Assert.AreEqual(secondPage, pages[0]);
+        });
+    }
+
+    [Test]
+    public void TestShiftingPageTime()
+    {
+        Page firstPage = new Page();
+        Page secondPage = new Page();
+
+        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        {
+            var pages = karaokeBeatmap.PageInfo.Pages;
+            pages.Add(firstPage);
+            pages.Add(secondPage);
+        });
+
+        TriggerHandlerChanged(c =>
+        {
+            c.ShiftingPageTime(new[] { firstPage }, 1000);
+        });
+
+        AssertKaraokeBeatmap(_ =>
+        {
+            Assert.AreEqual(1000, firstPage.Time);
+            Assert.AreEqual(0, secondPage.Time);
+        });
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
+
+public class BeatmapPagesChangeHandler : BeatmapPropertyChangeHandler, IBeatmapPagesChangeHandler
+{
+    public void Add(Page page)
+    {
+        performPageInfoChanged(pageInfo =>
+        {
+            pageInfo.Pages.Add(page);
+        });
+    }
+
+    public void Remove(Page page)
+    {
+        performPageInfoChanged(pageInfo =>
+        {
+            pageInfo.Pages.Remove(page);
+        });
+    }
+
+    public void RemoveRange(IEnumerable<Page> pages)
+    {
+        performPageInfoChanged(pageInfo =>
+        {
+            foreach (var page in pages.ToArray())
+            {
+                pageInfo.Pages.Remove(page);
+            }
+        });
+    }
+
+    public void ShiftingPageTime(IEnumerable<Page> pages, double offset)
+    {
+        performPageInfoChanged(pageInfo =>
+        {
+            foreach (var page in pages)
+            {
+                if (!pageInfo.Pages.Contains(page))
+                    throw new InvalidOperationException("All pages should be in the page info.");
+
+                page.Time += offset;
+            }
+        });
+    }
+
+    private void performPageInfoChanged(Action<PageInfo> action)
+    {
+        PerformBeatmapChanged(beatmap =>
+        {
+            action(beatmap.PageInfo);
+        });
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapPagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapPagesChangeHandler.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
+
+public interface IBeatmapPagesChangeHandler
+{
+    void Add(Page page);
+
+    void Remove(Page page);
+
+    void RemoveRange(IEnumerable<Page> pages);
+
+    void ShiftingPageTime(IEnumerable<Page> pages, double offset);
+}


### PR DESCRIPTION
Implement part of issue #1766.

What's done in this PR:
- Refactor the base change handler test utils for able to test hit-object in the beatmap-related change handler.
- Implement the beatmap page change handler.