### PR TITLE
Add utils to load save culture info.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/CultureInfoConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/CultureInfoConverterTest.cs
@@ -27,22 +27,5 @@ namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters
             var result = JsonConvert.DeserializeObject<CultureInfo>(json, CreateSettings());
             Assert.AreEqual(lcid, result?.LCID);
         }
-
-        [Test]
-        public void TestAllCultureInfo()
-        {
-            var cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures);
-
-            foreach (var cultureInfo in cultureInfos)
-            {
-                // this weird cultureInfo will let test case failed.
-                if (cultureInfo.LCID is 4096 or 4 or 31748)
-                    continue;
-
-                string json = JsonConvert.SerializeObject(cultureInfo, CreateSettings());
-                var actual = JsonConvert.DeserializeObject<CultureInfo>(json, CreateSettings());
-                Assert.AreEqual(cultureInfo, actual);
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/CultureInfoUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/CultureInfoUtilsTest.cs
@@ -8,10 +8,10 @@ using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Utils
 {
-    [Ignore("Cannot run those test cases right now because will got different results in the different platform...")]
     public class CultureInfoUtilsTest
     {
         [Test]
+        [Ignore("Cannot run those test cases right now because will got different results in the different platform...")]
         public void TestGetAvailableLanguages()
         {
             // seems there are 276 languages in the world.
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         }
 
         [Test]
+        [Ignore("Cannot run those test cases right now because will got different results in the different platform...")]
         public void TestGetAvailableLanguagesWithUniqueLcid()
         {
             var languages = CultureInfoUtils.GetAvailableLanguages();
@@ -63,11 +64,48 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Utils
         [TestCase(31748, "中文（繁體）")]
         [TestCase(30724, "中文")]
         [TestCase(1028, "中文（台灣）")]
+        [Ignore("Cannot run those test cases right now because will got different results in the different platform...")]
         public void TestGetLanguageDisplayText(int lcid, string displayText)
         {
             var cultureInfo = new CultureInfo(lcid);
             string actual = CultureInfoUtils.GetLanguageDisplayText(cultureInfo);
             Assert.AreEqual(displayText, actual);
+        }
+
+        [Test]
+        public void TestSaveAndLoadCultureInfoById()
+        {
+            var cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            foreach (var cultureInfo in cultureInfos)
+            {
+                // this weird cultureInfo will let test case failed.
+                if (cultureInfo.LCID is 4096 or 4 or 31748)
+                    continue;
+
+                // get the lcid and convert back to culture info again.
+                int lcid = CultureInfoUtils.GetSaveCultureInfoId(cultureInfo);
+                var actual = CultureInfoUtils.CreateLoadCultureInfoById(lcid);
+                Assert.AreEqual(cultureInfo, actual);
+            }
+        }
+
+        [Test]
+        public void TestSaveAndLoadCultureInfoByCode()
+        {
+            var cultureInfos = CultureInfo.GetCultures(CultureTypes.AllCultures);
+
+            foreach (var cultureInfo in cultureInfos)
+            {
+                // this weird cultureInfo will let test case failed.
+                if (cultureInfo.LCID is 4096 or 4 or 31748)
+                    continue;
+
+                // get the code and convert back to culture info again.
+                string lcid = CultureInfoUtils.GetSaveCultureInfoCode(cultureInfo);
+                var actual = CultureInfoUtils.CreateLoadCultureInfoByCode(lcid);
+                Assert.AreEqual(cultureInfo, actual);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/CultureInfoConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/CultureInfoConverter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
 {
@@ -18,12 +19,14 @@ namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters
             if (value == null)
                 return null;
 
-            return new CultureInfo(value.Value);
+            return CultureInfoUtils.CreateLoadCultureInfoById(value.Value);
         }
 
         public override void WriteJson(JsonWriter writer, CultureInfo? value, JsonSerializer serializer)
         {
-            writer.WriteValue(value?.LCID);
+            int? id = value != null ? CultureInfoUtils.GetSaveCultureInfoId(value) : null;
+
+            writer.WriteValue(id);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/CultureInfoUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/CultureInfoUtils.cs
@@ -22,5 +22,15 @@ namespace osu.Game.Rulesets.Karaoke.Utils
 
         public static string GetLanguageDisplayText(CultureInfo? cultureInfo)
             => cultureInfo?.NativeName ?? "None";
+
+        public static int GetSaveCultureInfoId(CultureInfo cultureInfo)
+            => cultureInfo.LCID;
+
+        public static CultureInfo CreateLoadCultureInfoById(int lcid) => new(lcid);
+
+        public static string GetSaveCultureInfoCode(CultureInfo cultureInfo)
+            => cultureInfo.ToString();
+
+        public static CultureInfo CreateLoadCultureInfoByCode(string code) => new(code);
     }
 }


### PR DESCRIPTION
Need some utils to make sure that there's a stable way to load/save the utils with different format(number and string).