### PR TITLE
Fix some issues in the change handler test.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -95,14 +95,14 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
             });
         }
 
-        protected void SetUpKaraokeBeatmap(Action<KaraokeBeatmap> assert)
+        protected void SetUpKaraokeBeatmap(Action<KaraokeBeatmap> action)
         {
             SetUpEditorBeatmap(editorBeatmap =>
             {
                 if (editorBeatmap.PlayableBeatmap is not KaraokeBeatmap karaokeBeatmap)
                     throw new InvalidCastException();
 
-                assert.Invoke(karaokeBeatmap);
+                action.Invoke(karaokeBeatmap);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -126,16 +126,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
         protected void AssertEditorBeatmap(Action<EditorBeatmap> assert)
         {
-            AddStep("Is result matched", () =>
+            AddAssert("Is result matched", () =>
             {
                 var editorBeatmap = Dependencies.Get<EditorBeatmap>();
                 assert(editorBeatmap);
-            });
 
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
+                // even if there's no property changed in the lyric editor, should still trigger the change handler.
+                // because every change handler call should cause one undo step.
+                // also, technically should not call the change handler if there's no possible to change the properties.
+                return IsTransactionOnlyTriggerOnce();
+            });
         }
 
         protected void AssertKaraokeBeatmap(Action<KaraokeBeatmap> assert)
@@ -181,24 +181,21 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
         protected void AssertHitObjects<THitObject>(Action<IEnumerable<THitObject>> assert) where THitObject : HitObject
         {
-            AddStep("Is result matched", () =>
+            AddAssert("Is result matched", () =>
             {
                 var editorBeatmap = Dependencies.Get<EditorBeatmap>();
                 assert(editorBeatmap.HitObjects.OfType<THitObject>());
-            });
 
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
+                // even if there's no property changed in the lyric editor, should still trigger the change handler.
+                // because every change handler call should cause one undo step.
+                // also, technically should not call the change handler if there's no possible to change the properties.
+                return IsTransactionOnlyTriggerOnce();
+            });
         }
 
-        protected void AssertTransactionOnlyTriggerOnce()
+        protected bool IsTransactionOnlyTriggerOnce()
         {
-            AddStep("Should only trigger transaction once", () =>
-            {
-                Assert.AreEqual(1, transactionCount);
-            });
+            return transactionCount == 1;
         }
 
         private partial class MockEditorChangeHandler : TransactionalCommitComponent, IEditorChangeHandler

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -37,16 +37,16 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers
 
         protected void AssertSelectedHitObjects(Action<IEnumerable<THitObject>> assert)
         {
-            AddStep("Is result matched", () =>
+            AddAssert("Is result matched", () =>
             {
                 var editorBeatmap = Dependencies.Get<EditorBeatmap>();
                 assert(editorBeatmap.SelectedHitObjects.OfType<THitObject>());
-            });
 
-            // even if there's no property changed in the lyric editor, should still trigger the change handler.
-            // because every change handler call should cause one undo step.
-            // also, technically should not call the change handler if there's no possible to change the properties.
-            AssertTransactionOnlyTriggerOnce();
+                // even if there's no property changed in the lyric editor, should still trigger the change handler.
+                // because every change handler call should cause one undo step.
+                // also, technically should not call the change handler if there's no possible to change the properties.
+                return IsTransactionOnlyTriggerOnce();
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -24,8 +24,20 @@ public partial class BeatmapPropertyChangeHandler : Component
 
     protected void PerformBeatmapChanged(Action<KaraokeBeatmap> action)
     {
-        beatmap.BeginChange();
-        action.Invoke(KaraokeBeatmap);
-        beatmap.EndChange();
+        try
+        {
+            beatmap.BeginChange();
+            action.Invoke(KaraokeBeatmap);
+            beatmap.EndChange();
+        }
+        catch
+        {
+            // We should make sure that editor beatmap will end the change if still changing.
+            // will goes to here if have exception in the change handler.
+            if (beatmap.TransactionActive)
+                beatmap.EndChange();
+
+            throw;
+        }
     }
 }


### PR DESCRIPTION
What's fixed in this PR:
- Fix wrong naming.
- Use `AddAssert()` instead of `AddStep()` for assertion function.
- Should call the missing `EndChange()` function if got the exception while changing.