### PR TITLE
Implement beatmap page checks.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
@@ -13,8 +13,12 @@ public class PageInfoTest
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 999, null)]
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1000, 1000)]
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1001, 1000)]
-    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4001, 4000)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4000, 4000)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4001, null)]
     [TestCase(new double[] { }, 0, null)]
+    [TestCase(new double[] { 1000 }, 999, null)] // should be able to get the time only if time is between two pages.
+    [TestCase(new double[] { 1000 }, 1000, null)]
+    [TestCase(new double[] { 1000 }, 1002, null)]
     [TestCase(new double[] { 4000, 3000, 2000, 1000 }, 1000, 1000)] // should works even not sorting.
     public void TestGetPageAt(double[] times, double time, double? expectedTime)
     {
@@ -29,8 +33,12 @@ public class PageInfoTest
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 999, null)]
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1000, 0)]
     [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 1001, 0)]
-    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4001, 3)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4000, 3)]
+    [TestCase(new double[] { 1000, 2000, 3000, 4000 }, 4001, null)]
     [TestCase(new double[] { }, 0, null)]
+    [TestCase(new double[] { 1000 }, 999, null)] // should be able to get the time only if time is between two pages.
+    [TestCase(new double[] { 1000 }, 1000, null)]
+    [TestCase(new double[] { 1000 }, 1002, null)]
     [TestCase(new double[] { 4000, 3000, 2000, 1000 }, 1000, 0)] // should works even not sorting.
     public void TestGetPageIndexAt(double[] times, double time, int? expectedIndex)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/BaseCheckTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/BaseCheckTest.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
-    public class BaseCheckTest<TCheck> where TCheck : class, ICheck, new()
+    public abstract class BaseCheckTest<TCheck> where TCheck : class, ICheck, new()
     {
         private TCheck check = null!;
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/BeatmapPropertyCheckTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/BeatmapPropertyCheckTest.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
+
+public abstract class BeatmapPropertyCheckTest<TCheck> : BaseCheckTest<TCheck> where TCheck : class, ICheck, new()
+{
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
@@ -17,7 +17,7 @@ using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapAvailableTranslat
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
     [TestFixture]
-    public class CheckBeatmapAvailableTranslatesTest : BaseCheckTest<CheckBeatmapAvailableTranslates>
+    public class CheckBeatmapAvailableTranslatesTest : BeatmapPropertyCheckTest<CheckBeatmapAvailableTranslates>
     {
         [Test]
         public void TestNoLyricAndNoLanguage()

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapPageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapPageInfoTest.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit.Checks;
+using osu.Game.Rulesets.Karaoke.Edit.Checks.Issues;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Beatmaps;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapPageInfo;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
+
+public class CheckBeatmapPageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapPageInfo>
+{
+    [Test]
+    public void TestCheckLessThanTwoPages()
+    {
+        var pages = new List<Page>
+        {
+            new(),
+        };
+
+        var lyrics = new List<Lyric>
+        {
+            new(),
+        };
+
+        // should have at least two pages.
+        var beatmap = createTestingBeatmap(null, null);
+        AssertNotOk<Issue, IssueTemplateLessThanTwoPages>(getContext(beatmap));
+
+        // should have at least two pages.
+        var beatmap2 = createTestingBeatmap(pages, null);
+        AssertNotOk<Issue, IssueTemplateLessThanTwoPages>(getContext(beatmap2));
+
+        // should have at least two pages.
+        var beatmap3 = createTestingBeatmap(null, lyrics);
+        AssertNotOk<Issue, IssueTemplateLessThanTwoPages>(getContext(beatmap3));
+
+        // should have at least two pages.
+        var beatmap4 = createTestingBeatmap(pages, lyrics);
+        AssertNotOk<Issue, IssueTemplateLessThanTwoPages>(getContext(beatmap4));
+    }
+
+    [Test]
+    public void TestCheckPageIntervalTooShort()
+    {
+        var pages = new List<Page>
+        {
+            new()
+            {
+                Time = 0,
+            },
+            new()
+            {
+                Time = MIN_INTERVAL - 1,
+            },
+        };
+
+        var lyrics = new List<Lyric>
+        {
+            // create a lyric that between two time-tags
+            new()
+            {
+                TimeTags = new List<TimeTag>
+                {
+                    new(new TextIndex(), 500)
+                }
+            },
+        };
+
+        var beatmap = createTestingBeatmap(pages, lyrics);
+        AssertNotOk<BeatmapPageIssue, IssueTemplatePageIntervalTooShort>(getContext(beatmap));
+    }
+
+    [Test]
+    public void TestCheckPageIntervalTooLong()
+    {
+        var pages = new List<Page>
+        {
+            new()
+            {
+                Time = 0,
+            },
+            new()
+            {
+                Time = MAX_INTERVAL + 1,
+            },
+        };
+
+        var lyrics = new List<Lyric>
+        {
+            // create a lyric that between two time-tags
+            new()
+            {
+                TimeTags = new List<TimeTag>
+                {
+                    new(new TextIndex(), 1000)
+                }
+            },
+        };
+
+        var beatmap = createTestingBeatmap(pages, lyrics);
+        AssertNotOk<BeatmapPageIssue, IssueTemplatePageIntervalTooLong>(getContext(beatmap));
+    }
+
+    [Test]
+    public void TestCheckPageIntervalShouldHaveAtLeastOneLyric()
+    {
+        var pages = new List<Page>
+        {
+            new()
+            {
+                Time = 0,
+            },
+            new()
+            {
+                Time = MIN_INTERVAL,
+            },
+        };
+
+        var beatmap = createTestingBeatmap(pages, null);
+        AssertNotOk<BeatmapPageIssue, IssueTemplatePageIntervalShouldHaveAtLeastOneLyric>(getContext(beatmap));
+    }
+
+    [Test]
+    public void TestCheckLyricNotWrapIntoTime()
+    {
+        var pages = new List<Page>
+        {
+            new()
+            {
+                Time = 0,
+            },
+            new()
+            {
+                Time = MIN_INTERVAL,
+            },
+        };
+
+        var timeTag = new TimeTag(new TextIndex(), 2000);
+
+        var lyrics = new List<Lyric>
+        {
+            // create a lyric that between two time-tags
+            new()
+            {
+                TimeTags = new List<TimeTag>
+                {
+                    new(new TextIndex(), MIN_INTERVAL - 1)
+                }
+            },
+            // another lyric's time is adjustable.
+            new()
+            {
+                TimeTags = new List<TimeTag>
+                {
+                    timeTag
+                }
+            },
+        };
+
+        // should be OK
+        var beatmap = createTestingBeatmap(pages, lyrics);
+        AssertOk(getContext(beatmap));
+
+        // out of range.
+        timeTag.Time = -1;
+        var beatmap2 = createTestingBeatmap(pages, lyrics);
+        AssertNotOk<LyricIssue, IssueTemplateLyricNotWrapIntoTime>(getContext(beatmap2));
+
+        // out of range.
+        timeTag.Time = MIN_INTERVAL + 1;
+        var beatmap3 = createTestingBeatmap(pages, lyrics);
+        AssertNotOk<LyricIssue, IssueTemplateLyricNotWrapIntoTime>(getContext(beatmap3));
+    }
+
+    private static IBeatmap createTestingBeatmap(IEnumerable<Page>? pages, IEnumerable<Lyric>? lyrics)
+    {
+        var karaokeBeatmap = new KaraokeBeatmap
+        {
+            BeatmapInfo =
+            {
+                Ruleset = new KaraokeRuleset().RulesetInfo,
+            },
+            HitObjects = lyrics?.OfType<KaraokeHitObject>().ToList() ?? new List<KaraokeHitObject>()
+        };
+        karaokeBeatmap.PageInfo.Pages.AddRange(pages ?? new List<Page>());
+        return new EditorBeatmap(karaokeBeatmap);
+    }
+
+    private static BeatmapVerifierContext getContext(IBeatmap beatmap)
+        => new(beatmap, new TestWorkingBeatmap(beatmap));
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/HitObjectCheckTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/HitObjectCheckTest.cs
@@ -11,7 +11,7 @@ using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
 {
-    public class HitObjectCheckTest<THitObject, TCheck> : BaseCheckTest<TCheck> where TCheck : class, ICheck, new()
+    public abstract class HitObjectCheckTest<THitObject, TCheck> : BaseCheckTest<TCheck> where TCheck : class, ICheck, new()
     {
         protected void AssertOk(HitObject hitObject)
         {

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
@@ -15,7 +15,17 @@ public class PageInfo : IDeepCloneable<PageInfo>
 
     public Page? GetPageAt(double time)
     {
-        return Pages.LastOrDefault(x => x.Time <= time);
+        if (Pages.Count < 2)
+            return null;
+
+        var page = Pages.LastOrDefault(x => x.Time <= time);
+
+        // should not be able to get the page if time exceed the last page.
+        var lastPage = Pages.LastOrDefault();
+        if (page == lastPage && page?.Time < time)
+            return null;
+
+        return page;
     }
 
     public int? GetPageIndexAt(double time)

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
@@ -1,45 +1,47 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
-    public class CheckBeatmapAvailableTranslates : ICheck
+    public class CheckBeatmapAvailableTranslates : CheckBeatmapProperty<IList<CultureInfo>, Lyric>
     {
-        public CheckMetadata Metadata => new(CheckCategory.HitObjects, "Lyrics with invalid translations.");
+        protected override string Description => "Lyrics with invalid translations.";
 
-        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
             new IssueTemplateMissingTranslate(this),
             new IssueTemplateMissingPartialTranslate(this),
             new IssueTemplateContainsNotListedLanguage(this)
         };
 
-        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
-        {
-            var languages = availableTranslateInBeatmap(context.Beatmap);
+        protected override IList<CultureInfo> GetPropertyFromBeatmap(KaraokeBeatmap karaokeBeatmap)
+            => karaokeBeatmap.AvailableTranslates;
 
-            var lyrics = context.Beatmap.HitObjects.OfType<Lyric>().ToList();
-            if (lyrics.Count == 0)
+        protected override IEnumerable<Issue> CheckProperty(IList<CultureInfo> property)
+        {
+            // todo: maybe check duplicated languages?
+            yield break;
+        }
+
+        protected override IEnumerable<Issue> CheckHitObjects(IList<CultureInfo> property, IReadOnlyList<Lyric> hitObject)
+        {
+            if (hitObject.Count == 0)
                 yield break;
 
             // check if some translate is missing or empty.
-            foreach (var language in languages)
+            foreach (var language in property)
             {
-                var notTranslateLyrics = lyrics.Where(x => !x.Translates.ContainsKey(language) || string.IsNullOrWhiteSpace(x.Translates[language])).ToArray();
+                var notTranslateLyrics = hitObject.Where(x => !x.Translates.ContainsKey(language) || string.IsNullOrWhiteSpace(x.Translates[language])).ToArray();
 
-                if (notTranslateLyrics.Length == lyrics.Count)
+                if (notTranslateLyrics.Length == hitObject.Count)
                 {
                     yield return new IssueTemplateMissingTranslate(this).Create(notTranslateLyrics, language);
                 }
@@ -51,26 +53,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 
             // should check is lyric contains translate that is not listed in beatmap.
             // if got this issue, then it's a bug.
-            var allTranslateLanguageInLyric = lyrics.SelectMany(x => x.Translates.Keys).Distinct();
-            var languageNotListInBeatmap = allTranslateLanguageInLyric.Except(languages);
+            var allTranslateLanguageInLyric = hitObject.SelectMany(x => x.Translates.Keys).Distinct();
+            var languageNotListInBeatmap = allTranslateLanguageInLyric.Except(property);
 
             foreach (var language in languageNotListInBeatmap)
             {
-                var notTranslateLyrics = lyrics.Where(x => !x.Translates.ContainsKey(language));
+                var notTranslateLyrics = hitObject.Where(x => !x.Translates.ContainsKey(language));
 
                 yield return new IssueTemplateContainsNotListedLanguage(this).Create(notTranslateLyrics, language);
             }
-        }
-
-        private IList<CultureInfo> availableTranslateInBeatmap(IBeatmap beatmap)
-        {
-            if (beatmap is not EditorBeatmap editorBeatmap)
-                return Array.Empty<CultureInfo>();
-
-            if (editorBeatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
-                return Array.Empty<CultureInfo>();
-
-            return karaokeBeatmap.AvailableTranslates;
         }
 
         public class IssueTemplateMissingTranslate : IssueTemplate

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapAvailableTranslates.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
 {
     public class CheckBeatmapAvailableTranslates : CheckBeatmapProperty<IList<CultureInfo>, Lyric>
     {
-        protected override string Description => "Lyrics with invalid translations.";
+        protected override string Description => "Beatmap with invalid localization info.";
 
         public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit.Checks.Issues;
+using osu.Game.Rulesets.Karaoke.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
+
+public class CheckBeatmapPageInfo : CheckBeatmapProperty<PageInfo, Lyric>
+{
+    public const double MIN_INTERVAL = 3000;
+
+    public const double MAX_INTERVAL = 10000;
+
+    protected override string Description => "Check invalid page in the beatmap";
+
+    public override IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+    {
+        new IssueTemplateLessThanTwoPages(this),
+        new IssueTemplatePageIntervalTooShort(this),
+        new IssueTemplatePageIntervalTooLong(this),
+        new IssueTemplatePageIntervalShouldHaveAtLeastOneLyric(this),
+        new IssueTemplateLyricNotWrapIntoTime(this)
+    };
+
+    protected override PageInfo GetPropertyFromBeatmap(KaraokeBeatmap karaokeBeatmap)
+        => karaokeBeatmap.PageInfo;
+
+    protected override IEnumerable<Issue> CheckProperty(PageInfo property)
+    {
+        var pages = property.Pages;
+
+        if (pages.Count < 2)
+        {
+            yield return new IssueTemplateLessThanTwoPages(this).Create();
+
+            yield break;
+        }
+
+        for (int i = 1; i < pages.Count; i++)
+        {
+            var previous = pages[i - 1];
+            var current = pages[i];
+
+            double previousTime = previous.Time;
+            double currentTime = current.Time;
+
+            if (currentTime - previousTime < MIN_INTERVAL)
+                yield return new IssueTemplatePageIntervalTooShort(this).Create(previous, current);
+
+            if (currentTime - previousTime > MAX_INTERVAL)
+                yield return new IssueTemplatePageIntervalTooLong(this).Create(previous, current);
+        }
+    }
+
+    protected override IEnumerable<Issue> CheckHitObjects(PageInfo property, IReadOnlyList<Lyric> hitObject)
+    {
+        var pages = property.Pages;
+        if (pages.Count < 2)
+            yield break;
+
+        var availablePagesInObject = hitObject.ToDictionary(k => k, v => property.GetPageAt(v.LyricStartTime));
+
+        var missingHitObjectPages = pages.Where(page => !availablePagesInObject.Values.Contains(page)).ToArray();
+
+        for (int i = 1; i < missingHitObjectPages.Length; i++)
+        {
+            var previous = missingHitObjectPages[i - 1];
+            var current = missingHitObjectPages[i];
+
+            yield return new IssueTemplatePageIntervalShouldHaveAtLeastOneLyric(this).Create(previous, current);
+        }
+
+        foreach (var lyric in availablePagesInObject.Where(x => x.Value == null).Select(x => x.Key))
+        {
+            yield return new IssueTemplateLyricNotWrapIntoTime(this).Create(lyric);
+        }
+    }
+
+    public class IssueTemplateLessThanTwoPages : IssueTemplate
+    {
+        public IssueTemplateLessThanTwoPages(ICheck check)
+            : base(check, IssueType.Warning, "Should have at least two pages.")
+        {
+        }
+
+        public Issue Create() => new(this);
+    }
+
+    public class IssueTemplatePageIntervalTooShort : IssueTemplate
+    {
+        public IssueTemplatePageIntervalTooShort(ICheck check)
+            : base(check, IssueType.Warning, "Interval between two pages are too short.")
+        {
+        }
+
+        public Issue Create(Page startPage, Page endPage)
+            => new BeatmapPageIssue(startPage, endPage, this);
+    }
+
+    public class IssueTemplatePageIntervalTooLong : IssueTemplate
+    {
+        public IssueTemplatePageIntervalTooLong(ICheck check)
+            : base(check, IssueType.Warning, "Interval between two pages are too long.")
+        {
+        }
+
+        public Issue Create(Page startPage, Page endPage)
+            => new BeatmapPageIssue(startPage, endPage, this);
+    }
+
+    public class IssueTemplatePageIntervalShouldHaveAtLeastOneLyric : IssueTemplate
+    {
+        public IssueTemplatePageIntervalShouldHaveAtLeastOneLyric(ICheck check)
+            : base(check, IssueType.Negligible, "Should have at least one lyric between two pages.")
+        {
+        }
+
+        public Issue Create(Page startPage, Page endPage)
+            => new BeatmapPageIssue(startPage, endPage, this);
+    }
+
+    public class IssueTemplateLyricNotWrapIntoTime : IssueTemplate
+    {
+        public IssueTemplateLyricNotWrapIntoTime(ICheck check)
+            : base(check, IssueType.Negligible, "Lyric is not wrap by the page.")
+        {
+        }
+
+        public Issue Create(Lyric lyric)
+            => new LyricIssue(lyric, this);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapProperty.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
+
+public abstract class CheckBeatmapProperty<TProperty, THitObject> : ICheck where THitObject : KaraokeHitObject
+{
+    public CheckMetadata Metadata => new(CheckCategory.Metadata, Description);
+
+    protected abstract string Description { get; }
+
+    public abstract IEnumerable<IssueTemplate> PossibleTemplates { get; }
+
+    public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+    {
+        var beatmap = getBeatmap(context);
+        var property = GetPropertyFromBeatmap(beatmap);
+
+        var issues = CheckProperty(property);
+        var hitObjectIssues = context.Beatmap.HitObjects.OfType<THitObject>().SelectMany(x => CheckHitObject(property, x));
+        var hitObjectsIssues = CheckHitObjects(property, context.Beatmap.HitObjects.OfType<THitObject>().ToList());
+
+        return issues.Concat(hitObjectIssues).Concat(hitObjectsIssues);
+    }
+
+    protected abstract TProperty GetPropertyFromBeatmap(KaraokeBeatmap karaokeBeatmap);
+
+    protected virtual IEnumerable<Issue> CheckProperty(TProperty property)
+    {
+        yield break;
+    }
+
+    protected virtual IEnumerable<Issue> CheckHitObject(TProperty property, THitObject hitObject)
+    {
+        yield break;
+    }
+
+    protected virtual IEnumerable<Issue> CheckHitObjects(TProperty property, IReadOnlyList<THitObject> hitObject)
+    {
+        yield break;
+    }
+
+    private static KaraokeBeatmap getBeatmap(BeatmapVerifierContext context)
+    {
+        // follow the usage in the IssueList in osu.Game
+        if (context.Beatmap is EditorBeatmap editorBeatmap && editorBeatmap.PlayableBeatmap is KaraokeBeatmap karaokeBeatmap)
+            return karaokeBeatmap;
+
+        throw new InvalidOperationException();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/BeatmapPageIssue.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/BeatmapPageIssue.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Checks.Issues;
+
+public class BeatmapPageIssue : Issue
+{
+    public Page StartPage;
+
+    public Page EndPage;
+
+    public BeatmapPageIssue(Page startPage, Page endPage, IssueTemplate template, params object[] args)
+        : base(template, args)
+    {
+        StartPage = startPage;
+        EndPage = endPage;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit
         private readonly List<ICheck> checks = new()
         {
             new CheckBeatmapAvailableTranslates(),
+            new CheckBeatmapPageInfo(),
             new CheckLyricLanguage(),
             new CheckLyricReferenceLyric(),
             new CheckLyricRomajiTag(),

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Issues/IssueIcon.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Issues/IssueIcon.cs
@@ -69,6 +69,7 @@ public class IssueIcon : CompositeDrawable
         check switch
         {
             CheckBeatmapAvailableTranslates => FontAwesome.Solid.Language,
+            CheckBeatmapPageInfo => FontAwesome.Solid.Pager,
             CheckLyricLanguage => FontAwesome.Solid.Globe,
             CheckLyricReferenceLyric => FontAwesome.Solid.Link,
             CheckLyricRomajiTag => FontAwesome.Solid.Tag,


### PR DESCRIPTION
Implement part of issue #1766.

What's done in this PR:
- Change the get page rules. Should be able to get the page only if time is between two pages.
- Implement the base check class for able to check the property from the karaoke beatmap.
- Implement the base check test for able to test beatmap property-related check.
- Implement the check for checking page info in the karaoke beatmap.