### PR TITLE
Apply the setting source into the config class.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
 public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TConfig>
     : BasePropertyDetectorTest<TDetector, TItem, TProperty>
     where TDetector : PropertyDetector<TItem, TProperty>
-    where TConfig : IHasConfig, new()
+    where TConfig : GeneratorConfig, new()
 {
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
@@ -15,6 +15,8 @@ public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TCon
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
+        GeneratorConfigHelper.ClearValue(config);
+
         action?.Invoke(config);
         return config;
     }
@@ -22,6 +24,7 @@ public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TCon
     protected static TConfig GeneratorDefaultConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
+
         action?.Invoke(config);
         return config;
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
@@ -21,7 +21,7 @@ public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TCon
 
     protected static TConfig GeneratorDefaultConfig(Action<TConfig>? action = null)
     {
-        var config = new TConfig().CreateDefaultConfig();
+        var config = new TConfig();
         action?.Invoke(config);
         return config;
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
 public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TConfig>
     : BasePropertyDetectorTest<TDetector, TItem, TProperty>
     where TDetector : PropertyDetector<TItem, TProperty>
-    where TConfig : IHasConfig<TConfig>, new()
+    where TConfig : IHasConfig, new()
 {
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
@@ -21,7 +21,7 @@ public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TC
 
     protected static TConfig GeneratorDefaultConfig(Action<TConfig>? action = null)
     {
-        var config = new TConfig().CreateDefaultConfig();
+        var config = new TConfig();
         action?.Invoke(config);
         return config;
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
 public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TConfig>
     : BasePropertyGeneratorTest<TGenerator, TItem, TProperty>
     where TGenerator : PropertyGenerator<TItem, TProperty>
-    where TConfig : IHasConfig<TConfig>, new()
+    where TConfig : IHasConfig, new()
 {
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
 public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TConfig>
     : BasePropertyGeneratorTest<TGenerator, TItem, TProperty>
     where TGenerator : PropertyGenerator<TItem, TProperty>
-    where TConfig : IHasConfig, new()
+    where TConfig : GeneratorConfig, new()
 {
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
@@ -15,6 +15,8 @@ public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TC
     protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
+        GeneratorConfigHelper.ClearValue(config);
+
         action?.Invoke(config);
         return config;
     }
@@ -22,6 +24,7 @@ public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TC
     protected static TConfig GeneratorDefaultConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
+
         action?.Invoke(config);
         return config;
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Beatmaps
     public abstract class BaseBeatmapDetectorTest<TDetector, TObject, TConfig>
         : BasePropertyDetectorTest<TDetector, KaraokeBeatmap, TObject, TConfig>
         where TDetector : BeatmapPropertyDetector<TObject, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Beatmaps
     public abstract class BaseBeatmapDetectorTest<TDetector, TObject, TConfig>
         : BasePropertyDetectorTest<TDetector, KaraokeBeatmap, TObject, TConfig>
         where TDetector : BeatmapPropertyDetector<TObject, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Beatmaps
     public abstract class BaseBeatmapGeneratorTest<TGenerator, TObject, TConfig>
         : BasePropertyGeneratorTest<TGenerator, KaraokeBeatmap, TObject, TConfig>
         where TGenerator : BeatmapPropertyGenerator<TObject, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Beatmaps/BaseBeatmapGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Beatmaps
     public abstract class BaseBeatmapGeneratorTest<TGenerator, TObject, TConfig>
         : BasePropertyGeneratorTest<TGenerator, KaraokeBeatmap, TObject, TConfig>
         where TGenerator : BeatmapPropertyGenerator<TObject, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/GeneratorConfigHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/GeneratorConfigHelper.cs
@@ -1,0 +1,40 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Game.Rulesets.Karaoke.Edit.Generator;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
+
+public class GeneratorConfigHelper
+{
+    public static void ClearValue(GeneratorConfig config)
+    {
+        foreach (var property in getAllBindableProperty(config))
+        {
+            object propertyInstance = property.GetValue(config, null)!;
+
+            // set the default value to the value.
+            var propertyType = propertyInstance.GetType();
+            propertyType.GetProperty(nameof(Bindable<object>.Value))!.SetValue(propertyInstance, default);
+        }
+    }
+
+    private static IEnumerable<PropertyInfo> getAllBindableProperty(GeneratorConfig config)
+    {
+        foreach (var property in config.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            object propertyInstance = property.GetValue(config, null)!;
+            var propertyType = propertyInstance.GetType();
+
+            if (propertyType.EnumerateBaseTypes().All(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(Bindable<>)))
+                continue;
+
+            yield return property;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics
     public abstract class BaseLyricDetectorTest<TDetector, TObject, TConfig>
         : BasePropertyDetectorTest<TDetector, Lyric, TObject, TConfig>
         where TDetector : LyricPropertyDetector<TObject, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricDetectorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics
     public abstract class BaseLyricDetectorTest<TDetector, TObject, TConfig>
         : BasePropertyDetectorTest<TDetector, Lyric, TObject, TConfig>
         where TDetector : LyricPropertyDetector<TObject, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics
     public abstract class BaseLyricGeneratorTest<TGenerator, TObject, TConfig>
         : BasePropertyGeneratorTest<TGenerator, Lyric, TObject, TConfig>
         where TGenerator : LyricPropertyGenerator<TObject, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/BaseLyricGeneratorTest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics
     public abstract class BaseLyricGeneratorTest<TGenerator, TObject, TConfig>
         : BasePropertyGeneratorTest<TGenerator, Lyric, TObject, TConfig>
         where TGenerator : LyricPropertyGenerator<TObject, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorTest.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.ReferenceLyric
                 },
                 detectedLyric
             };
-            var config = GeneratorConfig(x => x.IgnorePrefixAndPostfixSymbol = true);
+            var config = GeneratorConfig(x => x.IgnorePrefixAndPostfixSymbol.Value = true);
             CheckCanDetect(lyrics, detectedLyric, canDetect, config);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/BaseRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/BaseRomajiTagGeneratorTest.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RomajiTags
 {
     public abstract class BaseRomajiTagGeneratorTest<TRomajiTagGenerator, TConfig> : BaseLyricGeneratorTest<TRomajiTagGenerator, RomajiTag[], TConfig>
-        where TRomajiTagGenerator : RomajiTagGenerator<TConfig> where TConfig : RomajiTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TRomajiTagGenerator : RomajiTagGenerator<TConfig> where TConfig : RomajiTagGeneratorConfig, IHasConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/BaseRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/BaseRomajiTagGeneratorTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Edit.Generator;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -10,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RomajiTags
 {
     public abstract class BaseRomajiTagGeneratorTest<TRomajiTagGenerator, TConfig> : BaseLyricGeneratorTest<TRomajiTagGenerator, RomajiTag[], TConfig>
-        where TRomajiTagGenerator : RomajiTagGenerator<TConfig> where TConfig : RomajiTagGeneratorConfig, IHasConfig, new()
+        where TRomajiTagGenerator : RomajiTagGenerator<TConfig> where TConfig : RomajiTagGeneratorConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RomajiTags.Ja
         [TestCase("はなび", new[] { "[0,3]:HANABI" })]
         public void TestGenerateWithUppercase(string text, string[] expectedRomajies)
         {
-            var config = GeneratorConfig(x => x.Uppercase = true);
+            var config = GeneratorConfig(x => x.Uppercase.Value = true);
             CheckGenerateResult(text, expectedRomajies, config);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RubyTags
 {
     public abstract class BaseRubyTagGeneratorTest<TRubyTagGenerator, TConfig> : BaseLyricGeneratorTest<TRubyTagGenerator, RubyTag[], TConfig>
-        where TRubyTagGenerator : RubyTagGenerator<TConfig> where TConfig : RubyTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TRubyTagGenerator : RubyTagGenerator<TConfig> where TConfig : RubyTagGeneratorConfig, IHasConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Edit.Generator;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -10,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RubyTags
 {
     public abstract class BaseRubyTagGeneratorTest<TRubyTagGenerator, TConfig> : BaseLyricGeneratorTest<TRubyTagGenerator, RubyTag[], TConfig>
-        where TRubyTagGenerator : RubyTagGenerator<TConfig> where TConfig : RubyTagGeneratorConfig, IHasConfig, new()
+        where TRubyTagGenerator : RubyTagGenerator<TConfig> where TConfig : RubyTagGeneratorConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RubyTags.Ja
         [TestCase("ハナビ", new string[] { })]
         public void TestGenerateWithRubyAsKatakana(string text, string[] expectedRubies)
         {
-            var config = GeneratorConfig(x => x.RubyAsKatakana = true);
+            var config = GeneratorConfig(x => x.RubyAsKatakana.Value = true);
             CheckGenerateResult(text, expectedRubies, config);
         }
 
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.RubyTags.Ja
         [TestCase("ハナビ", new[] { "[0,3]:はなび" })]
         public void TestGenerateWithEnableDuplicatedRuby(string text, string[] expectedRubies)
         {
-            var config = GeneratorConfig(x => x.EnableDuplicatedRuby = true);
+            var config = GeneratorConfig(x => x.EnableDuplicatedRuby.Value = true);
             CheckGenerateResult(text, expectedRubies, config);
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Edit.Generator;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Tests.Asserts;
@@ -10,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags
 {
     public abstract class BaseTimeTagGeneratorTest<TTimeTagGenerator, TConfig> : BaseLyricGeneratorTest<TTimeTagGenerator, TimeTag[], TConfig>
-        where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, IHasConfig, new()
+        where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/BaseTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/BaseTimeTagGeneratorTest.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags
 {
     public abstract class BaseTimeTagGeneratorTest<TTimeTagGenerator, TConfig> : BaseLyricGeneratorTest<TTimeTagGenerator, TimeTag[], TConfig>
-        where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TTimeTagGenerator : TimeTagGenerator<TConfig> where TConfig : TimeTagGeneratorConfig, IHasConfig, new()
     {
         protected static void CheckCanGenerate(string text, bool canGenerate, TConfig config)
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -21,11 +21,19 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
             CheckCanGenerate(text, canGenerate, config);
         }
 
-        [TestCase("か", new[] { "[0,start]:" }, false)]
-        [TestCase("か", new[] { "[0,start]:", "[0,end]:" }, true)]
-        public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
+        [TestCase("がんばって", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false)]
+        [TestCase("がんばって", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[4,start]:" }, true)]
+        public void TestGenerateWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
-            var config = GeneratorConfig(x => x.CheckLineEndKeyUp = applyConfig);
+            var config = GeneratorConfig(x => x.Checkん.Value = applyConfig);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
+        }
+
+        [TestCase("買って", new[] { "[0,start]:", "[2,start]:" }, false)]
+        [TestCase("買って", new[] { "[0,start]:", "[1,start]:", "[2,start]:" }, true)]
+        public void TestGenerateWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
+        {
+            var config = GeneratorConfig(x => x.Checkっ.Value = applyConfig);
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
@@ -33,7 +41,15 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         [TestCase(" ", new[] { "[0,start]:" }, true)]
         public void TestGenerateWithCheckBlankLine(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
-            var config = GeneratorConfig(x => x.CheckBlankLine = applyConfig);
+            var config = GeneratorConfig(x => x.CheckBlankLine.Value = applyConfig);
+            CheckGenerateResult(lyric, expectedTimeTags, config);
+        }
+
+        [TestCase("か", new[] { "[0,start]:" }, false)]
+        [TestCase("か", new[] { "[0,start]:", "[0,end]:" }, true)]
+        public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
+        {
+            var config = GeneratorConfig(x => x.CheckLineEndKeyUp.Value = applyConfig);
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
@@ -41,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         [TestCase("か     ", new[] { "[0,start]:", "[1,start]:" }, true)]
         public void TestGenerateWithCheckWhiteSpace(string lyric, string[] expectedTimeTags, bool applyConfig)
         {
-            var config = GeneratorConfig(x => x.CheckWhiteSpace = applyConfig);
+            var config = GeneratorConfig(x => x.CheckWhiteSpace.Value = applyConfig);
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 
@@ -51,8 +67,8 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         {
             var config = GeneratorConfig(x =>
             {
-                x.CheckWhiteSpace = true;
-                x.CheckWhiteSpaceKeyUp = applyConfig;
+                x.CheckWhiteSpace.Value = true;
+                x.CheckWhiteSpaceKeyUp.Value = applyConfig;
             });
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
@@ -67,9 +83,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         {
             var config = GeneratorConfig(x =>
             {
-                x.CheckWhiteSpace = true;
-                x.CheckWhiteSpaceAlphabet = applyConfig;
-                x.CheckWhiteSpaceKeyUp = keyUp;
+                x.CheckWhiteSpace.Value = true;
+                x.CheckWhiteSpaceAlphabet.Value = applyConfig;
+                x.CheckWhiteSpaceKeyUp.Value = keyUp;
             });
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
@@ -84,9 +100,9 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         {
             var config = GeneratorConfig(x =>
             {
-                x.CheckWhiteSpace = true;
-                x.CheckWhiteSpaceDigit = applyConfig;
-                x.CheckWhiteSpaceKeyUp = keyUp;
+                x.CheckWhiteSpace.Value = true;
+                x.CheckWhiteSpaceDigit.Value = applyConfig;
+                x.CheckWhiteSpaceKeyUp.Value = keyUp;
             });
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
@@ -98,26 +114,10 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Ja
         {
             var config = GeneratorConfig(x =>
             {
-                x.CheckWhiteSpace = true;
-                x.CheckWhiteSpaceAsciiSymbol = applyConfig;
-                x.CheckWhiteSpaceKeyUp = keyUp;
+                x.CheckWhiteSpace.Value = true;
+                x.CheckWhiteSpaceAsciiSymbol.Value = applyConfig;
+                x.CheckWhiteSpaceKeyUp.Value = keyUp;
             });
-            CheckGenerateResult(lyric, expectedTimeTags, config);
-        }
-
-        [TestCase("がんばって", new[] { "[0,start]:", "[2,start]:", "[4,start]:" }, false)]
-        [TestCase("がんばって", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[4,start]:" }, true)]
-        public void TestGenerateWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
-        {
-            var config = GeneratorConfig(x => x.Checkん = applyConfig);
-            CheckGenerateResult(lyric, expectedTimeTags, config);
-        }
-
-        [TestCase("買って", new[] { "[0,start]:", "[2,start]:" }, false)]
-        [TestCase("買って", new[] { "[0,start]:", "[1,start]:", "[2,start]:" }, true)]
-        public void TestGenerateWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
-        {
-            var config = GeneratorConfig(x => x.Checkっ = applyConfig);
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.TimeTags.Zh
         [TestCase("拉~拉~拉~", new[] { "[0,start]:", "[2,start]:", "[4,start]:", "[5,end]:" })]
         public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags)
         {
-            var config = GeneratorConfig(x => x.CheckLineEndKeyUp = true);
+            var config = GeneratorConfig(x => x.CheckLineEndKeyUp.Value = true);
             CheckGenerateResult(lyric, expectedTimeTags, config);
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetEditGeneratorSetting.ReferenceLyricDetectorConfig, CreateDefaultConfig<ReferenceLyricDetectorConfig>());
         }
 
-        protected static T CreateDefaultConfig<T>() where T : IHasConfig<T>, new() => new();
+        protected static T CreateDefaultConfig<T>() where T : IHasConfig, new() => new();
     }
 
     public enum KaraokeRulesetEditGeneratorSetting

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetEditGeneratorSetting.ReferenceLyricDetectorConfig, CreateDefaultConfig<ReferenceLyricDetectorConfig>());
         }
 
-        protected static T CreateDefaultConfig<T>() where T : IHasConfig, new() => new();
+        protected static T CreateDefaultConfig<T>() where T : GeneratorConfig, new() => new();
     }
 
     public enum KaraokeRulesetEditGeneratorSetting

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
@@ -46,8 +46,7 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             SetDefault(KaraokeRulesetEditGeneratorSetting.ReferenceLyricDetectorConfig, CreateDefaultConfig<ReferenceLyricDetectorConfig>());
         }
 
-        protected static T CreateDefaultConfig<T>() where T : IHasConfig<T>, new()
-            => new T().CreateDefaultConfig();
+        protected static T CreateDefaultConfig<T>() where T : IHasConfig<T>, new() => new();
     }
 
     public enum KaraokeRulesetEditGeneratorSetting

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
@@ -40,7 +40,7 @@ public partial class BeatmapPagesChangeHandler : BeatmapPropertyChangeHandler, I
 
         performPageInfoChanged(pageInfo =>
         {
-            if (config.ClearExistPages)
+            if (config.ClearExistPages.Value)
                 pageInfo.Pages.Clear();
 
             pageInfo.Pages.AddRange(pages);

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyDetector.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class BeatmapPropertyDetector<TProperty, TConfig> : PropertyDetector<KaraokeBeatmap, TProperty, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
         protected BeatmapPropertyDetector(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyDetector.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class BeatmapPropertyDetector<TProperty, TConfig> : PropertyDetector<KaraokeBeatmap, TProperty, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
         protected BeatmapPropertyDetector(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyGenerator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class BeatmapPropertyGenerator<TProperty, TConfig> : PropertyGenerator<KaraokeBeatmap, TProperty, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
         protected BeatmapPropertyGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/BeatmapPropertyGenerator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class BeatmapPropertyGenerator<TProperty, TConfig> : PropertyGenerator<KaraokeBeatmap, TProperty, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
         protected BeatmapPropertyGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
@@ -42,10 +42,10 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
 
     protected override Page[] GenerateFromItem(KaraokeBeatmap item)
     {
-        if (Config.MinTime < CheckBeatmapPageInfo.MIN_INTERVAL || Config.MaxTime > CheckBeatmapPageInfo.MAX_INTERVAL)
+        if (Config.MinTime.Value < CheckBeatmapPageInfo.MIN_INTERVAL || Config.MaxTime.Value > CheckBeatmapPageInfo.MAX_INTERVAL)
             throw new InvalidOperationException("Interval time should be validate.");
 
-        var existPages = Config.ClearExistPages ? Array.Empty<Page>() : item.PageInfo.SortedPages.ToArray();
+        var existPages = Config.ClearExistPages.Value ? Array.Empty<Page>() : item.PageInfo.SortedPages.ToArray();
         var lyricTimingInfos = item.HitObjects.OfType<Lyric>().Select(x => new LyricTimingInfo
         {
             StartTime = x.LyricStartTime,
@@ -79,14 +79,14 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
 
             while (currentTime < expectedEndTime)
             {
-                if (expectedEndTime - currentTime < Config.MinTime && getAverageTimeWithNextLyric)
+                if (expectedEndTime - currentTime < Config.MinTime.Value && getAverageTimeWithNextLyric)
                 {
                     break;
                 }
 
-                if (expectedEndTime - currentTime > Config.MaxTime)
+                if (expectedEndTime - currentTime > Config.MaxTime.Value)
                 {
-                    yield return createReturnPage(currentTime + Config.MaxTime);
+                    yield return createReturnPage(currentTime + Config.MaxTime.Value);
                 }
                 else
                 {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Checks;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps.Pages;
 
-public class PageGeneratorConfig : IHasConfig
+public class PageGeneratorConfig : GeneratorConfig
 {
     public double MinTime { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
@@ -1,22 +1,27 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps.Pages;
 
 public class PageGeneratorConfig : GeneratorConfig
 {
-    public double MinTime { get; set; }
-
-    public double MaxTime { get; set; }
-
-    public bool ClearExistPages { get; set; }
-
-    public PageGeneratorConfig CreateDefaultConfig() => new()
+    [ConfigSource("Min time", "Min interval between pages.")]
+    public Bindable<double> MinTime { get; } = new BindableDouble(CheckBeatmapPageInfo.MIN_INTERVAL)
     {
-        MinTime = CheckBeatmapPageInfo.MIN_INTERVAL,
-        MaxTime = CheckBeatmapPageInfo.MAX_INTERVAL,
-        ClearExistPages = false
+        MinValue = CheckBeatmapPageInfo.MIN_INTERVAL,
+        MaxValue = CheckBeatmapPageInfo.MAX_INTERVAL
     };
+
+    [ConfigSource("Max time", "Max interval between pages.")]
+    public Bindable<double> MaxTime { get; } = new BindableDouble(CheckBeatmapPageInfo.MAX_INTERVAL)
+    {
+        MinValue = CheckBeatmapPageInfo.MIN_INTERVAL,
+        MaxValue = CheckBeatmapPageInfo.MAX_INTERVAL
+    };
+
+    [ConfigSource("Clear the exist page.", "Clear the exist page after generated.")]
+    public Bindable<bool> ClearExistPages { get; } = new BindableBool();
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Checks;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps.Pages;
 
-public class PageGeneratorConfig : IHasConfig<PageGeneratorConfig>
+public class PageGeneratorConfig : IHasConfig
 {
     public double MinTime { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigCategoryAttribute.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigCategoryAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Localisation;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
+
+public class ConfigCategoryAttribute : Attribute
+{
+    public LocalisableString Category { get; }
+
+    public ConfigCategoryAttribute(string category)
+    {
+        Category = category;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigSourceAttribute.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigSourceAttribute.cs
@@ -1,0 +1,30 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Configuration;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
+
+public class ConfigSourceAttribute : SettingSourceAttribute
+{
+    public ConfigSourceAttribute(Type declaringType, string label, string? description = null)
+        : base(declaringType, label, description)
+    {
+    }
+
+    public ConfigSourceAttribute(string? label, string? description = null)
+        : base(label, description)
+    {
+    }
+
+    public ConfigSourceAttribute(Type declaringType, string label, string description, int orderPosition)
+        : base(declaringType, label, description, orderPosition)
+    {
+    }
+
+    public ConfigSourceAttribute(string label, string description, int orderPosition)
+        : base(label, description, orderPosition)
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 {
-    public interface IHasConfig
+    public abstract class GeneratorConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/IHasConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/IHasConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 {
-    public interface IHasConfig<out T> where T : new()
+    public interface IHasConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/IHasConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/IHasConfig.cs
@@ -5,6 +5,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator
 {
     public interface IHasConfig<out T> where T : new()
     {
-        public T CreateDefaultConfig();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Globalization;
 using System.Linq;
 using osu.Framework.Localisation;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Language
         public LanguageDetector(LanguageDetectorConfig config)
             : base(config)
         {
-            var targetLanguages = config.AcceptLanguages.ToList();
+            var targetLanguages = config.AcceptLanguages.Value ?? Array.Empty<CultureInfo>();
 
             if (targetLanguages.Any())
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
@@ -3,13 +3,17 @@
 
 using System;
 using System.Globalization;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Language
 {
     public class LanguageDetectorConfig : GeneratorConfig
     {
-        public CultureInfo[] AcceptLanguages { get; set; } = Array.Empty<CultureInfo>();
+        protected const string CATEGORY_ACCEPT_LANGUAGES = "Accept languages";
 
-        public LanguageDetectorConfig CreateDefaultConfig() => new();
+        // todo: change to the bindablie list.
+        [ConfigCategory(CATEGORY_ACCEPT_LANGUAGES)]
+        [ConfigSource("Accept languages", "All accepted languages.")]
+        public Bindable<CultureInfo[]> AcceptLanguages { get; } = new(Array.Empty<CultureInfo>());
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Language
 {
-    public class LanguageDetectorConfig : IHasConfig<LanguageDetectorConfig>
+    public class LanguageDetectorConfig : IHasConfig
     {
         public CultureInfo[] AcceptLanguages { get; set; } = Array.Empty<CultureInfo>();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Language/LanguageDetectorConfig.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Language
 {
-    public class LanguageDetectorConfig : IHasConfig
+    public class LanguageDetectorConfig : GeneratorConfig
     {
         public CultureInfo[] AcceptLanguages { get; set; } = Array.Empty<CultureInfo>();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricGeneratorSelector.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
 
         protected void RegisterGenerator<TGenerator, TConfig>(CultureInfo info)
             where TGenerator : LyricPropertyGenerator<TProperty, TConfig>
-            where TConfig : TBaseConfig, IHasConfig<TConfig>, new()
+            where TConfig : TBaseConfig, IHasConfig, new()
         {
             generator.Add(info, new Lazy<PropertyGenerator<Lyric, TProperty>>(() =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricGeneratorSelector.cs
@@ -11,6 +11,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
 {
     public abstract class LyricGeneratorSelector<TProperty, TBaseConfig> : PropertyGenerator<Lyric, TProperty>
+        where TBaseConfig : GeneratorConfig
     {
         private Dictionary<CultureInfo, Lazy<PropertyGenerator<Lyric, TProperty>>> generator { get; } = new();
 
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
 
         protected void RegisterGenerator<TGenerator, TConfig>(CultureInfo info)
             where TGenerator : LyricPropertyGenerator<TProperty, TConfig>
-            where TConfig : TBaseConfig, IHasConfig, new()
+            where TConfig : TBaseConfig, new()
         {
             generator.Add(info, new Lazy<PropertyGenerator<Lyric, TProperty>>(() =>
             {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyDetector.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class LyricPropertyDetector<TProperty, TConfig> : PropertyDetector<Lyric, TProperty, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
         protected LyricPropertyDetector(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyDetector.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class LyricPropertyDetector<TProperty, TConfig> : PropertyDetector<Lyric, TProperty, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
         protected LyricPropertyDetector(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyGenerator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class LyricPropertyGenerator<TProperty, TConfig> : PropertyGenerator<Lyric, TProperty, TConfig>
-        where TConfig : IHasConfig<TConfig>, new()
+        where TConfig : IHasConfig, new()
     {
         protected LyricPropertyGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/LyricPropertyGenerator.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics
     /// <typeparam name="TProperty"></typeparam>
     /// <typeparam name="TConfig"></typeparam>
     public abstract class LyricPropertyGenerator<TProperty, TConfig> : PropertyGenerator<Lyric, TProperty, TConfig>
-        where TConfig : IHasConfig, new()
+        where TConfig : GeneratorConfig, new()
     {
         protected LyricPropertyGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Notes
 {
-    public class NoteGeneratorConfig : IHasConfig<NoteGeneratorConfig>
+    public class NoteGeneratorConfig : IHasConfig
     {
         public NoteGeneratorConfig CreateDefaultConfig() => new();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Notes
 {
-    public class NoteGeneratorConfig : IHasConfig
+    public class NoteGeneratorConfig : GeneratorConfig
     {
         public NoteGeneratorConfig CreateDefaultConfig() => new();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGeneratorConfig.cs
@@ -5,6 +5,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Notes
 {
     public class NoteGeneratorConfig : GeneratorConfig
     {
-        public NoteGeneratorConfig CreateDefaultConfig() => new();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetector.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.ReferenceLyric
             if (lyricText == referencedLyricText)
                 return true;
 
-            if (!Config.IgnorePrefixAndPostfixSymbol)
+            if (!Config.IgnorePrefixAndPostfixSymbol.Value)
                 return false;
 
             // check if contains intersect part between two lyrics.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
@@ -1,15 +1,13 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.ReferenceLyric
 {
     public class ReferenceLyricDetectorConfig : GeneratorConfig
     {
-        public bool IgnorePrefixAndPostfixSymbol { get; set; }
-
-        public ReferenceLyricDetectorConfig CreateDefaultConfig() => new()
-        {
-            IgnorePrefixAndPostfixSymbol = true,
-        };
+        [ConfigSource("Ruby as Katakana", "Ruby as Katakana.")]
+        public Bindable<bool> IgnorePrefixAndPostfixSymbol { get; } = new BindableBool(true);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.ReferenceLyric
 {
-    public class ReferenceLyricDetectorConfig : IHasConfig
+    public class ReferenceLyricDetectorConfig : GeneratorConfig
     {
         public bool IgnorePrefixAndPostfixSymbol { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.ReferenceLyric
 {
-    public class ReferenceLyricDetectorConfig : IHasConfig<ReferenceLyricDetectorConfig>
+    public class ReferenceLyricDetectorConfig : IHasConfig
     {
         public bool IgnorePrefixAndPostfixSymbol { get; set; }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGenerator.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags.Ja
 
                 // Convert to romaji.
                 string romaji = JpStringUtils.ToRomaji(katakana);
-                if (Config.Uppercase)
+                if (Config.Uppercase.Value)
                     romaji = romaji.ToUpper();
 
                 // Make tag

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags.Ja
 {
-    public class JaRomajiTagGeneratorConfig : RomajiTagGeneratorConfig, IHasConfig<JaRomajiTagGeneratorConfig>
+    public class JaRomajiTagGeneratorConfig : RomajiTagGeneratorConfig, IHasConfig
     {
         /// <summary>
         /// Generate romaji as uppercase.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags.Ja
 {
     public class JaRomajiTagGeneratorConfig : RomajiTagGeneratorConfig
     {
-        /// <summary>
-        /// Generate romaji as uppercase.
-        /// </summary>
-        public bool Uppercase { get; set; }
-
-        public JaRomajiTagGeneratorConfig CreateDefaultConfig() => new();
+        [ConfigSource("Uppercase", "Export romaji with uppercase.")]
+        public Bindable<bool> Uppercase { get; } = new BindableBool();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags.Ja
 {
-    public class JaRomajiTagGeneratorConfig : RomajiTagGeneratorConfig, IHasConfig
+    public class JaRomajiTagGeneratorConfig : RomajiTagGeneratorConfig
     {
         /// <summary>
         /// Generate romaji as uppercase.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGenerator.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags
 {
     public abstract class RomajiTagGenerator<TConfig> : LyricPropertyGenerator<RomajiTag[], TConfig>
-        where TConfig : RomajiTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TConfig : RomajiTagGeneratorConfig, IHasConfig, new()
     {
         protected RomajiTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGenerator.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags
 {
     public abstract class RomajiTagGenerator<TConfig> : LyricPropertyGenerator<RomajiTag[], TConfig>
-        where TConfig : RomajiTagGeneratorConfig, IHasConfig, new()
+        where TConfig : RomajiTagGeneratorConfig, new()
     {
         protected RomajiTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags
 {
-    public abstract class RomajiTagGeneratorConfig : IHasConfig
+    public abstract class RomajiTagGeneratorConfig : GeneratorConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RomajiTags/RomajiTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RomajiTags
 {
-    public abstract class RomajiTagGeneratorConfig
+    public abstract class RomajiTagGeneratorConfig : IHasConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGenerator.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
                 // Convert to Hiragana as default.
                 string hiragana = JpStringUtils.ToHiragana(katakana);
 
-                if (!Config.EnableDuplicatedRuby)
+                if (!Config.EnableDuplicatedRuby.Value)
                 {
                     // Not add duplicated ruby if same as parent.
                     string parentText = text[offsetAtt.StartOffset..offsetAtt.EndOffset];
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
                 // Make tag
                 tags.Add(new RubyTag
                 {
-                    Text = Config.RubyAsKatakana ? katakana : hiragana,
+                    Text = Config.RubyAsKatakana.Value ? katakana : hiragana,
                     StartIndex = offsetAtt.StartOffset,
                     EndIndex = offsetAtt.EndOffset
                 });

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
 {
     public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig
@@ -8,13 +10,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
         /// <summary>
         /// Generate ruby as Katakana.
         /// </summary>
-        public bool RubyAsKatakana { get; set; }
+        [ConfigSource("Ruby as Katakana", "Ruby as Katakana.")]
+        public Bindable<bool> RubyAsKatakana { get; } = new BindableBool();
 
         /// <summary>
         /// Generate ruby even it's same as lyric.
         /// </summary>
-        public bool EnableDuplicatedRuby { get; set; }
-
-        public JaRubyTagGeneratorConfig CreateDefaultConfig() => new();
+        [ConfigSource("Enable duplicated ruby.", "Enable output duplicated ruby even it's match with lyric.")]
+        public Bindable<bool> EnableDuplicatedRuby { get; } = new BindableBool();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
 {
-    public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig, IHasConfig<JaRubyTagGeneratorConfig>
+    public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig, IHasConfig
     {
         /// <summary>
         /// Generate ruby as Katakana.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags.Ja
 {
-    public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig, IHasConfig
+    public class JaRubyTagGeneratorConfig : RubyTagGeneratorConfig
     {
         /// <summary>
         /// Generate ruby as Katakana.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGenerator.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags
 {
     public abstract class RubyTagGenerator<TConfig> : LyricPropertyGenerator<RubyTag[], TConfig>
-        where TConfig : RubyTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TConfig : RubyTagGeneratorConfig, IHasConfig, new()
     {
         protected RubyTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGenerator.cs
@@ -7,7 +7,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags
 {
     public abstract class RubyTagGenerator<TConfig> : LyricPropertyGenerator<RubyTag[], TConfig>
-        where TConfig : RubyTagGeneratorConfig, IHasConfig, new()
+        where TConfig : RubyTagGeneratorConfig, new()
     {
         protected RubyTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags
 {
-    public abstract class RubyTagGeneratorConfig : IHasConfig
+    public abstract class RubyTagGeneratorConfig : GeneratorConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/RubyTags/RubyTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.RubyTags
 {
-    public abstract class RubyTagGeneratorConfig
+    public abstract class RubyTagGeneratorConfig : IHasConfig
     {
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGenerator.cs
@@ -46,29 +46,29 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
                 char c = text[i];
                 char pc = text[i - 1];
 
-                if (CharUtils.IsSpacing(c) && Config.CheckWhiteSpace)
+                if (CharUtils.IsSpacing(c) && Config.CheckWhiteSpace.Value)
                 {
                     // ignore continuous white space.
                     if (CharUtils.IsSpacing(pc))
                         continue;
 
-                    var timeTag = Config.CheckWhiteSpaceKeyUp
+                    var timeTag = Config.CheckWhiteSpaceKeyUp.Value
                         ? new TimeTag(new TextIndex(i - 1, TextIndex.IndexState.End))
                         : new TimeTag(new TextIndex(i));
 
                     if (CharUtils.IsLatin(pc))
                     {
-                        if (Config.CheckWhiteSpaceAlphabet)
+                        if (Config.CheckWhiteSpaceAlphabet.Value)
                             yield return timeTag;
                     }
                     else if (char.IsDigit(pc))
                     {
-                        if (Config.CheckWhiteSpaceDigit)
+                        if (Config.CheckWhiteSpaceDigit.Value)
                             yield return timeTag;
                     }
                     else if (CharUtils.IsAsciiSymbol(pc))
                     {
-                        if (Config.CheckWhiteSpaceAsciiSymbol)
+                        if (Config.CheckWhiteSpaceAsciiSymbol.Value)
                             yield return timeTag;
                     }
                     else
@@ -112,13 +112,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
                             break;
 
                         case 'ん':
-                            if (Config.Checkん)
+                            if (Config.Checkん.Value)
                                 yield return new TimeTag(new TextIndex(i));
 
                             break;
 
                         case 'っ':
-                            if (Config.Checkっ)
+                            if (Config.Checkっ.Value)
                                 yield return new TimeTag(new TextIndex(i));
 
                             break;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
 {
-    public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig
+    public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig
     {
         /// <summary>
         /// Add the <see cref="TimeTag"/> if spacing is next of the alphabet.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
@@ -8,40 +9,53 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
     public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig
     {
         /// <summary>
+        /// Add the <see cref="TimeTag"/> if character is "ん"
+        /// </summary>
+        [ConfigCategory(CATEGORY_CHECK_CHARACTER)]
+        [ConfigSource("Check ん", "Check ん or not.")]
+        public Bindable<bool> Checkん { get; } = new BindableBool(true);
+
+        /// <summary>
+        /// Add the <see cref="TimeTag"/> if character is "っ"
+        /// </summary>
+        [ConfigCategory(CATEGORY_CHECK_CHARACTER)]
+        [ConfigSource("Check っ", "Check っ or not.")]
+        public Bindable<bool> Checkっ { get; } = new BindableBool();
+
+        /// <summary>
         /// Add the <see cref="TimeTag"/> if spacing is next of the alphabet.
         /// This feature will work only if enable the <see cref="TimeTagGeneratorConfig.CheckWhiteSpace"/>
         /// </summary>
-        public bool CheckWhiteSpaceAlphabet { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_WHITE_SPACE)]
+        [ConfigSource("Check white space alphabet", "Check white space alphabet.")]
+        public Bindable<bool> CheckWhiteSpaceAlphabet { get; } = new BindableBool();
 
         /// <summary>
         /// Add the <see cref="TimeTag"/> if spacing is next of the digit.
         /// This feature will work only if enable the <see cref="TimeTagGeneratorConfig.CheckWhiteSpace"/>
         /// </summary>
-        public bool CheckWhiteSpaceDigit { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_WHITE_SPACE)]
+        [ConfigSource("Check white space digit", "Check white space digit.")]
+        public Bindable<bool> CheckWhiteSpaceDigit { get; } = new BindableBool();
 
         /// <summary>
         /// Add the <see cref="TimeTag"/> if spacing is next of the symbol.
         /// This feature will work only if enable the <see cref="TimeTagGeneratorConfig.CheckWhiteSpace"/>
         /// </summary>
-        public bool CheckWhiteSpaceAsciiSymbol { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_WHITE_SPACE)]
+        [ConfigSource("Check white space ascii symbol", "Check white space ascii symbol.")]
+        public Bindable<bool> CheckWhiteSpaceAsciiSymbol { get; } = new BindableBool();
 
-        /// <summary>
-        /// Add the <see cref="TimeTag"/> if character is "ん"
-        /// </summary>
-        public bool Checkん { get; set; }
+        public JaTimeTagGeneratorConfig()
+        {
+            CheckLineEndKeyUp.Default = true;
+            CheckLineEndKeyUp.SetDefault();
 
-        /// <summary>
-        /// Add the <see cref="TimeTag"/> if character is "っ"
-        /// </summary>
-        public bool Checkっ { get; set; }
+            CheckWhiteSpace.Default = true;
+            CheckWhiteSpace.SetDefault();
 
-        public JaTimeTagGeneratorConfig CreateDefaultConfig() =>
-            new()
-            {
-                Checkん = true,
-                CheckLineEndKeyUp = true,
-                CheckWhiteSpace = true,
-                CheckWhiteSpaceKeyUp = true,
-            };
+            CheckWhiteSpaceKeyUp.Default = true;
+            CheckWhiteSpaceKeyUp.SetDefault();
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Ja
 {
-    public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig<JaTimeTagGeneratorConfig>
+    public class JaTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig
     {
         /// <summary>
         /// Add the <see cref="TimeTag"/> if spacing is next of the alphabet.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 {
     public abstract class TimeTagGenerator<TConfig> : LyricPropertyGenerator<TimeTag[], TConfig>
-        where TConfig : TimeTagGeneratorConfig, IHasConfig, new()
+        where TConfig : TimeTagGeneratorConfig, new()
     {
         protected TimeTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 
             if (string.IsNullOrWhiteSpace(text))
             {
-                if (Config.CheckBlankLine)
+                if (Config.CheckBlankLine.Value)
                     timeTags.Add(new TimeTag(new TextIndex(0)));
 
                 return timeTags.ToArray();
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
             // create tag at start of lyric
             timeTags.Add(new TimeTag(new TextIndex(0)));
 
-            if (Config.CheckLineEndKeyUp)
+            if (Config.CheckLineEndKeyUp.Value)
                 timeTags.Add(new TimeTag(new TextIndex(text.Length - 1, TextIndex.IndexState.End)));
 
             TimeTagLogic(item, timeTags);

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGenerator.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 {
     public abstract class TimeTagGenerator<TConfig> : LyricPropertyGenerator<TimeTag[], TConfig>
-        where TConfig : TimeTagGeneratorConfig, IHasConfig<TConfig>, new()
+        where TConfig : TimeTagGeneratorConfig, IHasConfig, new()
     {
         protected TimeTagGenerator(TConfig config)
             : base(config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 {
-    public abstract class TimeTagGeneratorConfig : IHasConfig
+    public abstract class TimeTagGeneratorConfig : GeneratorConfig
     {
         /// <summary>
         /// Will create a <see cref="TimeTag"/> at the first of the lyric if only contains spacing in the <see cref="Lyric"/>.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
@@ -1,31 +1,44 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 {
     public abstract class TimeTagGeneratorConfig : GeneratorConfig
     {
+        protected const string CATEGORY_CHECK_CHARACTER = "Character checking";
+        protected const string CATEGORY_CHECK_LINE_END = "Line end checking";
+        protected const string CATEGORY_CHECK_WHITE_SPACE = "White space checking";
+
         /// <summary>
         /// Will create a <see cref="TimeTag"/> at the first of the lyric if only contains spacing in the <see cref="Lyric"/>.
         /// </summary>
-        public bool CheckBlankLine { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_CHARACTER)]
+        [ConfigSource("Check blank line", "Check blank line or not.")]
+        public Bindable<bool> CheckBlankLine { get; } = new BindableBool();
 
         /// <summary>
         /// Add end <see cref="TimeTag"/> at the end of the <see cref="Lyric"/>.
         /// </summary>
-        public bool CheckLineEndKeyUp { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_LINE_END)]
+        [ConfigSource("Use key-up time tag in line end", "Use key-up time tag in line end")]
+        public Bindable<bool> CheckLineEndKeyUp { get; } = new BindableBool();
 
         /// <summary>
         /// Will add the <see cref="TimeTag"/> if meet the spacing.
         /// </summary>
-        public bool CheckWhiteSpace { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_WHITE_SPACE)]
+        [ConfigSource( "Check white space", "Check white space")]
+        public Bindable<bool> CheckWhiteSpace { get; } = new BindableBool();
 
         /// <summary>
         /// Add the end <see cref="TimeTag"/> instead.
         /// This feature will work only if enable the <see cref="CheckWhiteSpace"/>.
         /// </summary>
-        public bool CheckWhiteSpaceKeyUp { get; set; }
+        [ConfigCategory(CATEGORY_CHECK_WHITE_SPACE)]
+        [ConfigSource("Use key-up", "Use key-up")]
+        public Bindable<bool> CheckWhiteSpaceKeyUp { get; } = new BindableBool();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/TimeTagGeneratorConfig.cs
@@ -5,7 +5,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags
 {
-    public abstract class TimeTagGeneratorConfig
+    public abstract class TimeTagGeneratorConfig : IHasConfig
     {
         /// <summary>
         /// Will create a <see cref="TimeTag"/> at the first of the lyric if only contains spacing in the <see cref="Lyric"/>.

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Zh
 {
-    public class ZhTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig
+    public class ZhTimeTagGeneratorConfig : TimeTagGeneratorConfig
     {
         public ZhTimeTagGeneratorConfig CreateDefaultConfig() => new();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
@@ -5,6 +5,5 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Zh
 {
     public class ZhTimeTagGeneratorConfig : TimeTagGeneratorConfig
     {
-        public ZhTimeTagGeneratorConfig CreateDefaultConfig() => new();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorConfig.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.TimeTags.Zh
 {
-    public class ZhTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig<ZhTimeTagGeneratorConfig>
+    public class ZhTimeTagGeneratorConfig : TimeTagGeneratorConfig, IHasConfig
     {
         public ZhTimeTagGeneratorConfig CreateDefaultConfig() => new();
     }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyDetector.cs
@@ -6,7 +6,7 @@ using osu.Framework.Localisation;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 public abstract class PropertyDetector<TItem, TProperty, TConfig> : PropertyDetector<TItem, TProperty>
-    where TConfig : IHasConfig<TConfig>, new()
+    where TConfig : IHasConfig, new()
 {
     protected readonly TConfig Config;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyDetector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyDetector.cs
@@ -6,7 +6,7 @@ using osu.Framework.Localisation;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 public abstract class PropertyDetector<TItem, TProperty, TConfig> : PropertyDetector<TItem, TProperty>
-    where TConfig : IHasConfig, new()
+    where TConfig : GeneratorConfig, new()
 {
     protected readonly TConfig Config;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyGenerator.cs
@@ -6,7 +6,7 @@ using osu.Framework.Localisation;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 public abstract class PropertyGenerator<TItem, TProperty, TConfig> : PropertyGenerator<TItem, TProperty>
-    where TConfig : IHasConfig<TConfig>, new()
+    where TConfig : IHasConfig, new()
 {
     protected readonly TConfig Config;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/PropertyGenerator.cs
@@ -6,7 +6,7 @@ using osu.Framework.Localisation;
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 public abstract class PropertyGenerator<TItem, TProperty, TConfig> : PropertyGenerator<TItem, TProperty>
-    where TConfig : IHasConfig, new()
+    where TConfig : GeneratorConfig, new()
 {
     protected readonly TConfig Config;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigPopover.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator
 {
-    public abstract partial class GeneratorConfigPopover<TConfig> : OsuPopover where TConfig : IHasConfig<TConfig>, new()
+    public abstract partial class GeneratorConfigPopover<TConfig> : OsuPopover where TConfig : IHasConfig, new()
     {
         private readonly Bindable<TConfig> bindableConfig = new();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigPopover.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Karaoke.Edit.Generator;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator
 {
-    public abstract partial class GeneratorConfigPopover<TConfig> : OsuPopover where TConfig : IHasConfig, new()
+    public abstract partial class GeneratorConfigPopover<TConfig> : OsuPopover where TConfig : GeneratorConfig, new()
     {
         private readonly Bindable<TConfig> bindableConfig = new();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
@@ -17,7 +17,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator
 {
-    public abstract partial class GeneratorConfigSection<TConfig> : GeneratorConfigSection where TConfig : IHasConfig<TConfig>, new()
+    public abstract partial class GeneratorConfigSection<TConfig> : GeneratorConfigSection where TConfig : IHasConfig, new()
     {
         private readonly TConfig defaultConfig;
         private readonly Bindable<TConfig> current;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator
         protected GeneratorConfigSection(Bindable<TConfig> current)
         {
             this.current = current;
-            defaultConfig = new TConfig().CreateDefaultConfig();
+            defaultConfig = new TConfig();
         }
 
         protected void RegisterConfig<TValue>(Bindable<TValue> bindable, string propertyName)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Configs/Generator/GeneratorConfigSection.cs
@@ -17,7 +17,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Configs.Generator
 {
-    public abstract partial class GeneratorConfigSection<TConfig> : GeneratorConfigSection where TConfig : IHasConfig, new()
+    public abstract partial class GeneratorConfigSection<TConfig> : GeneratorConfigSection where TConfig : GeneratorConfig, new()
     {
         private readonly TConfig defaultConfig;
         private readonly Bindable<TConfig> current;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Settings/PageAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Settings/PageAutoGenerateSection.cs
@@ -87,7 +87,7 @@ public partial class PageAutoGenerateSection : AutoGenerateSection
             }
 
             private bool clearExistPagesAfterGenerated()
-                => generatorConfigManager.Get<PageGeneratorConfig>(KaraokeRulesetEditGeneratorSetting.BeatmapPageGeneratorConfig).ClearExistPages;
+                => generatorConfigManager.Get<PageGeneratorConfig>(KaraokeRulesetEditGeneratorSetting.BeatmapPageGeneratorConfig).ClearExistPages.Value;
         }
     }
 }


### PR DESCRIPTION
What's done in this PR:
- Remove the `CreateDefaultConfig()` method in the config interface because default value will be in the bindable property.
- Make the `IHasConfig` from interface into the base class.
- Use the bindable in the config class.
- Implement helper in the test case for able to clear all default value.

And for now, should still able to show the popover with config and able to edit the value.