### PR TITLE
Implement classic stage info editor

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
@@ -1,0 +1,54 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
+using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+using osu.Game.Screens.Edit;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
+
+public abstract partial class ClassicStageScreenTestScene<T> : EditorClockTestScene where T : ClassicStageScreen
+{
+    [Cached(typeof(EditorBeatmap))]
+    [Cached(typeof(IBeatSnapProvider))]
+    private readonly EditorBeatmap editorBeatmap;
+
+    [Cached]
+    private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Blue);
+
+    protected ClassicStageScreenTestScene()
+    {
+        editorBeatmap = new EditorBeatmap(CreateBeatmap());
+    }
+
+    protected override void LoadComplete()
+    {
+        editorBeatmap.BeatmapInfo.Ruleset = new KaraokeRuleset().RulesetInfo;
+
+        Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+
+        Child = CreateEditorScreen().With(x =>
+        {
+            x.State.Value = Visibility.Visible;
+        });
+    }
+
+    protected abstract T CreateEditorScreen();
+
+    protected virtual KaraokeBeatmap CreateBeatmap()
+    {
+        var beatmap = new TestKaraokeBeatmap(new KaraokeRuleset().RulesetInfo);
+        if (new KaraokeBeatmapConverter(beatmap, new KaraokeRuleset()).Convert() is not KaraokeBeatmap karaokeBeatmap)
+            throw new ArgumentNullException(nameof(karaokeBeatmap));
+
+        return karaokeBeatmap;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneClassicStageEditor.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneClassicStageEditor.cs
@@ -1,0 +1,48 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
+using osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
+
+public partial class TestSceneClassicStageEditor : ScreenTestScene<ClassicStageEditor>
+{
+    [Cached(typeof(EditorBeatmap))]
+    [Cached(typeof(IBeatSnapProvider))]
+    private readonly EditorBeatmap editorBeatmap;
+
+    protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+
+    protected override ClassicStageEditor CreateScreen() => new();
+
+    private DialogOverlay dialogOverlay = null!;
+
+    public TestSceneClassicStageEditor()
+    {
+        var beatmap = new TestKaraokeBeatmap(new KaraokeRuleset().RulesetInfo);
+        var karaokeBeatmap = new KaraokeBeatmapConverter(beatmap, new KaraokeRuleset()).Convert() as KaraokeBeatmap;
+        editorBeatmap = new EditorBeatmap(karaokeBeatmap);
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+
+        base.Content.AddRange(new Drawable[]
+        {
+            Content,
+            dialogOverlay = new DialogOverlay(),
+        });
+
+        Dependencies.CacheAs<IDialogOverlay>(dialogOverlay);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneConfigScreen.cs
@@ -1,0 +1,11 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Config;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
+
+public partial class TestSceneConfigScreen : ClassicStageScreenTestScene<ConfigScreen>
+{
+    protected override ConfigScreen CreateEditorScreen() => new();
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
@@ -1,0 +1,11 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
+
+public partial class TestSceneStageScreen : ClassicStageScreenTestScene<StageScreen>
+{
+    protected override StageScreen CreateEditorScreen() => new();
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageEditor.cs
@@ -1,0 +1,33 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Config;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
+
+public partial class ClassicStageEditor : GenericEditor<ClassicStageEditorScreenMode>
+{
+    [Cached]
+    private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Green);
+
+    protected override GenericEditorScreen<ClassicStageEditorScreenMode> GenerateScreen(ClassicStageEditorScreenMode screenMode) =>
+        screenMode switch
+        {
+            ClassicStageEditorScreenMode.Stage => new StageScreen(),
+            ClassicStageEditorScreenMode.Config => new ConfigScreen(),
+            _ => throw new InvalidOperationException("Editor menu bar switched to an unsupported mode")
+        };
+
+    protected override MenuItem[] GenerateMenuItems(ClassicStageEditorScreenMode screenMode)
+    {
+        return screenMode switch
+        {
+            _ => Array.Empty<MenuItem>()
+        };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageEditorScreenMode.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageEditorScreenMode.cs
@@ -1,0 +1,15 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
+
+public enum ClassicStageEditorScreenMode
+{
+    [Description("Stage")]
+    Stage,
+
+    [Description("Config")]
+    Config,
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/ClassicStageScreen.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
+
+public partial class ClassicStageScreen : GenericEditorScreen<ClassicStageEditorScreenMode>
+{
+    public ClassicStageScreen(ClassicStageEditorScreenMode type)
+        : base(type)
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Config/ConfigScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Config/ConfigScreen.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Config;
+
+public partial class ConfigScreen : ClassicStageScreen
+{
+    public ConfigScreen()
+        : base(ClassicStageEditorScreenMode.Config)
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
+
+public partial class StageScreen : ClassicStageScreen
+{
+    public StageScreen()
+        : base(ClassicStageEditorScreenMode.Stage)
+    {
+    }
+}


### PR DESCRIPTION
Part of issue #1765.

![image](https://user-images.githubusercontent.com/9100368/212465993-84ef8878-7c69-4e9e-b366-1c2963c88a7c.png)
Implement empty stage info editor, include the screen test scene.