### PR TITLE
Adjust change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotePropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotePropertyChangeHandlerTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -88,6 +89,37 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Notes
             });
 
             TriggerHandlerChangedWithChangeForbiddenException(c => c.ChangeText("からおけ"));
+        }
+
+        [Test]
+        public void TestOffsetTone()
+        {
+            PrepareHitObject(new Note
+            {
+                Display = true,
+                Tone = new Tone(3)
+            });
+
+            TriggerHandlerChanged(c => c.OffsetTone(new Tone(-3)));
+
+            AssertSelectedHitObject(h =>
+            {
+                Assert.AreEqual(new Tone(), h.Tone);
+                Assert.IsTrue(h.Display);
+            });
+        }
+
+        [Test]
+        public void TestOffsetToneWithZeroValue()
+        {
+            PrepareHitObject(new Note
+            {
+                Display = true,
+                Tone = new Tone(3)
+            });
+
+            // offset value should not be zero.
+            TriggerHandlerChangedWithException<InvalidOperationException>(c => c.OffsetTone(new Tone()));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -6,22 +6,31 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 
 public partial class BeatmapPropertyChangeHandler : Component
 {
+    private readonly Cached changingCache = new();
+
     [Resolved, AllowNull]
     private EditorBeatmap beatmap { get; set; }
 
     protected KaraokeBeatmap KaraokeBeatmap => EditorBeatmapUtils.GetPlayableBeatmap(beatmap);
 
     protected IEnumerable<Lyric> Lyrics => KaraokeBeatmap.HitObjects.OfType<Lyric>();
+
+    protected BeatmapPropertyChangeHandler()
+    {
+        changingCache.Validate();
+    }
 
     protected void PerformBeatmapChanged(Action<KaraokeBeatmap> action)
     {
@@ -39,6 +48,40 @@ public partial class BeatmapPropertyChangeHandler : Component
                 beatmap.EndChange();
 
             throw;
+        }
+    }
+
+    protected void PerformOnSelection<T>(Action<T> action) where T : HitObject
+    {
+        if (!changingCache.IsValid)
+            throw new NotSupportedException("Cannot trigger the change while applying another change.");
+
+        if (beatmap.SelectedHitObjects.Count == 0)
+            throw new NotSupportedException($"Should contain at least one selected {nameof(T)}");
+
+        changingCache.Invalidate();
+
+        try
+        {
+            // should trigger the UpdateState() in the editor beatmap only if there's no active state.
+            beatmap.PerformOnSelection(h =>
+            {
+                if (h is T tHitObject)
+                    action(tHitObject);
+            });
+        }
+        catch
+        {
+            // We should make sure that editor beatmap will end the change if still changing.
+            // will goes to here if have exception in the change handler.
+            if (beatmap.TransactionActive)
+                beatmap.EndChange();
+
+            throw;
+        }
+        finally
+        {
+            changingCache.Validate();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapStageElementCategoryChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapStageElementCategoryChangeHandler.cs
@@ -3,14 +3,11 @@
 
 using System;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
-using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 
-public interface IBeatmapStageElementCategoryChangeHandler<TStageElement, in THitObject>
+public interface IBeatmapStageElementCategoryChangeHandler<TStageElement>
     where TStageElement : IStageElement
-    where THitObject : KaraokeHitObject, IHasPrimaryKey
 {
     void AddElement(Action<TStageElement>? action = null);
 
@@ -18,9 +15,11 @@ public interface IBeatmapStageElementCategoryChangeHandler<TStageElement, in THi
 
     void RemoveElement(TStageElement element);
 
-    void AddToMapping(TStageElement element, THitObject hitObject);
+    void AddToMapping(TStageElement element);
 
-    void RemoveFromMapping(THitObject hitObject);
+    void OffsetMapping(int offset);
+
+    void RemoveFromMapping();
 
     void ClearUnusedMapping();
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/INotePropertyChangeHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Karaoke.Objects;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
 {
     public interface INotePropertyChangeHandler
@@ -10,5 +12,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
         void ChangeRubyText(string ruby);
 
         void ChangeDisplayState(bool display);
+
+        void OffsetTone(Tone offset);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Notes/NotePropertyChangeHandler.cs
@@ -1,13 +1,20 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
 {
     public partial class NotePropertyChangeHandler : HitObjectPropertyChangeHandler<Note>, INotePropertyChangeHandler
     {
+        [Resolved, AllowNull]
+        private EditorBeatmap beatmap { get; set; }
+
         public void ChangeText(string text)
         {
             CheckExactlySelectedOneHitObject();
@@ -38,6 +45,28 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Notes
                 // Move to center if note is not display
                 if (!note.Display)
                     note.Tone = new Tone();
+            });
+        }
+
+        public void OffsetTone(Tone offset)
+        {
+            if (offset == default(Tone))
+                throw new InvalidOperationException("Offset number should not be zero.");
+
+            var noteInfo = EditorBeatmapUtils.GetPlayableBeatmap(beatmap).NoteInfo;
+
+            PerformOnSelection(note =>
+            {
+                if (note.Tone >= noteInfo.MaxTone && offset > 0)
+                    return;
+
+                if (note.Tone <= noteInfo.MinTone && offset < 0)
+                    return;
+
+                note.Tone += offset;
+
+                //Change all note to visible
+                note.Display = true;
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeSelectionHandler.cs
@@ -133,30 +133,19 @@ namespace osu.Game.Rulesets.Karaoke.Edit
             float lastCenterPosition = calculator.YPositionAt(lastTone);
             float delta = centerPosition.Y - lastCenterPosition;
 
-            // get delta tone.
+            // get offset tone.
             const float trigger_height = ScrollingNotePlayfield.COLUMN_SPACING + DefaultColumnBackground.COLUMN_HEIGHT;
-            var deltaTone = delta switch
+            var offset = delta switch
             {
                 > trigger_height => -new Tone { Half = true },
                 < 0 => new Tone { Half = true },
                 _ => default
             };
 
-            if (deltaTone == default(Tone))
+            if (offset == default(Tone))
                 return;
 
-            foreach (var note in EditorBeatmap.SelectedHitObjects.OfType<Note>())
-            {
-                if (note.Tone >= calculator.MaxTone && deltaTone > 0)
-                    continue;
-                if (note.Tone <= calculator.MinTone && deltaTone < 0)
-                    continue;
-
-                note.Tone += deltaTone;
-
-                //Change all note to visible
-                note.Display = true;
-            }
+            notePropertyChangeHandler.OffsetTone(offset);
         }
     }
 }


### PR DESCRIPTION
What's done in this PR:
- `NotePropertyChangeHandler` now can support the dragging change. Thanks to the change in the #1855.
- Let `BeatmapPropertyChangeHandler` able to interact with list of selected hit-objects.
- If change the mapping between hit-object and the element in the `BeatmapStageElementCategoryChangeHandler`, must select the hit-object first.