### PR TITLE
Improve the page editor.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageBlueprintContainer.cs
@@ -15,10 +15,20 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timel
 
 public partial class PageBlueprintContainer : EditableTimelineBlueprintContainer<Page>
 {
+    [Resolved, AllowNull]
+    private IBeatmapPagesChangeHandler beatmapPagesChangeHandler { get; set; }
+
     [BackgroundDependencyLoader]
     private void load(IPageStateProvider pageStateProvider)
     {
         Items.BindTo(pageStateProvider.PageInfo.Pages);
+    }
+
+    protected override bool ApplyOffsetResult(Page[] items, double time)
+    {
+        double offset = time - items.First().Time;
+        beatmapPagesChangeHandler.ShiftingPageTime(items, offset);
+        return true;
     }
 
     protected override IEnumerable<SelectionBlueprint<Page>> SortForMovement(IReadOnlyList<SelectionBlueprint<Page>> blueprints)
@@ -43,6 +53,9 @@ public partial class PageBlueprintContainer : EditableTimelineBlueprintContainer
         {
             SelectedItems.BindTo(pageStateProvider.SelectedItems);
         }
+
+        // for now we always allow movement. snapping is provided by the Timeline's "distance" snap implementation
+        public override bool HandleMovement(MoveSelectionEvent<Page> moveEvent) => true;
 
         protected override void DeleteItems(IEnumerable<Page> items)
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
@@ -61,6 +61,7 @@ public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint
     private partial class PageInfoPiece : CompositeDrawable
     {
         private readonly Page page;
+        private readonly IBindable<int> pagesVersion = new Bindable<int>();
 
         public PageInfoPiece(Page page)
         {
@@ -80,7 +81,7 @@ public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, IPageStateProvider pageStateProvider)
         {
-            int? order = pageStateProvider.PageInfo.GetPageOrder(page);
+            OsuSpriteText spriteText;
 
             InternalChildren = new Drawable[]
             {
@@ -89,16 +90,22 @@ public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint
                     Colour = colours.Yellow,
                     RelativeSizeAxes = Axes.Both,
                 },
-                new OsuSpriteText
+                spriteText = new OsuSpriteText
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Padding = new MarginPadding(3),
                     Font = OsuFont.Default.With(size: 14, weight: FontWeight.SemiBold),
                     Colour = colours.B5,
-                    Text = $" #{order} "
                 }
             };
+
+            pagesVersion.BindTo(pageStateProvider.PageInfo.PagesVersion);
+            pagesVersion.BindValueChanged(x =>
+            {
+                int? order = pageStateProvider.PageInfo.GetPageOrder(page);
+                spriteText.Text = $" #{order} ";
+            }, true);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Components/Timeline/PageSelectionBlueprint.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Pages.Components.Timel
 
 public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint<Page>
 {
-    private const float body_width = 2;
+    private const float body_width = 4;
 
     private readonly IBindable<double> startTime;
 
@@ -55,8 +55,6 @@ public partial class PageSelectionBlueprint : EditableTimelineSelectionBlueprint
     private void load(IPageEditorVerifier pageEditorVerifier)
     {
     }
-
-    protected override Drawable GetInteractDrawable() => pageBodyPiece;
 
     private partial class PageInfoPiece : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PagesSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/PagesSection.cs
@@ -93,7 +93,7 @@ public partial class PagesSection : EditorSection
 
         public Action<LabelledPage, float>? DepthChanged;
 
-        private readonly IBindable<double> bindableTime = new Bindable<double>();
+        private readonly IBindable<int> pagesVersion = new Bindable<int>();
 
         [Resolved, AllowNull]
         private IBeatmapPagesChangeHandler beatmapPagesChangeHandler { get; set; }
@@ -105,7 +105,6 @@ public partial class PagesSection : EditorSection
         public LabelledPage(Page page)
         {
             Page = page;
-            bindableTime.BindTo(Page.TimeBindable);
 
             Masking = true;
             CornerRadius = 5;
@@ -147,10 +146,11 @@ public partial class PagesSection : EditorSection
             spriteText.Colour = colour.YellowDarker;
             deleteIconButton.IconColour = colour.YellowDarker;
 
-            bindableTime.BindValueChanged(x =>
+            pagesVersion.BindTo(pageStateProvider.PageInfo.PagesVersion);
+            pagesVersion.BindValueChanged(_ =>
             {
                 int? order = pageStateProvider.PageInfo.GetPageOrder(Page);
-                double time = x.NewValue;
+                double time = Page.Time;
 
                 DepthChanged?.Invoke(this, (float)time);
                 spriteText.Text = $"#{order} {time.ToEditorFormattedString()}";

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimeline.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimeline.cs
@@ -7,14 +7,16 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Containers;
 using osu.Game.Screens.Edit;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
 
 [Cached]
-public partial class EditableTimeline : BindableScrollContainer
+public partial class EditableTimeline : BindableScrollContainer, IPositionSnapProvider
 {
     [Resolved, AllowNull]
     private EditorClock editorClock { get; set; }
@@ -60,5 +62,11 @@ public partial class EditableTimeline : BindableScrollContainer
     public float PositionAtTime(double time)
     {
         return (float)(time / editorClock.TrackLength * Content.DrawWidth);
+    }
+
+    public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
+    {
+        double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);
+        return new SnapResult(screenSpacePosition, time);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimelineBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableTimelineBlueprintContainer.cs
@@ -47,6 +47,21 @@ public partial class EditableTimelineBlueprintContainer<TItem> : BlueprintContai
         SelectedItems.AddRange(Items);
     }
 
+    protected sealed override bool ApplySnapResult(SelectionBlueprint<TItem>[] blueprints, SnapResult result)
+    {
+        if (!base.ApplySnapResult(blueprints, result))
+            return false;
+
+        if (result.Time == null)
+            return false;
+
+        var items = blueprints.Select(x => x.Item).ToArray();
+        double time = result.Time.Value;
+        return ApplyOffsetResult(items, time);
+    }
+
+    protected virtual bool ApplyOffsetResult(TItem[] items, double time) => false;
+
     protected override Container<SelectionBlueprint<TItem>> CreateSelectionBlueprintContainer()
         => new EditableTimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
 


### PR DESCRIPTION
Implement part of issue #1766

What's done in this PR:
- Create `bindable page version` property in the `page info` for able to get the property changed event.
- Should be able to update the time and the order if create or remove or change the time in the section or blueprint.
- Let the `EditableTimeline` able to get the snap position.
- Let the blueprint able to drag.
- Make the blueprint bigger for able to drag.