### PR TITLE
Prevent directly assign working property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -137,7 +137,7 @@ public class KaraokeLegacyBeatmapDecoderTest
     [TestCase(0.3, 1, null)] // start + duration should not exceed 1
     public void TestSliceNoteTime(double startPercentage, double durationPercentage, double[]? expected)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[1,start]:4000" }),
         };
@@ -145,7 +145,8 @@ public class KaraokeLegacyBeatmapDecoderTest
         // start time will be 1000, and duration will be 3000.
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0
         };
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
@@ -60,10 +60,13 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     [Test]
     public void TestLockToReferenceLyric()
     {
+        var referencedLyric = new Lyric { ID = 2 };
+
         PrepareHitObject(new Lyric
         {
             Text = "カラオケ",
-            ReferenceLyric = new Lyric(),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig(),
         });
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
@@ -14,6 +14,7 @@ public abstract partial class LyricPropertyChangeHandlerTest<TChangeHandler> : B
     {
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = config ?? new SyncLyricConfig()
         };

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
@@ -13,23 +13,23 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestUpdateReferenceLyric()
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(lyric, false);
+        PrepareHitObject(referencedLyric, false);
 
         PrepareHitObject(new Lyric
         {
             Text = "I need the reference lyric."
         });
 
-        TriggerHandlerChanged(c => c.UpdateReferenceLyric(lyric));
+        TriggerHandlerChanged(c => c.UpdateReferenceLyric(referencedLyric));
 
         AssertSelectedHitObject(h =>
         {
-            Assert.AreEqual(lyric, h.ReferenceLyric);
+            Assert.AreEqual(referencedLyric, h.ReferenceLyric);
             Assert.IsTrue(h.ReferenceLyricConfig is ReferenceLyricConfig);
         });
     }
@@ -37,7 +37,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestSwitchToReferenceLyricConfig()
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "Referenced lyric"
         };
@@ -45,14 +45,15 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
         PrepareHitObject(new Lyric
         {
             Text = "Lyric",
-            ReferenceLyric = lyric
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         });
 
         TriggerHandlerChanged(c => c.SwitchToReferenceLyricConfig());
 
         AssertSelectedHitObject(h =>
         {
-            Assert.AreEqual(lyric, h.ReferenceLyric);
+            Assert.AreEqual(referencedLyric, h.ReferenceLyric);
             Assert.IsTrue(h.ReferenceLyricConfig is ReferenceLyricConfig);
         });
     }
@@ -60,7 +61,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestSwitchToSyncLyricConfig()
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "Referenced lyric"
         };
@@ -68,14 +69,15 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
         PrepareHitObject(new Lyric
         {
             Text = "Lyric",
-            ReferenceLyric = lyric
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         });
 
         TriggerHandlerChanged(c => c.SwitchToSyncLyricConfig());
 
         AssertSelectedHitObject(h =>
         {
-            Assert.AreEqual(lyric, h.ReferenceLyric);
+            Assert.AreEqual(referencedLyric, h.ReferenceLyric);
             Assert.IsTrue(h.ReferenceLyricConfig is SyncLyricConfig);
         });
     }
@@ -83,7 +85,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestAdjustLyricConfig()
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "Referenced lyric"
         };
@@ -91,7 +93,8 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
         PrepareHitObject(new Lyric
         {
             Text = "Lyric",
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig(),
         });
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
@@ -14,10 +14,13 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
     [Test]
     public void TestSplit()
     {
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "カラオケ", 1000, 1000);
+
         PrepareHitObject(new Note
         {
             Text = "カラオケ",
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 1000, 1000)
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         });
 
         TriggerHandlerChanged(c => c.Split());
@@ -45,24 +48,26 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
     [Test]
     public void TestCombine()
     {
-        var lyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 1000, 1000);
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "カラオケ", 1000, 1000);
 
         // note that lyric and notes should in the selection.
-        PrepareHitObject(lyric);
+        PrepareHitObject(referencedLyric);
         PrepareHitObjects(new[]
         {
             new Note
             {
                 Text = "カラ",
                 RubyText = "から",
-                ReferenceLyric = lyric,
+                ReferenceLyricId = referencedLyric.ID,
+                ReferenceLyric = referencedLyric,
                 ReferenceTimeTagIndex = 0
             },
             new Note
             {
                 Text = "オケ",
                 RubyText = "おけ",
-                ReferenceLyric = lyric,
+                ReferenceLyricId = referencedLyric.ID,
+                ReferenceLyric = referencedLyric,
                 ReferenceTimeTagIndex = 0
             }
         });
@@ -85,23 +90,25 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
     [Test]
     public void TestClear()
     {
-        var lyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
 
         // note that lyric and notes should in the selection.
-        PrepareHitObject(lyric);
+        PrepareHitObject(referencedLyric);
         PrepareHitObjects(new[]
         {
             new Note
             {
                 Text = "カラ",
                 RubyText = "から",
-                ReferenceLyric = lyric,
+                ReferenceLyricId = referencedLyric.ID,
+                ReferenceLyric = referencedLyric,
             },
             new Note
             {
                 Text = "オケ",
                 RubyText = "おけ",
-                ReferenceLyric = lyric,
+                ReferenceLyricId = referencedLyric.ID,
+                ReferenceLyric = referencedLyric,
             }
         }, false);
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricReferenceLyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricReferenceLyricTest.cs
@@ -16,9 +16,10 @@ public class CheckLyricReferenceLyricTest : HitObjectCheckTest<Lyric, CheckLyric
     [Test]
     public void TestCheck()
     {
-        var referencedLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new ReferenceLyricConfig(),
         };
@@ -34,6 +35,7 @@ public class CheckLyricReferenceLyricTest : HitObjectCheckTest<Lyric, CheckLyric
             ReferenceLyricConfig = new ReferenceLyricConfig(),
         };
 
+        lyric.ReferenceLyricId = lyric.ID;
         lyric.ReferenceLyric = lyric;
 
         AssertNotOk<LyricIssue, IssueTemplateLyricSelfReference>(lyric);
@@ -42,9 +44,10 @@ public class CheckLyricReferenceLyricTest : HitObjectCheckTest<Lyric, CheckLyric
     [Test]
     public void TestCheckInvalidReferenceLyric()
     {
-        var referencedLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new ReferenceLyricConfig(),
         };
@@ -55,9 +58,10 @@ public class CheckLyricReferenceLyricTest : HitObjectCheckTest<Lyric, CheckLyric
     [Test]
     public void TestCheckNullReferenceLyricConfig()
     {
-        var referencedLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
         };
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteReferenceLyricTest.cs
@@ -21,18 +21,19 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     [TestCase(3, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
     public void TestCheck(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertOk(new HitObject[] { lyric, note });
+        AssertOk(new HitObject[] { referencedLyric, note });
     }
 
     [Test]
@@ -40,6 +41,7 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     {
         var note = new Note
         {
+            ReferenceLyricId = null,
             ReferenceLyric = null // reference should not be null.
         };
 
@@ -49,14 +51,15 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     [Test]
     public void TestCheckInvalidReferenceLyric()
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[3,end]:5000" })
         };
         var note = new Note
         {
-            ReferenceLyric = lyric, // reference lyric should be in the beatmap.
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric, // reference lyric should be in the beatmap.
             ReferenceTimeTagIndex = 0,
         };
 
@@ -70,36 +73,38 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     [TestCase(-2, new[] { "[0,start]:1000" })]
     public void TestCheckMissingReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex,
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteMissingReferenceTimeTag>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteMissingReferenceTimeTag>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase(-1, new[] { "[0,start]:1000", "[3,end]:5000" })]
     [TestCase(-1, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
     public void TestCheckMissingStartReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteMissingStartReferenceTimeTag>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteMissingStartReferenceTimeTag>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase(0, new[] { "[0,start]:", "[3,end]:5000" })]
@@ -107,36 +112,38 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     [TestCase(1, new[] { "[0,start]:1000", "[1,start]:", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
     public void TestCheckStartReferenceTimeTagMissingTime(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteStartReferenceTimeTagMissingTime>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteStartReferenceTimeTagMissingTime>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase(1, new[] { "[0,start]:1000", "[3,end]:5000" })]
     [TestCase(4, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
     public void TestCheckMissingEndReferenceTimeTag(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteMissingEndReferenceTimeTag>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteMissingEndReferenceTimeTag>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase(0, new[] { "[0,start]:1000", "[3,end]:" })]
@@ -144,17 +151,18 @@ public class CheckNoteReferenceLyricTest : HitObjectCheckTest<Note, CheckNoteRef
     [TestCase(2, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:", "[3,end]:5000" })]
     public void TestCheckEndReferenceTimeTagMissingTime(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteEndReferenceTimeTagMissingTime>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteEndReferenceTimeTagMissingTime>(new HitObject[] { referencedLyric, note });
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteTimeTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckNoteTimeTest.cs
@@ -17,18 +17,19 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
     [TestCase(3, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]
     public void TestCheck(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
-        AssertOk(new HitObject[] { lyric, note });
+        AssertOk(new HitObject[] { referencedLyric, note });
     }
 
     [Test]
@@ -37,6 +38,7 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
         var note = new Note
         {
             Text = "karaoke",
+            ReferenceLyricId = null,
             ReferenceLyric = null,
         };
 
@@ -48,19 +50,20 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
     [TestCase(2, new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:", "[3,end]:5000" })] // will missing end time-tag.
     public void TestCheckMissingStartOrEndTimeTag(int referenceTimeTagIndex, string[] timeTags)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(timeTags)
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = referenceTimeTagIndex
         };
 
         // should not have error because this check will be handled in other check.
-        AssertOk(new HitObject[] { lyric, note });
+        AssertOk(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase("[0,start]:2000", "[1,start]:1000")]
@@ -70,18 +73,19 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
     [TestCase("[1,start]:2000", "[0,start]:1000")] // should have error even if time-tag index is not sorted. we did not care about the time-tag index in here.
     public void TestCheckInvalidReferenceTimeTagTime(string startTimeTag, string endTimeTag)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { startTimeTag, endTimeTag })
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteInvalidReferenceTimeTagTime>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteInvalidReferenceTimeTagTime>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase("[0,start]:", "[1,start]:")]
@@ -91,18 +95,19 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
     [TestCase("[1,start]:", "[0,start]:")] // should have error even if time-tag index is not sorted. we did not care about the time-tag index in here.
     public void TestCheckDurationTooShort(string startTimeTag, string endTimeTag)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { $"{startTimeTag}0", $"{endTimeTag}{MIN_DURATION - 1}" })
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteDurationTooShort>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteDurationTooShort>(new HitObject[] { referencedLyric, note });
     }
 
     [TestCase("[0,start]:", "[1,start]:")]
@@ -112,17 +117,18 @@ public class CheckNoteTimeTest : HitObjectCheckTest<Note, CheckNoteTime>
     [TestCase("[1,start]:", "[0,start]:")] // should have error even if time-tag index is not sorted. we did not care about the time-tag index in here.
     public void TestCheckDurationTooLong(string startTimeTag, string endTimeTag)
     {
-        var lyric = new Lyric
+        var referencedLyric = new Lyric
         {
             Text = "カラオケ",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { $"{startTimeTag}0", $"{endTimeTag}{MAX_DURATION + 1}" })
         };
         var note = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0
         };
 
-        AssertNotOk<NoteIssue, IssueTemplateNoteDurationTooLong>(new HitObject[] { lyric, note });
+        AssertNotOk<NoteIssue, IssueTemplateNoteDurationTooLong>(new HitObject[] { referencedLyric, note });
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Utils/HitObjectWritableUtilsTest.cs
@@ -137,9 +137,11 @@ public class HitObjectWritableUtilsTest
         test(new Note());
 
         // test with reference lyric.
+        var referencedLyric = new Lyric { ID = 2 };
         test(new Note
         {
-            ReferenceLyric = new Lyric(),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
         });
 
         static void test(Note note)

--- a/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseNoteHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Helper/TestCaseNoteHelper.cs
@@ -9,10 +9,11 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 public static class TestCaseNoteHelper
 {
-    public static Lyric CreateLyricForNote(string text, double startTime, double duration)
+    public static Lyric CreateLyricForNote(int id, string text, double startTime, double duration)
     {
         return new Lyric
         {
+            ID = id,
             Text = text,
             TimeTags = new List<TimeTag>
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
@@ -57,9 +57,11 @@ public class LyricConverterTest : BaseSingleConverterTest<LyricConverter>
     [Test]
     public void TestLyricConverterWithSyncConfig()
     {
+        var referencedLyric = new Lyric { ID = 0 };
         var lyric = new Lyric
         {
-            ReferenceLyric = new Lyric(),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig()
         };
 
@@ -72,9 +74,11 @@ public class LyricConverterTest : BaseSingleConverterTest<LyricConverter>
     [Test]
     public void TestLyricConverterWithReferenceConfig()
     {
+        var referencedLyric = new Lyric { ID = 0 };
         var lyric = new Lyric
         {
-            ReferenceLyric = new Lyric(),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new ReferenceLyricConfig()
         };
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
@@ -19,7 +19,7 @@ public class LyricTest
     [TestCase]
     public void TestClone()
     {
-        var referencedLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
 
         var lyric = new Lyric
         {
@@ -38,6 +38,7 @@ public class LyricTest
             Language = new CultureInfo("ja-JP"),
             Order = 1,
             Lock = LockState.None,
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new ReferenceLyricConfig
             {
@@ -106,6 +107,7 @@ public class LyricTest
     {
         var referencedLyric = new Lyric
         {
+            ID = 2,
             Text = "karaoke",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1100" }),
             RubyTags = TestCaseTagHelper.ParseRubyTags(new[] { "[0,1]:か" }),
@@ -120,6 +122,7 @@ public class LyricTest
 
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig(),
         };
@@ -136,10 +139,11 @@ public class LyricTest
     [Test]
     public void TestReferenceLyricPropertyChanged()
     {
-        var referencedLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
 
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig(),
         };
@@ -175,6 +179,7 @@ public class LyricTest
 
         var referencedLyric = new Lyric
         {
+            ID = 2,
             Text = "karaoke",
             TimeTags = new[] { timeTag },
             RubyTags = new[] { rubyTag },
@@ -189,6 +194,7 @@ public class LyricTest
 
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = new SyncLyricConfig(),
         };
@@ -232,6 +238,7 @@ public class LyricTest
 
         var referencedLyric = new Lyric
         {
+            ID = 2,
             Text = "karaoke",
             TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1100" }),
             RubyTags = TestCaseTagHelper.ParseRubyTags(new[] { "[0,1]:か" }),
@@ -246,6 +253,7 @@ public class LyricTest
 
         var lyric = new Lyric
         {
+            ReferenceLyricId = referencedLyric.ID,
             ReferenceLyric = referencedLyric,
             ReferenceLyricConfig = config
         };
@@ -263,49 +271,6 @@ public class LyricTest
         Assert.AreEqual(referencedLyric.Singers, lyric.Singers);
     }
 
-    [Test]
-    public void TestReferenceLyricAffectedByReferenceLyricId()
-    {
-        var lyric = new Lyric
-        {
-            ReferenceLyric = new Lyric
-            {
-                ID = 2,
-            },
-        };
-        Assert.AreEqual(lyric.ReferenceLyric.ID, lyric.ReferenceLyricId);
-
-        // Should not affect the reference lyric if reference lyric id is the same.
-        lyric.ReferenceLyricId = 2;
-        Assert.AreEqual(lyric.ReferenceLyric.ID, lyric.ReferenceLyricId);
-
-        // Should clear the reference lyric if id changed.
-        lyric.ReferenceLyricId = 3;
-        Assert.IsNull(lyric.ReferenceLyric);
-    }
-
-    [Test]
-    public void TestReferenceLyricIdAffectedByReferenceLyric()
-    {
-        var lyric = new Lyric
-        {
-            ReferenceLyric = new Lyric
-            {
-                ID = 2,
-            },
-            ReferenceLyricId = 2,
-        };
-        Assert.AreEqual(lyric.ReferenceLyric.ID, lyric.ReferenceLyricId);
-
-        // Should change the reference lyric id if reference lyric changed.
-        lyric.ReferenceLyric = new Lyric { ID = 3 };
-        Assert.AreEqual(lyric.ReferenceLyric.ID, lyric.ReferenceLyricId);
-
-        // Should clear the reference lyric id if remove the reference lyric.
-        lyric.ReferenceLyric = null;
-        Assert.IsNull(lyric.ReferenceLyricId);
-    }
-
     #endregion
 
     #region MyRegion
@@ -319,7 +284,9 @@ public class LyricTest
         lyric.Lock = LockState.Partial;
         Assert.AreEqual(1, lyric.LyricPropertyWritableVersion.Value);
 
-        lyric.ReferenceLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
+        lyric.ReferenceLyricId = referencedLyric.ID;
+        lyric.ReferenceLyric = referencedLyric;
         Assert.AreEqual(2, lyric.LyricPropertyWritableVersion.Value);
 
         lyric.ReferenceLyricConfig = new SyncLyricConfig();

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/NoteTest.cs
@@ -13,6 +13,7 @@ public class NoteTest
     [TestCase]
     public void TestClone()
     {
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "ノート", 1000, 1000);
         var note = new Note
         {
             Text = "ノート",
@@ -20,7 +21,8 @@ public class NoteTest
             Display = true,
             StartTimeOffset = 100,
             EndTimeOffset = -100,
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("ノート", 1000, 1000),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0,
         };
 
@@ -71,15 +73,16 @@ public class NoteTest
         const double first_time_tag_time = 1000;
         const double second_time_tag_time = 3000;
         const double duration = second_time_tag_time - first_time_tag_time;
-        var lyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", first_time_tag_time, duration);
-        note.ReferenceLyric = lyric;
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "Lyric", first_time_tag_time, duration);
+        note.ReferenceLyricId = referencedLyric.ID;
+        note.ReferenceLyric = referencedLyric;
 
         // Should have calculated time.
         Assert.AreEqual(first_time_tag_time, note.StartTime);
         Assert.AreEqual(duration, note.Duration);
 
         const double time_tag_offset_time = 500;
-        lyric.TimeTags.ForEach(x => x.Time += time_tag_offset_time);
+        referencedLyric.TimeTags.ForEach(x => x.Time += time_tag_offset_time);
 
         // Should change the time if time-tag time has been changed.
         Assert.AreEqual(first_time_tag_time + time_tag_offset_time, note.StartTime);
@@ -113,53 +116,11 @@ public class NoteTest
         Assert.AreEqual(first_time_tag_time + time_tag_offset_time + note_start_offset_time, note.StartTime);
         Assert.AreEqual(0, note.Duration);
 
+        note.ReferenceLyricId = null;
         note.ReferenceLyric = null;
 
         // time will be zero if lyric has been removed.
         Assert.AreEqual(0, note.StartTime);
         Assert.AreEqual(0, note.Duration);
-    }
-
-    [Test]
-    public void TestReferenceLyricAffectedByReferenceLyricId()
-    {
-        var note = new Note
-        {
-            ReferenceLyric = new Lyric
-            {
-                ID = 2,
-            },
-        };
-        Assert.AreEqual(note.ReferenceLyric.ID, note.ReferenceLyricId);
-
-        // Should not affect the reference lyric if reference lyric id is the same.
-        note.ReferenceLyricId = 2;
-        Assert.AreEqual(note.ReferenceLyric.ID, note.ReferenceLyricId);
-
-        // Should clear the reference lyric if id changed.
-        note.ReferenceLyricId = 3;
-        Assert.IsNull(note.ReferenceLyric);
-    }
-
-    [Test]
-    public void TestReferenceLyricIdAffectedByReferenceLyric()
-    {
-        var note = new Note
-        {
-            ReferenceLyric = new Lyric
-            {
-                ID = 2,
-            },
-            ReferenceLyricId = 2,
-        };
-        Assert.AreEqual(note.ReferenceLyric.ID, note.ReferenceLyricId);
-
-        // Should change the reference lyric id if reference lyric changed.
-        note.ReferenceLyric = new Lyric { ID = 3 };
-        Assert.AreEqual(note.ReferenceLyric.ID, note.ReferenceLyricId);
-
-        // Should clear the reference lyric id if remove the reference lyric.
-        note.ReferenceLyric = null;
-        Assert.IsNull(note.ReferenceLyricId);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Replays/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Replays/TestSceneAutoGeneration.cs
@@ -21,13 +21,16 @@ public partial class TestSceneAutoGeneration : OsuTestScene
         // |  -  |
         // |     |
 
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "karaoke!", 1000, 50);
+
         var beatmap = new KaraokeBeatmap();
         beatmap.HitObjects.Add(new Note
         {
             Text = "karaoke!",
             Display = true,
             Tone = new Tone(0, true),
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 50)
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         });
 
         var generated = new KaraokeAutoGenerator(beatmap).Generate();
@@ -46,13 +49,16 @@ public partial class TestSceneAutoGeneration : OsuTestScene
         // | *** |
         // |     |
 
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "karaoke!", 1000, 1000);
+
         var beatmap = new KaraokeBeatmap();
         beatmap.HitObjects.Add(new Note
         {
             Text = "karaoke!",
             Display = true,
             Tone = new Tone(0, true),
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 1000)
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         });
 
         var generated = new KaraokeAutoGenerator(beatmap).Generate();
@@ -71,20 +77,25 @@ public partial class TestSceneAutoGeneration : OsuTestScene
         // |    - |
         // | -    |
 
+        var firstReferencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "karaoke!", 1000, 50);
+        var secondReferencedLyric = TestCaseNoteHelper.CreateLyricForNote(3, "karaoke!", 1050, 50);
+
         var beatmap = new KaraokeBeatmap();
         beatmap.HitObjects.Add(new Note
         {
             Text = "kara",
             Display = true,
             Tone = new Tone(0, true),
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1000, 50)
+            ReferenceLyricId = firstReferencedLyric.ID,
+            ReferenceLyric = firstReferencedLyric
         });
         beatmap.HitObjects.Add(new Note
         {
             Text = "oke!",
             Display = true,
             Tone = new Tone(1, true),
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("karaoke!", 1050, 50)
+            ReferenceLyricId = secondReferencedLyric.ID,
+            ReferenceLyric = secondReferencedLyric
         });
 
         var generated = new KaraokeAutoGenerator(beatmap).Generate();

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeBeatmapSkinDecodingTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeBeatmapSkinDecodingTest.cs
@@ -18,15 +18,16 @@ public class KaraokeBeatmapSkinDecodingTest
         var storage = TestResources.CreateSkinStorageResourceProvider();
         var skin = new KaraokeBeatmapSkin(new SkinInfo { Name = "special-skin" }, storage);
 
-        var testingLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
         var testingNote = new Note
         {
-            ReferenceLyric = testingLyric
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         };
 
         // try to get default value from the skin.
-        var defaultLyricFontInfo = skin.GetConfig<Lyric, LyricFontInfo>(testingLyric)!.Value;
-        var defaultLyricStyle = skin.GetConfig<Lyric, LyricStyle>(testingLyric)!.Value;
+        var defaultLyricFontInfo = skin.GetConfig<Lyric, LyricFontInfo>(referencedLyric)!.Value;
+        var defaultLyricStyle = skin.GetConfig<Lyric, LyricStyle>(referencedLyric)!.Value;
         var defaultNoteStyle = skin.GetConfig<Note, NoteStyle>(testingNote)!.Value;
 
         // should be able to get the default value.

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeSkinDecodingTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/KaraokeSkinDecodingTest.cs
@@ -18,15 +18,16 @@ public class KaraokeSkinDecodingTest
         var storage = TestResources.CreateSkinStorageResourceProvider();
         var skin = new KaraokeSkin(new SkinInfo { Name = "special-skin" }, storage);
 
-        var testingLyric = new Lyric();
+        var referencedLyric = new Lyric { ID = 2 };
         var testingNote = new Note
         {
-            ReferenceLyric = testingLyric
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric
         };
 
         // try to get default value from the skin.
-        var defaultLyricFontInfo = skin.GetConfig<Lyric, LyricFontInfo>(testingLyric)!.Value;
-        var defaultLyricStyle = skin.GetConfig<Lyric, LyricStyle>(testingLyric)!.Value;
+        var defaultLyricFontInfo = skin.GetConfig<Lyric, LyricFontInfo>(referencedLyric)!.Value;
+        var defaultLyricStyle = skin.GetConfig<Lyric, LyricStyle>(referencedLyric)!.Value;
         var defaultNoteStyle = skin.GetConfig<Note, NoteStyle>(testingNote)!.Value;
 
         // should be able to get the default value.

--- a/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Skinning/TestSceneNote.cs
@@ -28,10 +28,12 @@ public partial class TestSceneNote : KaraokeHitObjectTestScene
 
     protected override DrawableHitObject CreateHitObject()
     {
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "カラオケ", 100, 800);
         var note = new Note
         {
             Text = "カラオケ",
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("カラオケ", 100, 800),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
         };
         note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneNotePlayfield.cs
@@ -111,12 +111,14 @@ public partial class TestSceneNotePlayfield : OsuTestScene
     {
         notePlayfields.ForEach(x =>
         {
+            var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "Here", Time.Current + increaseTime, duration);
             var note = new Note
             {
                 Text = "Here",
                 Display = true,
                 Tone = new Tone { Scale = tone },
-                ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("Here", Time.Current + increaseTime, duration),
+                ReferenceLyricId = referencedLyric.ID,
+                ReferenceLyric = referencedLyric,
                 ReferenceTimeTagIndex = 0
             };
             note.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
@@ -21,9 +21,11 @@ public class NotesUtilsTest
     [TestCase(new double[] { 1000, 5000 }, 1, null, null)]
     public void TestSplitNoteTime(double[] time, double percentage, double[]? firstTime, double[]? secondTime)
     {
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "Lyric", time[0], time[1]);
         var note = new Note
         {
-            ReferenceLyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", time[0], time[1]),
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
         };
 
         if (firstTime != null && secondTime != null)
@@ -47,15 +49,16 @@ public class NotesUtilsTest
     {
         const double percentage = 0.3;
 
-        var lyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", 1000, 2000);
-        lyric.Singers = new[] { 0 };
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "Lyric", 1000, 2000);
+        referencedLyric.Singers = new[] { 0 };
 
         var note = new Note
         {
             Text = "ka",
             Display = false,
             Tone = new Tone(-1, true),
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             ReferenceTimeTagIndex = 0
         };
 
@@ -88,11 +91,12 @@ public class NotesUtilsTest
     [TestCase(new double[] { 1000, 0 }, new double[] { 1000, 0 }, new double[] { 1000, 0 })] // it's ok to combine if duration is 0.
     public void TestCombineNoteTime(double[] firstOffset, double[] secondOffset, double[] expectedOffset)
     {
-        var lyric = TestCaseNoteHelper.CreateLyricForNote("Lyric", 1000, 5000);
+        var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "Lyric", 1000, 5000);
 
         var firstNote = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             StartTimeOffset = firstOffset[0],
             EndTimeOffset = firstOffset[1],
             ReferenceTimeTagIndex = 0,
@@ -100,7 +104,8 @@ public class NotesUtilsTest
 
         var secondNote = new Note
         {
-            ReferenceLyric = lyric,
+            ReferenceLyricId = referencedLyric.ID,
+            ReferenceLyric = referencedLyric,
             StartTimeOffset = secondOffset[0],
             EndTimeOffset = secondOffset[1],
             ReferenceTimeTagIndex = 0,

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandler.cs
@@ -137,10 +137,13 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                     var referenceLyricDetector = createLyricDetector<Lyric>();
                     PerformOnSelection(lyric =>
                     {
-                        var detectedLanguage = referenceLyricDetector.Detect(lyric);
-                        lyric.ReferenceLyric = detectedLanguage;
+                        var referencedLyric = referenceLyricDetector.Detect(lyric);
+                        lyric.ReferenceLyricId = referencedLyric.ID;
 
-                        if (lyric.ReferenceLyric != null && lyric.ReferenceLyricConfig is not SyncLyricConfig)
+                        // technically this property should be assigned by beatmap processor, but should be OK to assign here for testing purpose.
+                        lyric.ReferenceLyric = referencedLyric;
+
+                        if (lyric.ReferenceLyricId != null && lyric.ReferenceLyricConfig is not SyncLyricConfig)
                             lyric.ReferenceLyricConfig = new SyncLyricConfig();
                     });
                     break;

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
@@ -24,9 +24,12 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                 if (referenceLyric?.ReferenceLyric != null)
                     throw new InvalidOperationException($"{nameof(referenceLyric)} should not contains another reference lyric.");
 
+                lyric.ReferenceLyricId = referenceLyric?.ID;
+
+                // technically this property should be assigned by beatmap processor, but should be OK to assign here for testing purpose.
                 lyric.ReferenceLyric = referenceLyric;
 
-                if (lyric.ReferenceLyric == null)
+                if (lyric.ReferenceLyricId == null)
                 {
                     lyric.ReferenceLyricConfig = null;
                 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Notes/NoteGenerator.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Notes
                     {
                         Text = text,
                         RubyText = ruby,
+                        ReferenceLyricId = item.ID,
+                        // technically this property should be assigned by beatmap processor, but should be OK to assign here for testing purpose.
                         ReferenceLyric = item,
                         ReferenceTimeTagIndex = timeTagIndex
                     });

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -183,7 +183,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
                     return;
 
                 // should trying to reload the reference lyric.
-                ReferenceLyric = null;
                 Validator.Invalidate(LyricInvalidation.ReferenceLyric);
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Objects;
 
@@ -77,7 +78,7 @@ public partial class Lyric
 
             if (value?.ID != ReferenceLyricId)
             {
-                ReferenceLyricId = value?.ID;
+                throw new InvalidWorkingPropertyAssignException();
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -111,7 +111,6 @@ namespace osu.Game.Rulesets.Karaoke.Objects
                     return;
 
                 // should trying to reload the reference lyric.
-                ReferenceLyric = null;
                 Validator.Invalidate(NoteInvalidation.ReferenceLyric);
             }
         }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Objects;
 
@@ -80,7 +81,7 @@ public partial class Note
 
             if (value?.ID != ReferenceLyricId)
             {
-                ReferenceLyricId = value?.ID;
+                throw new InvalidWorkingPropertyAssignException();
             }
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/InvalidWorkingPropertyAssignException.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/InvalidWorkingPropertyAssignException.cs
@@ -1,0 +1,10 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
+
+public class InvalidWorkingPropertyAssignException : Exception
+{
+}


### PR DESCRIPTION
Preparation of issue #1885.
This PR is trying to prevent assign the working property(e.g. reference lyric) that is not matched to the data field(e.d. reference lyric id).
Should avoid such things.
The working property can be not synced(or called invalid), but cannot have not matched value.

Technically, all working property should be assigned by the `KaraokeBeatmapProcessor`.
So such things will not happened.
But it will be happened if testing the lyric with working property.

If want to test with `ReferenceLyric` property in the `Note` or `Lyric`. MUST assign the same referenced lyric if first.

e.g.:
```csharp
var referencedLyric = new Lyric { ID = 2 };

PrepareHitObject(new Lyric
{
    Text = "カラオケ",

    // must assign the id first.
    ReferenceLyricId = referencedLyric.ID,

    // will throw exception here if not assign the reference lyric id first.
    ReferenceLyric = referencedLyric,
    ReferenceLyricConfig = new SyncLyricConfig(),
});
```