### PR TITLE
Able to switch category and edit mode in test scene

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
@@ -1,6 +1,8 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
@@ -8,4 +10,28 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
 public partial class TestSceneStageScreen : ClassicStageScreenTestScene<StageScreen>
 {
     protected override StageScreen CreateEditorScreen() => new();
+
+    [Test]
+    public void TestSwitchCategoryAndEditMode()
+    {
+        if (Child is not StageScreen stageScreen)
+            throw new InvalidOperationException();
+
+        AddWaitStep("wait for editor to load", 5);
+
+        foreach (var category in Enum.GetValues<StageEditorEditCategory>())
+        {
+            foreach (var editMode in Enum.GetValues<StageEditorEditMode>())
+            {
+                AddLabel($"{Enum.GetName(category)} category with {Enum.GetName(editMode)} mode");
+
+                AddStep($"switch to mode {Enum.GetName(editMode)}", () =>
+                {
+                    stageScreen.ChangeEditCategory(category);
+                    stageScreen.ChangeEditMode(editMode);
+                });
+                AddWaitStep("wait for switch to new mode", 5);
+            }
+        }
+    }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/IStageEditorStateProvider.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/IStageEditorStateProvider.cs
@@ -7,15 +7,15 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
 
 public interface IStageEditorStateProvider
 {
-    IBindable<StageEditorEditMode> BindableEditMode { get; }
-
-    StageEditorEditMode EditMode => BindableEditMode.Value;
-
-    void ChangeEditMode(StageEditorEditMode mode);
-
     IBindable<StageEditorEditCategory> BindableEditCategory { get; }
 
     StageEditorEditCategory EditCategory => BindableEditCategory.Value;
 
     void ChangeEditCategory(StageEditorEditCategory mode);
+
+    IBindable<StageEditorEditMode> BindableEditMode { get; }
+
+    StageEditorEditMode EditMode => BindableEditMode.Value;
+
+    void ChangeEditMode(StageEditorEditMode mode);
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
@@ -12,11 +12,11 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
 [Cached(typeof(IStageEditorStateProvider))]
 public partial class StageScreen : ClassicStageScreen, IStageEditorStateProvider
 {
-    public IBindable<StageEditorEditMode> BindableEditMode => bindableEditMode;
     public IBindable<StageEditorEditCategory> BindableEditCategory => bindableCategory;
+    public IBindable<StageEditorEditMode> BindableEditMode => bindableEditMode;
 
-    private readonly Bindable<StageEditorEditMode> bindableEditMode = new();
     private readonly Bindable<StageEditorEditCategory> bindableCategory = new();
+    private readonly Bindable<StageEditorEditMode> bindableEditMode = new();
 
     [Cached(typeof(IStageEditorVerifier))]
     private readonly StageEditorVerifier stageEditorVerifier;
@@ -48,13 +48,13 @@ public partial class StageScreen : ClassicStageScreen, IStageEditorStateProvider
         };
     }
 
-    public void ChangeEditMode(StageEditorEditMode mode)
-    {
-        bindableEditMode.Value = mode;
-    }
-
     public void ChangeEditCategory(StageEditorEditCategory mode)
     {
         bindableCategory.Value = mode;
+    }
+
+    public void ChangeEditMode(StageEditorEditMode mode)
+    {
+        bindableEditMode.Value = mode;
     }
 }


### PR DESCRIPTION
Implement part of #1765

![image](https://user-images.githubusercontent.com/9100368/212546648-1ff1b6b7-641b-4bd6-abbf-ec08326c28a5.png)
Before implement the area to switch the category, should let developers able to switch the edit mode by test case(see the left side).
Also, should make sure that all category and edit mode should be open with no crash issue.