### PR TITLE
Implement the extension for able to get all setting controls in the `GeneratorConfig`

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/GeneratorConfigExtensionTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/GeneratorConfigExtensionTest.cs
@@ -1,0 +1,73 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using J2N.Collections.Generic.Extensions;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Edit.Generator;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator;
+
+public class GeneratorConfigExtensionTest
+{
+    [Test]
+    public void TestGetOrderedConfigsSourceDictionary()
+    {
+        var config = new TestGeneratorConfig();
+        var defaultCategory = new ConfigCategoryAttribute("Category 0");
+        var result = config.GetOrderedConfigsSourceDictionary(defaultCategory);
+
+        Assert.AreEqual(result[defaultCategory].Length, 1);
+        Assert.AreEqual(result[new ConfigCategoryAttribute("Category 1")].Length, 2);
+    }
+
+    [Test]
+    public void TestGetOrderedConfigsSourceProperties()
+    {
+        var config = new TestGeneratorConfig();
+        var result = config.GetOrderedConfigsSourceProperties().ToArray();
+
+        checkSingleProperty(result[0], "Culture infos");
+        checkSingleProperty(result[1], "Boolean");
+        checkSingleProperty(result[2], "Double"); // todo: this shit should be the first one.
+
+        static void checkSingleProperty((ConfigSourceAttribute, ConfigCategoryAttribute?, PropertyInfo) property, string title) =>
+            Assert.AreEqual(property.Item1.Label.ToString(), title);
+    }
+
+    [Test]
+    public void TestGetConfigSourceProperties()
+    {
+        var config = new TestGeneratorConfig();
+        var result = config.GetConfigSourceProperties().ToArray();
+
+        checkSingleProperty(result[0], "Double", "Edit the double value");
+        checkSingleProperty(result[1], "Boolean", "Edit the boolean value", "Category 1");
+        checkSingleProperty(result[2], "Culture infos", "Edit the culture infos", "Category 1");
+
+        static void checkSingleProperty((ConfigSourceAttribute, ConfigCategoryAttribute?, PropertyInfo) property, string title, string description, string? category = null)
+        {
+            Assert.AreEqual(property.Item1.Label.ToString(), title);
+            Assert.AreEqual(property.Item1.Description.ToString(), description);
+            Assert.AreEqual(property.Item2?.Category.ToString(), category);
+        }
+    }
+
+    private class TestGeneratorConfig : GeneratorConfig
+    {
+        [ConfigSource("Double", "Edit the double value")]
+        public Bindable<double> Double { get; } = new BindableDouble();
+
+        [ConfigCategory("Category 1")]
+        [ConfigSource("Boolean", "Edit the boolean value", 1)]
+        public Bindable<bool> Boolean { get; } = new BindableBool();
+
+        [ConfigCategory("Category 1")]
+        [ConfigSource("Culture infos", "Edit the culture infos", 0)]
+        public Bindable<CultureInfo[]> CultureInfos { get; } = new(Array.Empty<CultureInfo>());
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
+++ b/osu.Game.Rulesets.Karaoke/Configuration/KaraokeRulesetEditGeneratorConfigManager.cs
@@ -41,9 +41,6 @@ namespace osu.Game.Rulesets.Karaoke.Configuration
             // Time tag generator
             SetDefault(KaraokeRulesetEditGeneratorSetting.JaTimeTagGeneratorConfig, CreateDefaultConfig<JaTimeTagGeneratorConfig>());
             SetDefault(KaraokeRulesetEditGeneratorSetting.ZhTimeTagGeneratorConfig, CreateDefaultConfig<ZhTimeTagGeneratorConfig>());
-
-            // Language detection
-            SetDefault(KaraokeRulesetEditGeneratorSetting.ReferenceLyricDetectorConfig, CreateDefaultConfig<ReferenceLyricDetectorConfig>());
         }
 
         protected static T CreateDefaultConfig<T>() where T : GeneratorConfig, new() => new();

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigCategoryAttribute.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/ConfigCategoryAttribute.cs
@@ -6,12 +6,31 @@ using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
 
-public class ConfigCategoryAttribute : Attribute
+public class ConfigCategoryAttribute : Attribute, IEquatable<ConfigCategoryAttribute>
 {
     public LocalisableString Category { get; }
 
     public ConfigCategoryAttribute(string category)
     {
         Category = category;
+    }
+
+    public bool Equals(ConfigCategoryAttribute? other)
+    {
+        return Category == other?.Category;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj switch
+        {
+            ConfigCategoryAttribute category => Equals(category),
+            _ => false
+        };
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(base.GetHashCode(), Category);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorConfigExtension.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/GeneratorConfigExtension.cs
@@ -1,0 +1,42 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.Generator;
+
+public static class GeneratorConfigExtension
+{
+    public static IDictionary<ConfigCategoryAttribute, (ConfigSourceAttribute, PropertyInfo)[]> GetOrderedConfigsSourceDictionary(this GeneratorConfig config, ConfigCategoryAttribute defaultCategory)
+    {
+        return GetOrderedConfigsSourceProperties(config)
+               .GroupBy(attr => attr.Item2)
+               .ToDictionary(
+                   group => group.Key ?? defaultCategory,
+                   group => group.Select(x => (x.Item1, x.Item3)).ToArray()
+               );
+    }
+
+    public static ICollection<(ConfigSourceAttribute, ConfigCategoryAttribute?, PropertyInfo)> GetOrderedConfigsSourceProperties(this GeneratorConfig config)
+        => GetConfigSourceProperties(config)
+           .OrderBy(attr => attr.Item1)
+           .ToArray();
+
+    public static IEnumerable<(ConfigSourceAttribute, ConfigCategoryAttribute?, PropertyInfo)> GetConfigSourceProperties(this GeneratorConfig config)
+    {
+        var type = config.GetType();
+
+        foreach (var property in type.GetProperties(BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance))
+        {
+            var configSourceAttribute = property.GetCustomAttribute<ConfigSourceAttribute>(true);
+            var configCategoryAttribute = property.GetCustomAttribute<ConfigCategoryAttribute>(true);
+
+            if (configSourceAttribute == null)
+                continue;
+
+            yield return (configSourceAttribute, configCategoryAttribute, property);
+        }
+    }
+}


### PR DESCRIPTION
Implementation of issue #1869

This extension can:
- Get all property with config source and category.
- Order the result.
- Combine them with dictionary, the key is category.