### PR TITLE
Make `EditModeSection<T>` and `LyricEditorSettings ` more generic.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/TestSceneLyricEditorScreen.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Beatmap
         {
             AddStep("Click the button", () =>
             {
-                var editModeSection = this.ChildrenOfType<EditModeSection<T>>().Single();
+                var editModeSection = this.ChildrenOfType<LyricEditorEditModeSection<T>>().Single();
                 editModeSection.UpdateEditMode(editMode);
             });
             AddWaitStep("wait for switch to new edit mode.", 10);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/IssueSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/IssueSection.cs
@@ -24,7 +24,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class IssueSection : LyricEditorSection
+    public abstract partial class IssueSection : EditorSection
     {
         protected sealed override LocalisableString Title => "Issues";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Language/LanguageEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Language/LanguageEditModeSection.cs
@@ -12,7 +12,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Language
 {
-    public partial class LanguageEditModeSection : EditModeSection<ILanguageModeState, LanguageEditMode>
+    public partial class LanguageEditModeSection : LyricEditorEditModeSection<ILanguageModeState, LanguageEditMode>
     {
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Pink;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Language/LanguageEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Language/LanguageEditModeSection.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Langua
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class LanguageVerifySelection : VerifySelection
+        private partial class LanguageVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.Language;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
         }
     }
 
-    public abstract partial class LyricEditorEditModeSection<TEditMode> : LyricEditorSection where TEditMode : Enum
+    public abstract partial class LyricEditorEditModeSection<TEditMode> : EditorSection where TEditMode : Enum
     {
         private const int horizontal_padding = 20;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -4,8 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -14,15 +12,12 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Components.Markdown;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
-using osu.Game.Rulesets.Karaoke.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
@@ -43,118 +38,23 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
         }
     }
 
-    public abstract partial class LyricEditorEditModeSection<TEditMode> : EditorSection where TEditMode : Enum
+    public abstract partial class LyricEditorEditModeSection<TEditMode> : EditModeSection<TEditMode>
+        where TEditMode : Enum
     {
-        private const int horizontal_padding = 20;
-
         protected sealed override LocalisableString Title => "Edit mode";
-
-        [Cached]
-        private readonly OverlayColourProvider overlayColourProvider;
-
-        [Resolved]
-        private OsuColour colours { get; set; }
 
         [Resolved]
         private ILyricSelectionState lyricSelectionState { get; set; }
 
-        private readonly Selection[] selections;
-        private readonly LyricEditorDescriptionTextFlowContainer lyricEditorDescription;
+        protected override DescriptionTextFlowContainer CreateDescriptionTextFlowContainer()
+            => new LyricEditorDescriptionTextFlowContainer();
 
-        protected LyricEditorEditModeSection()
-        {
-            overlayColourProvider = new OverlayColourProvider(CreateColourScheme());
-
-            Children = new Drawable[]
-            {
-                new GridContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    RowDimensions = new[]
-                    {
-                        new Dimension(GridSizeMode.AutoSize)
-                    },
-                    Content = new[]
-                    {
-                        selections = createSelections()
-                    }
-                },
-                lyricEditorDescription = new LyricEditorDescriptionTextFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = horizontal_padding },
-                }
-            };
-
-            // should wait until derived class BDL ready.
-            Schedule(() =>
-            {
-                UpdateEditMode(DefaultMode());
-            });
-        }
-
-        private Selection[] createSelections()
-            => EnumUtils.GetValues<TEditMode>().Select(mode =>
-            {
-                var selection = CreateSelection(mode);
-                selection.Mode = mode;
-                selection.Text = GetSelectionText(mode);
-                selection.Padding = new MarginPadding { Horizontal = 5 };
-                selection.Action = UpdateEditMode;
-
-                return selection;
-            }).ToArray();
-
-        internal virtual void UpdateEditMode(TEditMode mode)
+        internal override void UpdateEditMode(TEditMode mode)
         {
             // should cancel the selection after change to the new edit mode.
             lyricSelectionState?.EndSelecting(LyricEditorSelectingAction.Cancel);
 
-            // update button style.
-            foreach (var button in selections)
-            {
-                bool highLight = EqualityComparer<TEditMode>.Default.Equals(button.Mode, mode);
-                button.Alpha = highLight ? 0.8f : 0.4f;
-                button.BackgroundColour = GetSelectionColour(colours, button.Mode, highLight);
-
-                if (!highLight)
-                    continue;
-
-                Schedule(() =>
-                {
-                    // update description text.
-                    lyricEditorDescription.Description = GetSelectionDescription(mode);
-                });
-            }
-        }
-
-        protected abstract OverlayColourScheme CreateColourScheme();
-
-        protected abstract TEditMode DefaultMode();
-
-        protected abstract Selection CreateSelection(TEditMode mode);
-
-        protected abstract LocalisableString GetSelectionText(TEditMode mode);
-
-        protected abstract Color4 GetSelectionColour(OsuColour colours, TEditMode mode, bool active);
-
-        protected abstract DescriptionFormat GetSelectionDescription(TEditMode mode);
-
-        protected partial class Selection : OsuButton
-        {
-            public new Action<TEditMode> Action;
-
-            public TEditMode Mode { get; set; }
-
-            public Selection()
-            {
-                RelativeSizeAxes = Axes.X;
-                Content.CornerRadius = 15;
-
-                base.Action = () => Action?.Invoke(Mode);
-            }
+            base.UpdateEditMode(mode);
         }
 
         protected abstract partial class VerifySelection : Selection

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -27,7 +27,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class EditModeSection<TEditModeState, TEditMode> : EditModeSection<TEditMode>
+    public abstract partial class LyricEditorEditModeSection<TEditModeState, TEditMode> : LyricEditorEditModeSection<TEditMode>
         where TEditModeState : IHasEditModeState<TEditMode> where TEditMode : Enum
     {
         [Resolved]
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
         }
     }
 
-    public abstract partial class EditModeSection<TEditMode> : LyricEditorSection where TEditMode : Enum
+    public abstract partial class LyricEditorEditModeSection<TEditMode> : LyricEditorSection where TEditMode : Enum
     {
         private const int horizontal_padding = 20;
 
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
         private readonly Selection[] selections;
         private readonly LyricEditorDescriptionTextFlowContainer lyricEditorDescription;
 
-        protected EditModeSection()
+        protected LyricEditorEditModeSection()
         {
             overlayColourProvider = new OverlayColourProvider(CreateColourScheme());
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -5,20 +5,11 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Overlays.Toolbar;
-using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Components.Markdown;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
@@ -57,91 +48,15 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
             base.UpdateEditMode(mode);
         }
 
-        protected abstract partial class LyricEditorVerifySelection : Selection
+        protected abstract partial class LyricEditorVerifySelection : VerifySelection
         {
-            private readonly IBindableList<Issue> bindableIssues = new BindableList<Issue>();
-
-            protected LyricEditorVerifySelection()
-            {
-                CountCircle countCircle;
-
-                AddInternal(countCircle = new CountCircle
-                {
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.Centre,
-                    X = -5,
-                });
-
-                bindableIssues.BindCollectionChanged((_, _) =>
-                {
-                    int count = bindableIssues.Count;
-                    countCircle.Alpha = count == 0 ? 0 : 1;
-                    countCircle.Count = count;
-                });
-            }
-
             [BackgroundDependencyLoader]
             private void load(ILyricEditorVerifier verifier)
             {
-                bindableIssues.BindTo(verifier.GetIssueByEditMode(EditMode));
+                Issues.BindTo(verifier.GetIssueByEditMode(EditMode));
             }
 
             protected abstract LyricEditorMode EditMode { get; }
-        }
-
-        /// <summary>
-        /// Copied from <see cref="ToolbarNotificationButton"/>
-        /// </summary>
-        private partial class CountCircle : CompositeDrawable
-        {
-            private readonly OsuSpriteText countText;
-            private readonly Circle circle;
-
-            private int count;
-
-            public int Count
-            {
-                get => count;
-                set
-                {
-                    if (count == value)
-                        return;
-
-                    if (value != count)
-                    {
-                        circle.FlashColour(Color4.White, 600, Easing.OutQuint);
-                        this.ScaleTo(1.1f).Then().ScaleTo(1, 600, Easing.OutElastic);
-                    }
-
-                    count = value;
-                    countText.Text = value.ToString("#,0");
-                }
-            }
-
-            public CountCircle()
-            {
-                AutoSizeAxes = Axes.X;
-                Height = 20;
-
-                InternalChildren = new Drawable[]
-                {
-                    circle = new Circle
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Red
-                    },
-                    countText = new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Y = -1,
-                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold),
-                        Padding = new MarginPadding(5),
-                        Colour = Color4.White,
-                        UseFullGlyphHeight = true,
-                    }
-                };
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -57,11 +57,11 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
             base.UpdateEditMode(mode);
         }
 
-        protected abstract partial class VerifySelection : Selection
+        protected abstract partial class LyricEditorVerifySelection : Selection
         {
             private readonly IBindableList<Issue> bindableIssues = new BindableList<Issue>();
 
-            protected VerifySelection()
+            protected LyricEditorVerifySelection()
             {
                 CountCircle countCircle;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorSettings.cs
@@ -3,24 +3,13 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class LyricEditorSettings : EditorRoundedScreenSettings
+    public abstract partial class LyricEditorSettings : EditorSettings
     {
-        public abstract SettingsDirection Direction { get; }
-
-        public abstract float SettingsWidth { get; }
-
-        protected void ReloadSections()
-        {
-            this.ChildrenOfType<FillFlowContainer>().First().Children = CreateSections();
-        }
-
         [BackgroundDependencyLoader]
         private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider)
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricPropertySection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricPropertySection.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class LyricPropertySection : LyricEditorSection
+    public abstract partial class LyricPropertySection : EditorSection
     {
         private readonly IBindable<Lyric?> bindableFocusedLyric = new Bindable<Lyric?>();
         private readonly IBindable<int> bindablePropertyWritableVersion = new Bindable<int>();

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteConfigSection.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Notes
 {
-    public partial class NoteConfigSection : LyricEditorSection
+    public partial class NoteConfigSection : EditorSection
     {
         protected override LocalisableString Title => "Config";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditModeSection.cs
@@ -12,7 +12,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Notes
 {
-    public partial class NoteEditModeSection : EditModeSection<IEditNoteModeState, NoteEditMode>
+    public partial class NoteEditModeSection : LyricEditorEditModeSection<IEditNoteModeState, NoteEditMode>
     {
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Blue;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditModeSection.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Notes
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class NoteVerifySelection : VerifySelection
+        private partial class NoteVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.EditNote;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditPropertyModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Notes/NoteEditPropertyModeSection.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Notes
 {
-    public partial class NoteEditPropertyModeSection : LyricEditorSection
+    public partial class NoteEditPropertyModeSection : EditorSection
     {
         protected override LocalisableString Title => "Edit property";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricAutoGenerateSection.cs
@@ -5,12 +5,11 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator.ReferenceLyric;
-using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Components.Markdown;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Reference
 {
-    public partial class ReferenceLyricAutoGenerateSection : LyricEditorSection
+    public partial class ReferenceLyricAutoGenerateSection : EditorSection
     {
         protected override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
@@ -49,7 +49,7 @@ public partial class ReferenceLyricEditModeSection : LyricEditorEditModeSection<
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
 
-    private partial class ReferenceLyricVerifySelection : VerifySelection
+    private partial class ReferenceLyricVerifySelection : LyricEditorVerifySelection
     {
         protected override LyricEditorMode EditMode => LyricEditorMode.Reference;
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Reference/ReferenceLyricEditModeSection.cs
@@ -12,7 +12,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Reference;
 
-public partial class ReferenceLyricEditModeSection : EditModeSection<IEditReferenceLyricModeState, ReferenceLyricEditMode>
+public partial class ReferenceLyricEditModeSection : LyricEditorEditModeSection<IEditReferenceLyricModeState, ReferenceLyricEditMode>
 {
     protected override OverlayColourScheme CreateColourScheme()
         => OverlayColourScheme.Pink;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/RomajiTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/RomajiTagEditModeSection.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.RubyRo
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class RomajiTagVerifySelection : VerifySelection
+        private partial class RomajiTagVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.EditRomaji;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/RubyTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/RubyTagEditModeSection.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.RubyRo
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class RubyTagVerifySelection : VerifySelection
+        private partial class RubyTagVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.EditRuby;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagAutoGenerateSection.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.RubyRomaji
 {
-    public abstract partial class TextTagAutoGenerateSection : LyricEditorSection
+    public abstract partial class TextTagAutoGenerateSection : EditorSection
     {
         protected sealed override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagEditModeSection.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.RubyRomaji
 {
-    public abstract partial class TextTagEditModeSection<TEditModeState, TEditMode> : EditModeSection<TEditModeState, TEditMode>
+    public abstract partial class TextTagEditModeSection<TEditModeState, TEditMode> : LyricEditorEditModeSection<TEditModeState, TEditMode>
         where TEditModeState : IHasEditModeState<TEditMode>
         where TEditMode : Enum
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/SpecialActionSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/SpecialActionSection.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class SpecialActionSection<TAction> : LyricEditorSection where TAction : struct, Enum
+    public abstract partial class SpecialActionSection<TAction> : EditorSection where TAction : struct, Enum
     {
         protected sealed override LocalisableString Title => "Action";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Texting/TextingEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Texting/TextingEditModeSection.cs
@@ -12,7 +12,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Texting
 {
-    public partial class TextingEditModeSection : EditModeSection<ITextingModeState, TextingEditMode>
+    public partial class TextingEditModeSection : LyricEditorEditModeSection<ITextingModeState, TextingEditMode>
     {
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Red;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Texting/TextingEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/Texting/TextingEditModeSection.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Textin
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class TextingVerifySelection : VerifySelection
+        private partial class TextingVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.Texting;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagAdjustConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagAdjustConfigSection.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTags
 {
-    public partial class TimeTagAdjustConfigSection : LyricEditorSection
+    public partial class TimeTagAdjustConfigSection : EditorSection
     {
         protected override LocalisableString Title => "Config";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagAutoGenerateSection.cs
@@ -16,7 +16,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTags
 {
-    public partial class TimeTagAutoGenerateSection : LyricEditorSection
+    public partial class TimeTagAutoGenerateSection : EditorSection
     {
         protected override LocalisableString Title => "Auto generate";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagCreateConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagCreateConfigSection.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTags
 {
-    public partial class TimeTagCreateConfigSection : LyricEditorSection
+    public partial class TimeTagCreateConfigSection : EditorSection
     {
         protected override LocalisableString Title => "Config Tool";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagEditModeSection.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTa
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
-        private partial class TimeTagVerifySelection : VerifySelection
+        private partial class TimeTagVerifySelection : LyricEditorVerifySelection
         {
             protected override LyricEditorMode EditMode => LyricEditorMode.EditTimeTag;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagEditModeSection.cs
@@ -13,7 +13,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTags
 {
-    public partial class TimeTagEditModeSection : EditModeSection<ITimeTagModeState, TimeTagEditMode>
+    public partial class TimeTagEditModeSection : LyricEditorEditModeSection<ITimeTagModeState, TimeTagEditMode>
     {
         protected override OverlayColourScheme CreateColourScheme()
             => OverlayColourScheme.Orange;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagRecordingConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TimeTagRecordingConfigSection.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.TimeTags
 {
-    public partial class TimeTagRecordingConfigSection : LyricEditorSection
+    public partial class TimeTagRecordingConfigSection : EditorSection
     {
         protected override LocalisableString Title => "Config";
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/EditModeSection.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit;
+
+public abstract partial class EditModeSection<TEditMode> : EditorSection where TEditMode : Enum
+{
+    private const int horizontal_padding = 20;
+
+    [Cached]
+    private readonly OverlayColourProvider overlayColourProvider;
+
+    [Resolved]
+    private OsuColour colours { get; set; }
+
+    private readonly Selection[] selections;
+    private readonly DescriptionTextFlowContainer lyricEditorDescription;
+
+    protected EditModeSection()
+    {
+        overlayColourProvider = new OverlayColourProvider(CreateColourScheme());
+
+        Children = new Drawable[]
+        {
+            new GridContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                RowDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize)
+                },
+                Content = new[]
+                {
+                    selections = createSelections()
+                }
+            },
+            lyricEditorDescription = CreateDescriptionTextFlowContainer().With(x =>
+            {
+                x.RelativeSizeAxes = Axes.X;
+                x.AutoSizeAxes = Axes.Y;
+                x.Padding = new MarginPadding { Horizontal = horizontal_padding };
+            })
+        };
+
+        // should wait until derived class BDL ready.
+        Schedule(() =>
+        {
+            UpdateEditMode(DefaultMode());
+        });
+    }
+
+    private Selection[] createSelections()
+        => EnumUtils.GetValues<TEditMode>().Select(mode =>
+        {
+            var selection = CreateSelection(mode);
+            selection.Mode = mode;
+            selection.Text = GetSelectionText(mode);
+            selection.Padding = new MarginPadding { Horizontal = 5 };
+            selection.Action = UpdateEditMode;
+
+            return selection;
+        }).ToArray();
+
+    internal virtual void UpdateEditMode(TEditMode mode)
+    {
+        // update button style.
+        foreach (var button in selections)
+        {
+            bool highLight = EqualityComparer<TEditMode>.Default.Equals(button.Mode, mode);
+            button.Alpha = highLight ? 0.8f : 0.4f;
+            button.BackgroundColour = GetSelectionColour(colours, button.Mode, highLight);
+
+            if (!highLight)
+                continue;
+
+            Schedule(() =>
+            {
+                // update description text.
+                lyricEditorDescription.Description = GetSelectionDescription(mode);
+            });
+        }
+    }
+
+    protected abstract DescriptionTextFlowContainer CreateDescriptionTextFlowContainer();
+
+    protected abstract OverlayColourScheme CreateColourScheme();
+
+    protected abstract TEditMode DefaultMode();
+
+    protected abstract Selection CreateSelection(TEditMode mode);
+
+    protected abstract LocalisableString GetSelectionText(TEditMode mode);
+
+    protected abstract Color4 GetSelectionColour(OsuColour colours, TEditMode mode, bool active);
+
+    protected abstract DescriptionFormat GetSelectionDescription(TEditMode mode);
+
+    protected partial class Selection : OsuButton
+    {
+        public new Action<TEditMode> Action;
+
+        public TEditMode Mode { get; set; }
+
+        public Selection()
+        {
+            RelativeSizeAxes = Axes.X;
+            Content.CornerRadius = 15;
+
+            base.Action = () => Action?.Invoke(Mode);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/EditorSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/EditorSection.cs
@@ -4,15 +4,15 @@
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Containers;
 
-namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit
 {
     /// <summary>
     /// Base section class for lyric editor.
     /// todo: should inherit the EditorRoundedScreenSettingsSection eventually, but seems that class haven't ready.
     /// </summary>
-    public abstract partial class LyricEditorSection : Section
+    public abstract partial class EditorSection : Section
     {
-        protected LyricEditorSection()
+        protected EditorSection()
         {
             Padding = new MarginPadding(0);
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/EditorSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/EditorSettings.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit;
+
+public abstract partial class EditorSettings : EditorRoundedScreenSettings
+{
+    public abstract SettingsDirection Direction { get; }
+
+    public abstract float SettingsWidth { get; }
+
+    protected void ReloadSections()
+    {
+        this.ChildrenOfType<FillFlowContainer>().First().Children = CreateSections();
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/206835922-a1f42cf1-5bb3-40ba-99a1-430635ee00eb.png)
Implement part of #1766
Make those classes able to use in the other editor:
- Editor section
- Edit mode section
- Editor settings