### PR TITLE
Implement compare utils for better to compare two objects.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/ToneCalculationTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/ToneCalculationTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects
@@ -9,6 +10,20 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects
     [TestFixture]
     public class ToneCalculationTest
     {
+        [TestCase(0, false, 0)]
+        [TestCase(0, true, 1)] // left tone should be larger than right tone.
+        [TestCase(1, false, 1)]
+        [TestCase(-1, false, -1)] // left tone should be smaller than right tone.
+        [TestCase(-1, true, -1)]
+        public void TestCompareTo(int scale, bool half, int expected)
+        {
+            var leftTone = new Tone(scale, half);
+            var rightTone = new Tone();
+
+            int actual = leftTone.CompareTo(rightTone);
+            Assert.AreEqual(expected, actual);
+        }
+
         [TestCase(1, 1, 2)]
         [TestCase(-1, 1, 0)]
         [TestCase(1, -1, 0)]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/ComparableUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/ComparableUtilsTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Utils;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Utils;
+
+public class ComparableUtilsTest
+{
+    [TestCase("{\"A\":0,\"B\":0,\"C\":\" \"}", "{\"A\":0,\"B\":0,\"C\":\" \"}", 0)] // should be the same if two values are the same.
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", 0)] // should be the same if two values are the same.
+    [TestCase("{\"A\":0,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -1)]
+    [TestCase("{\"A\":1,\"B\":0,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -49)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":0,\"B\":1,\"C\":\"1\"}", 1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":0,\"C\":\"1\"}", 1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"\"}", 49)]
+    public void TestCompare(string leftObjectProperty, string rightObjectProperty, int expected)
+    {
+        var leftObject = JsonConvert.DeserializeObject<TestObject>(leftObjectProperty);
+        var rightObject = JsonConvert.DeserializeObject<TestObject>(rightObjectProperty);
+        int actual = ComparableUtils.Compare(leftObject, rightObject,
+            (left, right) => left.A.CompareTo(right.A),
+            (left, right) => left.B.CompareTo(right.B),
+            (left, right) => string.Compare(left.C, right.C, StringComparison.Ordinal)); // using different comparator might get different compare number.
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase("{\"A\":0,\"B\":0,\"C\":\" \"}", "{\"A\":0,\"B\":0,\"C\":\" \"}", 0)] // should be the same if two values are the same.
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", 0)] // should be the same if two values are the same.
+    [TestCase("{\"A\":0,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -1)]
+    [TestCase("{\"A\":1,\"B\":0,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"\"}", "{\"A\":1,\"B\":1,\"C\":\"1\"}", -1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":0,\"B\":1,\"C\":\"1\"}", 1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":0,\"C\":\"1\"}", 1)]
+    [TestCase("{\"A\":1,\"B\":1,\"C\":\"1\"}", "{\"A\":1,\"B\":1,\"C\":\"\"}", 1)]
+    public void TestCompareByProperty(string leftObjectProperty, string rightObjectProperty, int expected)
+    {
+        var leftObject = JsonConvert.DeserializeObject<TestObject>(leftObjectProperty);
+        var rightObject = JsonConvert.DeserializeObject<TestObject>(rightObjectProperty);
+        int actual = ComparableUtils.CompareByProperty(leftObject, rightObject,
+            (t) => t.A,
+            (t) => t.B,
+            (t) => t.C);
+        Assert.AreEqual(expected, actual);
+    }
+
+    private class TestObject
+    {
+        public int A { get; set; } = 0;
+
+        public double B { get; set; } = 0;
+
+        public string C { get; set; } = string.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicLyricTimingPoint.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicLyricTimingPoint.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text.Json.Serialization;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Classic;
@@ -38,5 +39,10 @@ public class ClassicLyricTimingPoint : IDeepCloneable<ClassicLyricTimingPoint>, 
         };
     }
 
-    public int CompareTo(ClassicLyricTimingPoint? other) => Time.CompareTo(other?.Time);
+    public int CompareTo(ClassicLyricTimingPoint? other)
+    {
+        return ComparableUtils.CompareByProperty(this, other,
+            t => t.Time,
+            t => t.ID);
+    }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
@@ -11,6 +11,7 @@ using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Utils;
 using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps.Pages;
@@ -107,6 +108,11 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
 
         public double EndTime { get; set; }
 
-        public int CompareTo(LyricTimingInfo other) => StartTime.CompareTo(other.StartTime);
+        public int CompareTo(LyricTimingInfo other)
+        {
+            return ComparableUtils.CompareByProperty(this, other,
+                t => t.StartTime,
+                t => t.EndTime);
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Tone.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Tone.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Objects
 {
@@ -19,30 +20,14 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public int CompareTo(Tone other)
         {
-            if (Scale > other.Scale)
-                return 1;
-
-            if (Scale < other.Scale)
-                return -1;
-
-            if (Half == other.Half)
-                return 0;
-
-            if (Half)
-                return 1;
-
-            return -1;
+            return ComparableUtils.CompareByProperty(this, other,
+                t => t.Scale,
+                t => t.Half);
         }
 
         public int CompareTo(int other)
         {
-            if (Scale > other)
-                return 1;
-
-            if (Scale < other)
-                return -1;
-
-            return Half ? 1 : 0;
+            return CompareTo(new Tone(other));
         }
 
         public bool Equals(Tone other) => Scale == other.Scale && Half == other.Half;

--- a/osu.Game.Rulesets.Karaoke/Objects/Tone.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Tone.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             };
         }
 
-        public override int GetHashCode() => base.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(Scale, Half);
 
         public static Tone operator +(Tone left, Tone right) => add(left, right);
 

--- a/osu.Game.Rulesets.Karaoke/Utils/ComparableUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/ComparableUtils.cs
@@ -1,0 +1,37 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Utils;
+
+public static class ComparableUtils
+{
+    public static int Compare<T>(T? x, T? y, params Func<T, T, int>[] comparers)
+    {
+        if (x == null || y == null)
+            throw new InvalidOperationException("This utils does not support null cases");
+
+        return comparers.Select(cmp => cmp(x, y))
+                        .FirstOrDefault(result => result != 0);
+    }
+
+    public static int CompareByProperty<T>(T? x, T? y, params Func<T, object>[] comparers)
+    {
+        var comparerResults = comparers.Select(comparer =>
+        {
+            int compareFunction(T aa, T bb)
+            {
+                object xPropertyValue = comparer(aa);
+                object yPropertyValue = comparer(bb);
+                return Comparer.Default.Compare(xPropertyValue, yPropertyValue);
+            }
+
+            return (Func<T, T, int>)compareFunction;
+        }).ToArray();
+
+        return Compare(x, y, comparerResults);
+    }
+}


### PR DESCRIPTION
In some cases, we need to compare object by some of the properties.
For example, if compare the `Tone.cs`, we need to compare the `Scale` first. If the scale in the tones are the same, than next is compare the `Half` property.
.
Should be better to write a utils for compare the object by list of the properties.