### PR TITLE
Implement generic interface to invalidate the property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
@@ -2,37 +2,26 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Objects.Workings;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
 public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag>
     where TFlag : struct, Enum
-    where THitObject : KaraokeHitObject, new()
+    where THitObject : KaraokeHitObject, IHasWorkingProperty<TFlag>, new()
 {
-    protected abstract HitObjectWorkingPropertyValidator<THitObject, TFlag> GetValidatorFromHitObject(THitObject hitObject);
-
     [Test]
     public void RunAllInvalidateTest([Values] TFlag flag)
     {
         // run this test case just make sure that all working property are checked.
-        var validator = GetValidatorFromHitObject(new THitObject());
-        Assert.DoesNotThrow(() => validator.Invalidate(flag));
-    }
-
-    [Test]
-    public void RunAllValidateTest([Values] TFlag flag)
-    {
-        // run this test case just make sure that all working property are checked.
-        var validator = GetValidatorFromHitObject(new THitObject());
-        Assert.DoesNotThrow(() => validator.Validate(flag));
+        Assert.DoesNotThrow(() => new THitObject().InvalidateWorkingProperty(flag));
     }
 
     protected void AssetIsValid(THitObject hitObject, TFlag flag, bool isValid)
     {
-        var validator = GetValidatorFromHitObject(hitObject);
-        Assert.AreEqual(isValid, validator.IsValid(flag));
+        Assert.AreEqual(isValid, !hitObject.GetAllInvalidWorkingProperties().Contains(flag));
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
 public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty>
 {
-    protected override HitObjectWorkingPropertyValidator<Lyric, LyricWorkingProperty> GetValidatorFromHitObject(Lyric hitObject)
-        => hitObject.WorkingPropertyValidator;
-
     [Test]
     public void TestPage()
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
 public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Note, NoteWorkingProperty>
 {
-    protected override HitObjectWorkingPropertyValidator<Note, NoteWorkingProperty> GetValidatorFromHitObject(Note hitObject)
-        => hitObject.WorkingPropertyValidator;
-
     [Test]
     public void TestPage()
     {

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                 switch (hitObject)
                 {
                     case Lyric lyric:
-                        foreach (var flag in lyric.WorkingPropertyValidator.GetAllInvalidFlags())
+                        foreach (var flag in lyric.GetAllInvalidWorkingProperties())
                         {
                             applyInvalidProperty(lyric, flag);
                         }
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                         break;
 
                     case Note note:
-                        foreach (var flag in note.WorkingPropertyValidator.GetAllInvalidFlags())
+                        foreach (var flag in note.GetAllInvalidWorkingProperties())
                         {
                             applyInvalidProperty(note, flag);
                         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 
@@ -82,6 +83,16 @@ public partial class BeatmapPropertyChangeHandler : Component
         finally
         {
             changingCache.Validate();
+        }
+    }
+
+    // todo: before having better solution to handle the undo/redo with better performance, we should use this to method to force invalidate all hit-object's working property.
+    protected void InvalidateAllHitObjectWorkingProperty<TWorkingProperty>(TWorkingProperty property)
+        where TWorkingProperty : struct, Enum
+    {
+        foreach (var hitObject in KaraokeBeatmap.HitObjects.OfType<IHasWorkingProperty<TWorkingProperty>>())
+        {
+            hitObject.InvalidateWorkingProperty(property);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandler.cs
@@ -10,7 +10,6 @@ using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Beatmaps.Pages;
-using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
@@ -113,25 +112,8 @@ public partial class BeatmapPagesChangeHandler : BeatmapPropertyChangeHandler, I
         {
             action(beatmap.PageInfo);
 
-            // todo: need to consider the undo/redo cases.
-            markWorkingPropertyAsInvalid();
+            InvalidateAllHitObjectWorkingProperty(LyricWorkingProperty.Page);
+            InvalidateAllHitObjectWorkingProperty(NoteWorkingProperty.Page);
         });
-    }
-
-    private void markWorkingPropertyAsInvalid()
-    {
-        foreach (var hitObject in KaraokeBeatmap.HitObjects)
-        {
-            switch (hitObject)
-            {
-                case Lyric lyric:
-                    lyric.WorkingPropertyValidator.Invalidate(LyricWorkingProperty.Page);
-                    break;
-
-                case Note note:
-                    note.WorkingPropertyValidator.Invalidate(NoteWorkingProperty.Page);
-                    break;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             set
             {
                 referenceLyricId = value;
-                WorkingPropertyValidator.Invalidate(LyricWorkingProperty.ReferenceLyric);
+                InvalidateWorkingProperty(LyricWorkingProperty.ReferenceLyric);
             }
         }
 
@@ -207,9 +207,10 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public Lyric()
         {
+            workingPropertyValidator = new LyricWorkingPropertyValidator(this);
+
             initInternalBindingEvent();
             initReferenceLyricEvent();
-            initWorkingPropertyValidator();
         }
 
         public override Judgement CreateJudgement() => new KaraokeLyricJudgement();

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Objects;
@@ -12,15 +13,19 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Lyric
+public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>
 {
-    private void initWorkingPropertyValidator()
-    {
-        WorkingPropertyValidator = new LyricWorkingPropertyValidator(this);
-    }
-
     [JsonIgnore]
-    public LyricWorkingPropertyValidator WorkingPropertyValidator { get; private set; } = null!;
+    private readonly LyricWorkingPropertyValidator workingPropertyValidator;
+
+    public bool InvalidateWorkingProperty(LyricWorkingProperty workingProperty)
+        => workingPropertyValidator.Invalidate(workingProperty);
+
+    private bool validateWorkingProperty(LyricWorkingProperty workingProperty)
+        => workingPropertyValidator.Validate(workingProperty);
+
+    public LyricWorkingProperty[] GetAllInvalidWorkingProperties()
+        => workingPropertyValidator.GetAllInvalidFlags();
 
     [JsonIgnore]
     public double LyricStartTime { get; private set; }
@@ -66,7 +71,7 @@ public partial class Lyric
         set
         {
             PageIndexBindable.Value = value;
-            WorkingPropertyValidator.Validate(LyricWorkingProperty.Page);
+            validateWorkingProperty(LyricWorkingProperty.Page);
         }
     }
 
@@ -84,7 +89,7 @@ public partial class Lyric
         set
         {
             ReferenceLyricBindable.Value = value;
-            WorkingPropertyValidator.Validate(LyricWorkingProperty.ReferenceLyric);
+            validateWorkingProperty(LyricWorkingProperty.ReferenceLyric);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects
             set
             {
                 referenceLyricId = value;
-                WorkingPropertyValidator.Invalidate(NoteWorkingProperty.ReferenceLyric);
+                InvalidateWorkingProperty(NoteWorkingProperty.ReferenceLyric);
             }
         }
 
@@ -122,9 +122,10 @@ namespace osu.Game.Rulesets.Karaoke.Objects
 
         public Note()
         {
+            workingPropertyValidator = new NoteWorkingPropertyValidator(this);
+
             initInternalBindingEvent();
             initReferenceLyricEvent();
-            initWorkingPropertyValidator();
         }
 
         public override Judgement CreateJudgement() => new KaraokeNoteJudgement();

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Objects;
@@ -14,15 +15,19 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Note
+public partial class Note : IHasWorkingProperty<NoteWorkingProperty>
 {
-    private void initWorkingPropertyValidator()
-    {
-        WorkingPropertyValidator = new NoteWorkingPropertyValidator(this);
-    }
-
     [JsonIgnore]
-    public NoteWorkingPropertyValidator WorkingPropertyValidator { get; private set; } = null!;
+    private readonly NoteWorkingPropertyValidator workingPropertyValidator;
+
+    public bool InvalidateWorkingProperty(NoteWorkingProperty workingProperty)
+        => workingPropertyValidator.Invalidate(workingProperty);
+
+    private bool validateWorkingProperty(NoteWorkingProperty workingProperty)
+        => workingPropertyValidator.Validate(workingProperty);
+
+    public NoteWorkingProperty[] GetAllInvalidWorkingProperties()
+        => workingPropertyValidator.GetAllInvalidFlags();
 
     [JsonIgnore]
     public readonly Bindable<int?> PageIndexBindable = new();
@@ -37,7 +42,7 @@ public partial class Note
         set
         {
             PageIndexBindable.Value = value;
-            WorkingPropertyValidator.Validate(NoteWorkingProperty.Page);
+            validateWorkingProperty(NoteWorkingProperty.Page);
         }
     }
 
@@ -87,7 +92,7 @@ public partial class Note
         set
         {
             ReferenceLyricBindable.Value = value;
-            WorkingPropertyValidator.Validate(NoteWorkingProperty.ReferenceLyric);
+            validateWorkingProperty(NoteWorkingProperty.ReferenceLyric);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
@@ -1,0 +1,13 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Types;
+
+public interface IHasWorkingProperty<TWorkingProperty> where TWorkingProperty : struct, Enum
+{
+    bool InvalidateWorkingProperty(TWorkingProperty workingProperty);
+
+    TWorkingProperty[] GetAllInvalidWorkingProperties();
+}


### PR DESCRIPTION
Implement the interface for the hit-object with working property has two reason:
1. Making the invalidate state cannot be modify easily.
2. Easy to invalidate the working property in the hit-object by the interface.