### PR TITLE
Implement page bottom timeline.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Metadatas/PageInfoTest.cs
@@ -50,6 +50,21 @@ public class PageInfoTest
         Assert.AreEqual(expectedIndex, actualPageIndex);
     }
 
+    [Test]
+    public void TestGetPageOrder()
+    {
+        var pageInfo = new PageInfo();
+        pageInfo.Pages.AddRange(createPages(new double[] { 1000 }));
+
+        var existPage = pageInfo.Pages.First();
+        int? existPageOrder = pageInfo.GetPageOrder(existPage);
+        Assert.AreEqual(1, existPageOrder);
+
+        var notExistPage = new Page { Time = 1000 };
+        int? notExistPageOrder = pageInfo.GetPageOrder(notExistPage);
+        Assert.IsNull(notExistPageOrder);
+    }
+
     private static IEnumerable<Page> createPages(IEnumerable<double> times)
         => times.Select(x => new Page { Time = x });
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
@@ -39,6 +39,12 @@ public class PageInfo : IDeepCloneable<PageInfo>
         return SortedPages.FindIndex(x => x == page);
     }
 
+    public int? GetPageOrder(Page page)
+    {
+        int index = SortedPages.IndexOf(page);
+        return index == -1 ? null : index + 1;
+    }
+
     public PageInfo DeepClone()
     {
         var controlPointInfo = (PageInfo)Activator.CreateInstance(GetType());

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagSelectionBlueprint.cs
@@ -9,22 +9,21 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Cursor;
 using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
 using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Screens.Edit;
 using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomEditor.AdjustTimeTags
 {
-    public partial class AdjustTimeTagSelectionBlueprint : SelectionBlueprint<TimeTag>, IHasCustomTooltip<TimeTag>
+    public partial class AdjustTimeTagSelectionBlueprint : EditableTimelineSelectionBlueprint<TimeTag>, IHasCustomTooltip<TimeTag>
     {
         private const float time_tag_triangle_size = 10;
 
@@ -39,11 +38,6 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomE
             : base(item)
         {
             startTime = item.TimeBindable.GetBoundCopy();
-
-            Anchor = Anchor.CentreLeft;
-            Origin = Anchor.CentreLeft;
-
-            RelativePositionAxes = Axes.X;
             RelativeSizeAxes = Axes.None;
             AutoSizeAxes = Axes.X;
 
@@ -120,32 +114,13 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomE
             }, true);
         }
 
-        protected override void OnSelected()
-        {
-            // base logic hides selected blueprints when not selected, but timeline doesn't do that.
-        }
-
-        protected override void OnDeselected()
-        {
-            // base logic hides selected blueprints when not selected, but timeline doesn't do that.
-        }
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            getContent().ReceivePositionalInputAt(screenSpacePos);
-
-        public override Quad SelectionQuad =>
-            getContent().ScreenSpaceDrawQuad;
-
-        public override Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.TopLeft;
+        protected override Drawable GetInteractDrawable() => hasTime() ? timeTagPiece : timeTagWithNoTimePiece;
 
         public ITooltip<TimeTag> GetCustomTooltip() => new TimeTagTooltip();
 
         public TimeTag TooltipContent => Item;
 
         private bool hasTime() => startTime.Value.HasValue;
-
-        private Drawable getContent()
-            => hasTime() ? timeTagPiece : timeTagWithNoTimePiece;
 
         public partial class TimeTagPiece : CompositeDrawable
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/LyricBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/LyricBlueprintContainer.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
+
+public partial class LyricBlueprintContainer : EditableTimelineBlueprintContainer<Lyric>
+{
+    [BackgroundDependencyLoader]
+    private void load(ILyricsProvider lyricsProvider)
+    {
+        Items.BindTo(lyricsProvider.BindableLyrics);
+    }
+
+    protected override SelectionBlueprint<Lyric> CreateBlueprintFor(Lyric item)
+        => new PreviewLyricSelectionBlueprint(item);
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageBlueprintContainer.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
+
+public partial class PageBlueprintContainer : EditableTimelineBlueprintContainer<Page>
+{
+    [BackgroundDependencyLoader]
+    private void load(IPageStateProvider pageStateProvider)
+    {
+        Items.BindTo(pageStateProvider.PageInfo.Pages);
+    }
+
+    protected override IEnumerable<SelectionBlueprint<Page>> SortForMovement(IReadOnlyList<SelectionBlueprint<Page>> blueprints)
+        => blueprints.OrderBy(b => b.Item.Time);
+
+    protected override SelectionHandler<Page> CreateSelectionHandler()
+        => new PageSelectionHandler();
+
+    protected override SelectionBlueprint<Page> CreateBlueprintFor(Page item)
+        => new PageSelectionBlueprint(item);
+
+    protected partial class PageSelectionHandler : EditableTimelineSelectionHandler
+    {
+        [Resolved, AllowNull]
+        private IBeatmapPagesChangeHandler beatmapPagesChangeHandler { get; set; }
+
+        [Resolved, AllowNull]
+        private IPageStateProvider pageStateProvider { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            SelectedItems.BindTo(pageStateProvider.SelectedItems);
+        }
+
+        protected override void DeleteItems(IEnumerable<Page> items)
+        {
+            beatmapPagesChangeHandler.RemoveRange(items);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
+
+public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint<Page>
+{
+    private const float body_width = 2;
+
+    private readonly IBindable<double> startTime;
+
+    private readonly PageInfoPiece pageInfoPiece;
+    private readonly PageBodyPiece pageBodyPiece;
+
+    public PageSelectionBlueprint(Page item)
+        : base(item)
+    {
+        startTime = item.TimeBindable.GetBoundCopy();
+        RelativeSizeAxes = Axes.None;
+
+        Width = body_width;
+
+        // todo: not really sure why it fix the issue. should have more checks about this.
+        Height = PagesTimeLine.TIMELINE_HEIGHT - 1;
+
+        AddRangeInternal(new Drawable[]
+        {
+            pageInfoPiece = new PageInfoPiece(item)
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.BottomCentre,
+            },
+            pageBodyPiece = new PageBodyPiece(item)
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                RelativeSizeAxes = Axes.Both,
+            },
+        });
+
+        startTime.BindValueChanged(_ => X = (float)Item.Time, true);
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(IPageEditorVerifier pageEditorVerifier)
+    {
+    }
+
+    protected override Drawable GetInteractDrawable() => pageBodyPiece;
+
+    private partial class PageInfoPiece : CompositeDrawable
+    {
+        private readonly Page page;
+
+        public PageInfoPiece(Page page)
+        {
+            this.page = page;
+
+            AutoSizeAxes = Axes.X;
+            Height = 16;
+            Margin = new MarginPadding(4);
+
+            Masking = true;
+            CornerRadius = Height / 2;
+
+            Origin = Anchor.TopCentre;
+            Anchor = Anchor.TopCentre;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, IPageStateProvider pageStateProvider)
+        {
+            int? order = pageStateProvider.PageInfo.GetPageOrder(page);
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Yellow,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Padding = new MarginPadding(3),
+                    Font = OsuFont.Default.With(size: 14, weight: FontWeight.SemiBold),
+                    Colour = colours.B5,
+                    Text = $" #{order} "
+                }
+            };
+        }
+    }
+
+    private partial class PageBodyPiece : CompositeDrawable
+    {
+        private readonly Page page;
+
+        public PageBodyPiece(Page page)
+        {
+            this.page = page;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Yellow,
+                    RelativeSizeAxes = Axes.Both,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PagesTimeLine.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PagesTimeLine.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
+
+public partial class PagesTimeLine : EditableTimeline
+{
+    public const float TIMELINE_HEIGHT = 38;
+
+    [Resolved, AllowNull]
+    private EditorBeatmap beatmap { get; set; }
+
+    [BackgroundDependencyLoader]
+    private void load(OsuColour colour, IPageStateProvider pageStateProvider)
+    {
+        AddInternal(new Box
+        {
+            Name = "Background",
+            Depth = 1,
+            RelativeSizeAxes = Axes.X,
+            Height = TIMELINE_HEIGHT,
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+            Colour = colour.Gray3,
+        });
+
+        BindableZoom.BindTo(pageStateProvider.BindableZoom);
+        BindableCurrent.BindTo(pageStateProvider.BindableCurrent);
+    }
+
+    protected override Container CreateMainContainer()
+    {
+        return base.CreateMainContainer().With(c => c.Height = TIMELINE_HEIGHT);
+    }
+
+    protected override IEnumerable<Drawable> CreateBlueprintContainer()
+    {
+        yield return new LyricBlueprintContainer();
+        yield return new PageBlueprintContainer();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PreviewLyricSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PreviewLyricSelectionBlueprint.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
+
+public partial class PreviewLyricSelectionBlueprint : EditableLyricTimelineSelectionBlueprint
+{
+    public PreviewLyricSelectionBlueprint(Lyric item)
+        : base(item)
+    {
+        Selectable = false;
+    }
+
+    protected override void OnSelectableStatusChanged(bool selectable)
+    {
+        Alpha = 0.5f;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
@@ -15,4 +15,8 @@ public interface IPageStateProvider
     void ChangeEditMode(PageEditorEditMode mode);
 
     PageInfo PageInfo { get; }
+
+    BindableList<Page> SelectedItems { get; }
+
+    void Select(Page item);
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/IPageStateProvider.cs
@@ -19,4 +19,8 @@ public interface IPageStateProvider
     BindableList<Page> SelectedItems { get; }
 
     void Select(Page item);
+
+    BindableFloat BindableZoom { get; }
+
+    BindableFloat BindableCurrent { get; }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageEditor.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timeline;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
 
@@ -20,8 +21,14 @@ public partial class PageEditor : CompositeDrawable
             background = new Box
             {
                 RelativeSizeAxes = Axes.Both
+            },
+            new PagesTimeLine
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = 100,
             }
-            // todo: add the time-line and the top editor.
         };
     }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
@@ -31,6 +31,8 @@ public partial class PageScreen : BeatmapEditorRoundedScreen, IPageStateProvider
 
     public PageInfo PageInfo => (editorBeatmap.PlayableBeatmap as KaraokeBeatmap)!.PageInfo;
 
+    public BindableList<Page> SelectedItems { get; } = new();
+
     private readonly Bindable<PageEditorEditMode> bindableEditMode = new();
 
     public PageScreen()
@@ -73,6 +75,12 @@ public partial class PageScreen : BeatmapEditorRoundedScreen, IPageStateProvider
     public void ChangeEditMode(PageEditorEditMode mode)
     {
         bindableEditMode.Value = mode;
+    }
+
+    public void Select(Page item)
+    {
+        SelectedItems.Clear();
+        SelectedItems.Add(item);
     }
 
     private partial class FixedSectionsContainer<T> : SectionsContainer<T> where T : Drawable

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PageScreen.cs
@@ -11,6 +11,7 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages;
@@ -33,6 +34,10 @@ public partial class PageScreen : BeatmapEditorRoundedScreen, IPageStateProvider
 
     public BindableList<Page> SelectedItems { get; } = new();
 
+    public BindableFloat BindableZoom { get; } = new();
+
+    public BindableFloat BindableCurrent { get; } = new();
+
     private readonly Bindable<PageEditorEditMode> bindableEditMode = new();
 
     public PageScreen()
@@ -43,8 +48,12 @@ public partial class PageScreen : BeatmapEditorRoundedScreen, IPageStateProvider
     }
 
     [BackgroundDependencyLoader]
-    private void load()
+    private void load(EditorClock editorClock)
     {
+        BindableZoom.MaxValue = ZoomableScrollContainerUtils.GetZoomLevelForVisibleMilliseconds(editorClock, 8000);
+        BindableZoom.MinValue = ZoomableScrollContainerUtils.GetZoomLevelForVisibleMilliseconds(editorClock, 80000);
+        BindableZoom.Value = BindableZoom.Default = ZoomableScrollContainerUtils.GetZoomLevelForVisibleMilliseconds(editorClock, 40000);
+
         Add(new FixedSectionsContainer<Drawable>
         {
             FixedHeader = new PageScreenHeader(),

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PagesSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PagesSection.cs
@@ -149,7 +149,7 @@ public partial class PagesSection : EditorSection
 
             bindableTime.BindValueChanged(x =>
             {
-                int order = pageStateProvider.PageInfo.SortedPages.IndexOf(Page) + 1;
+                int? order = pageStateProvider.PageInfo.GetPageOrder(Page);
                 double time = x.NewValue;
 
                 DepthChanged?.Invoke(this, (float)time);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
@@ -4,32 +4,23 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Graphics.Cursor;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
 
-public partial class EditableLyricTimelineSelectionBlueprint : SelectionBlueprint<Lyric>, IHasCustomTooltip<Lyric>
+public partial class EditableLyricTimelineSelectionBlueprint : EditableTimelineSelectionBlueprint<Lyric>, IHasCustomTooltip<Lyric>
 {
     private const float lyric_size = 20;
-
-    private bool selectable = true;
 
     public EditableLyricTimelineSelectionBlueprint(Lyric item)
         : base(item)
     {
-        Anchor = Anchor.CentreLeft;
-        Origin = Anchor.CentreLeft;
-
         X = (float)Item.LyricStartTime;
 
-        RelativePositionAxes = Axes.X;
         RelativeSizeAxes = Axes.X;
         Height = lyric_size;
 
@@ -59,47 +50,6 @@ public partial class EditableLyricTimelineSelectionBlueprint : SelectionBlueprin
             }
         });
     }
-
-    protected bool Selectable
-    {
-        get => selectable;
-        set
-        {
-            if (selectable == value)
-                return;
-
-            selectable = value;
-            OnSelectableStatusChanged(selectable);
-        }
-    }
-
-    protected virtual void OnSelectableStatusChanged(bool selectable)
-    {
-        if (selectable)
-        {
-            Show();
-        }
-        else
-        {
-            this.FadeTo(0.1f, 200);
-        }
-    }
-
-    protected override void OnSelected()
-    {
-        // base logic hides selected blueprints when not selected, but timeline doesn't do that.
-    }
-
-    protected override void OnDeselected()
-    {
-        // base logic hides selected blueprints when not selected, but timeline doesn't do that.
-    }
-
-    // prevent selection.
-    public override Vector2 ScreenSpaceSelectionPoint => selectable ? ScreenSpaceDrawQuad.TopLeft : new Vector2(int.MinValue);
-
-    // prevent single select.
-    public override Quad SelectionQuad => selectable ? base.SelectionQuad : new Quad();
 
     protected override void Update()
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimelineSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimelineSelectionBlueprint.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Edit;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
+
+public abstract partial class EditableTimelineSelectionBlueprint<TItem> : SelectionBlueprint<TItem>
+{
+    private bool selectable = true;
+
+    protected EditableTimelineSelectionBlueprint(TItem item)
+        : base(item)
+    {
+        Anchor = Anchor.CentreLeft;
+        Origin = Anchor.CentreLeft;
+
+        RelativePositionAxes = Axes.X;
+    }
+
+    protected bool Selectable
+    {
+        get => selectable;
+        set
+        {
+            if (selectable == value)
+                return;
+
+            selectable = value;
+            OnSelectableStatusChanged(selectable);
+        }
+    }
+
+    protected virtual void OnSelectableStatusChanged(bool selectable)
+    {
+        if (selectable)
+        {
+            Show();
+        }
+        else
+        {
+            this.FadeTo(0.1f, 200);
+        }
+    }
+
+    protected sealed override void OnSelected()
+    {
+        // base logic hides selected blueprints when not selected, but timeline doesn't do that.
+    }
+
+    protected sealed override void OnDeselected()
+    {
+        // base logic hides selected blueprints when not selected, but timeline doesn't do that.
+    }
+
+    public sealed override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+    {
+        var drawable = GetInteractDrawable();
+        if (drawable == this)
+            return base.ReceivePositionalInputAt(screenSpacePos);
+
+        return drawable.ReceivePositionalInputAt(screenSpacePos);
+    }
+
+    // prevent selection.
+    public sealed override Vector2 ScreenSpaceSelectionPoint => selectable ? GetInteractDrawable().ScreenSpaceDrawQuad.TopLeft : new Vector2(int.MinValue);
+
+    // prevent single select.
+    public sealed override Quad SelectionQuad => selectable ? GetInteractDrawable().ScreenSpaceDrawQuad : new Quad();
+
+    protected virtual Drawable GetInteractDrawable() => this;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/208276070-0f82b5a7-7d94-41d8-b69f-b186e559b3e1.png)
What's done in this PR:
- Create the generic editable time-line based selection blueprint, can be the part of #1798
- Implement the timeline area for the page editor (see #1766).

This PR is the initial PR and guess might have improvement PRs after.