### PR TITLE
Implement edit mode state for page edit mode.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/TestSceneLyricEditorScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/TestSceneLyricEditorScreen.cs
@@ -11,9 +11,9 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Screens.Edit;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics;
-using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Utils;
 
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Beatmap
         {
             AddStep("Click the button", () =>
             {
-                var editModeSection = this.ChildrenOfType<LyricEditorEditModeSection<T>>().Single();
+                var editModeSection = this.ChildrenOfType<EditModeSection<T>>().Single();
                 editModeSection.UpdateEditMode(editMode);
             });
             AddWaitStep("wait for switch to new edit mode.", 10);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/LyricEditorEditModeSection.cs
@@ -8,39 +8,22 @@ using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.Components.Markdown;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
-using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings
 {
-    public abstract partial class LyricEditorEditModeSection<TEditModeState, TEditMode> : LyricEditorEditModeSection<TEditMode>
+    public abstract partial class LyricEditorEditModeSection<TEditModeState, TEditMode> : EditModeSection<TEditModeState, TEditMode>
         where TEditModeState : IHasEditModeState<TEditMode> where TEditMode : Enum
-    {
-        [Resolved]
-        private TEditModeState tEditModeState { get; set; }
-
-        protected sealed override TEditMode DefaultMode() => tEditModeState.EditMode;
-
-        internal sealed override void UpdateEditMode(TEditMode mode)
-        {
-            tEditModeState.ChangeEditMode(mode);
-
-            base.UpdateEditMode(mode);
-        }
-    }
-
-    public abstract partial class LyricEditorEditModeSection<TEditMode> : EditModeSection<TEditMode>
-        where TEditMode : Enum
     {
         protected sealed override LocalisableString Title => "Edit mode";
 
         [Resolved]
         private ILyricSelectionState lyricSelectionState { get; set; }
 
-        protected override DescriptionTextFlowContainer CreateDescriptionTextFlowContainer()
+        protected sealed override DescriptionTextFlowContainer CreateDescriptionTextFlowContainer()
             => new LyricEditorDescriptionTextFlowContainer();
 
-        internal override void UpdateEditMode(TEditMode mode)
+        internal sealed override void UpdateEditMode(TEditMode mode)
         {
             // should cancel the selection after change to the new edit mode.
             lyricSelectionState?.EndSelecting(LyricEditorSelectingAction.Cancel);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/RubyRomaji/TextTagEditModeSection.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Settings.RubyRomaji
 {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
+
+public interface IPageStateProvider : IHasEditModeState<PageEditorEditMode>
+{
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditMode.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
+
+public enum PageEditorEditMode
+{
+    Edit,
+
+    Verify
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditModeSection.cs
@@ -10,15 +10,12 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
 
-public partial class PageEditorEditModeSection : EditModeSection<PageEditorEditMode>
+public partial class PageEditorEditModeSection : EditModeSection<IPageStateProvider, PageEditorEditMode>
 {
     protected sealed override LocalisableString Title => "Edit mode";
 
     protected override OverlayColourScheme CreateColourScheme()
         => OverlayColourScheme.Green;
-
-    protected override PageEditorEditMode DefaultMode()
-        => PageEditorEditMode.Edit;
 
     protected override Selection CreateSelection(PageEditorEditMode mode) =>
         mode switch

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditorEditModeSection.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Markdown;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
+
+public partial class PageEditorEditModeSection : EditModeSection<PageEditorEditMode>
+{
+    protected sealed override LocalisableString Title => "Edit mode";
+
+    protected override OverlayColourScheme CreateColourScheme()
+        => OverlayColourScheme.Green;
+
+    protected override PageEditorEditMode DefaultMode()
+        => PageEditorEditMode.Edit;
+
+    protected override Selection CreateSelection(PageEditorEditMode mode) =>
+        mode switch
+        {
+            PageEditorEditMode.Edit => new Selection(),
+            PageEditorEditMode.Verify => new PageEditorVerifySelection(),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override LocalisableString GetSelectionText(PageEditorEditMode mode) =>
+        mode switch
+        {
+            PageEditorEditMode.Edit => "Generate",
+            PageEditorEditMode.Verify => "Verify",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override Color4 GetSelectionColour(OsuColour colours, PageEditorEditMode mode, bool active) =>
+        mode switch
+        {
+            PageEditorEditMode.Edit => active ? colours.Blue : colours.BlueDarker,
+            PageEditorEditMode.Verify => active ? colours.Yellow : colours.YellowDarker,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    protected override DescriptionFormat GetSelectionDescription(PageEditorEditMode mode) =>
+        mode switch
+        {
+            PageEditorEditMode.Edit => "Edit the page.",
+            PageEditorEditMode.Verify => "Check if have any page issues.",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+    private partial class PageEditorVerifySelection : VerifySelection
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
@@ -10,10 +11,15 @@ using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
 
-public partial class PageScreen : BeatmapEditorRoundedScreen
+[Cached(typeof(IPageStateProvider))]
+public partial class PageScreen : BeatmapEditorRoundedScreen, IPageStateProvider
 {
     [Cached(typeof(IBeatmapPagesChangeHandler))]
     private readonly BeatmapPagesChangeHandler beatmapPagesChangeHandler;
+
+    public IBindable<PageEditorEditMode> BindableEditMode => bindableEditMode;
+
+    private readonly Bindable<PageEditorEditMode> bindableEditMode = new();
 
     public PageScreen()
         : base(KaraokeBeatmapEditorScreenMode.Page)
@@ -49,6 +55,11 @@ public partial class PageScreen : BeatmapEditorRoundedScreen
                 }
             }
         });
+    }
+
+    public void ChangeEditMode(PageEditorEditMode mode)
+    {
+        bindableEditMode.Value = mode;
     }
 
     private partial class FixedSectionsContainer<T> : SectionsContainer<T> where T : Drawable

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageSettings.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Overlays;
 
@@ -10,15 +12,31 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
 
 public partial class PageSettings : EditorSettings
 {
-    protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
-    {
-        // todo: should create section for able to show all the pages and the invalid page info.
-    };
+    private readonly IBindable<PageEditorEditMode> bindableMode = new Bindable<PageEditorEditMode>();
 
     [BackgroundDependencyLoader]
-    private void load(OverlayColourProvider colourProvider)
+    private void load(OverlayColourProvider colourProvider, IPageStateProvider pageStateProvider)
     {
+        bindableMode.BindTo(pageStateProvider.BindableEditMode);
+        bindableMode.BindValueChanged(e =>
+        {
+            ReloadSections();
+        }, true);
+
         // change the background colour to the lighter one.
         ChangeBackgroundColour(colourProvider.Background3);
     }
+
+    protected override IReadOnlyList<Drawable> CreateSections() => bindableMode.Value switch
+    {
+        PageEditorEditMode.Edit => new Drawable[]
+        {
+            new PageEditorEditModeSection(),
+        },
+        PageEditorEditMode.Verify => new Drawable[]
+        {
+            new PageEditorEditModeSection(),
+        },
+        _ => throw new ArgumentOutOfRangeException()
+    };
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/EditModeSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/EditModeSection.cs
@@ -24,6 +24,22 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit;
 
+public abstract partial class EditModeSection<TEditModeState, TEditMode> : EditModeSection<TEditMode>
+    where TEditModeState : IHasEditModeState<TEditMode> where TEditMode : Enum
+{
+    [Resolved]
+    private TEditModeState tEditModeState { get; set; }
+
+    protected sealed override TEditMode DefaultMode() => tEditModeState.EditMode;
+
+    internal override void UpdateEditMode(TEditMode mode)
+    {
+        tEditModeState.ChangeEditMode(mode);
+
+        base.UpdateEditMode(mode);
+    }
+}
+
 public abstract partial class EditModeSection<TEditMode> : EditorSection where TEditMode : Enum
 {
     private const int horizontal_padding = 20;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/IHasEditModeState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/IHasEditModeState.cs
@@ -4,7 +4,7 @@
 using System;
 using osu.Framework.Bindables;
 
-namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States.Modes
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit
 {
     public interface IHasEditModeState<T> where T : Enum
     {


### PR DESCRIPTION
Implement part of issue #1766.

What's done in this PR:
- Move the edit mode state interface for more generic location.
- Implement the state provider for the page editor.
- Apply the edit mode switch section to the page editor.