### PR TITLE
Should not check the lyric's property in the note check.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
@@ -63,11 +63,12 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
             AssertNotOk<NoteIssue, IssueTemplateNoteInvalidReferenceLyric>(note);
         }
 
-        [TestCase(0, new string[] { })]
-        [TestCase(0, new[] { "[0,start]:1000" })]
-        [TestCase(-1, new[] { "[0,start]:1000" })] // should not show other error if time-tag amount is not enough.
-        [TestCase(2, new[] { "[0,start]:1000" })]
-        public void TestCheckReferenceLyricHasLessThanTwoTimeTag(int referenceTimeTagIndex, string[] timeTags)
+        [TestCase(2, new[] { "[0,start]:1000", "[3,end]:5000" })] // will find the time-tag at index 2 and 3.
+        [TestCase(-2, new[] { "[0,start]:1000", "[3,end]:5000" })] // will find the time-tag at index -2 and -1.
+        [TestCase(0, new string[] { })] // should have error because start and end time-tag not found.
+        [TestCase(1, new[] { "[0,start]:1000" })]
+        [TestCase(-2, new[] { "[0,start]:1000" })]
+        public void TestCheckMissingReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
         {
             var lyric = new Lyric
             {
@@ -80,7 +81,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks
                 ReferenceTimeTagIndex = referenceTimeTagIndex,
             };
 
-            AssertNotOk<NoteIssue, IssueTemplateNoteReferenceLyricHasLessThanTwoTimeTag>(new HitObject[] { lyric, note });
+            AssertNotOk<NoteIssue, IssueTemplateNoteMissingReferenceTimeTag>(new HitObject[] { lyric, note });
         }
 
         [TestCase(-1, new[] { "[0,start]:1000", "[3,end]:5000" })]

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteReferenceLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckNoteReferenceLyric.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
         {
             new IssueTemplateNoteNullReferenceLyric(this),
             new IssueTemplateNoteInvalidReferenceLyric(this),
-            new IssueTemplateNoteReferenceLyricHasLessThanTwoTimeTag(this),
+            new IssueTemplateNoteMissingReferenceTimeTag(this),
             new IssueTemplateNoteMissingStartReferenceTimeTag(this),
             new IssueTemplateNoteStartReferenceTimeTagMissingTime(this),
             new IssueTemplateNoteMissingEndReferenceTimeTag(this),
@@ -36,15 +36,15 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
             if (note.ReferenceLyric != null && !allAvailableReferencedHitObjects.Contains(note.ReferenceLyric))
                 yield return new IssueTemplateNoteInvalidReferenceLyric(this).Create(note);
 
-            if (note.ReferenceLyric?.TimeTags.Count < 2)
+            var startTimeTag = note.StartReferenceTimeTag;
+            var endTimeTag = note.EndReferenceTimeTag;
+
+            if (startTimeTag == null && endTimeTag == null)
             {
-                yield return new IssueTemplateNoteReferenceLyricHasLessThanTwoTimeTag(this).Create(note);
+                yield return new IssueTemplateNoteMissingReferenceTimeTag(this).Create(note);
 
                 yield break;
             }
-
-            var startTimeTag = note.StartReferenceTimeTag;
-            var endTimeTag = note.EndReferenceTimeTag;
 
             if (startTimeTag == null)
                 yield return new IssueTemplateNoteMissingStartReferenceTimeTag(this).Create(note);
@@ -81,10 +81,10 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks
                 => new NoteIssue(note, this);
         }
 
-        public class IssueTemplateNoteReferenceLyricHasLessThanTwoTimeTag : IssueTemplate
+        public class IssueTemplateNoteMissingReferenceTimeTag : IssueTemplate
         {
-            public IssueTemplateNoteReferenceLyricHasLessThanTwoTimeTag(ICheck check)
-                : base(check, IssueType.Problem, "Note's reference lyric must have at least two time-tags.")
+            public IssueTemplateNoteMissingReferenceTimeTag(ICheck check)
+                : base(check, IssueType.Problem, "Note's reference time-tag is missing.")
             {
             }
 


### PR DESCRIPTION
As title.

And note that there's no need to have role to have at least 2 time-tags in the lyric.
If user add the start and end time-tag to the lyric for fixing the issue, then lyric will have at least 2 time-tags.