### PR TITLE
Implement inject working time.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -10,6 +10,49 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty>
 {
     [Test]
+    public void TestStartTime()
+    {
+        var lyric = new Lyric();
+
+        // should be invalid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.StartTime, false);
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
+        AssetIsValid(lyric, LyricWorkingProperty.StartTime, true);
+    }
+
+    [Test]
+    public void TestDuration()
+    {
+        var lyric = new Lyric();
+
+        // should be invalid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.Duration, false);
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.Duration = 1000);
+        AssetIsValid(lyric, LyricWorkingProperty.Duration, true);
+    }
+
+    [Test]
+    public void TestTiming()
+    {
+        var lyric = new Lyric();
+
+        // should be invalid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
+
+        // state is still invalid because not assign all timing properties.
+        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
+
+        // ok, should be valid now.
+        Assert.DoesNotThrow(() => lyric.Duration = 1000);
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
+    }
+
+    [Test]
     public void TestPage()
     {
         var lyric = new Lyric();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Patterns;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -55,6 +56,18 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
         {
             switch (flag)
             {
+                case LyricWorkingProperty.StartTime:
+                    lyric.StartTime = getStartTime();
+                    break;
+
+                case LyricWorkingProperty.Duration:
+                    lyric.Duration = getDuration();
+                    break;
+
+                case LyricWorkingProperty.Timing:
+                    // start time and duration should be set by other condition.
+                    break;
+
                 case LyricWorkingProperty.Page:
                     var pageInfo = Beatmap.PageInfo;
                     lyric.PageIndex = pageInfo.GetPageIndexAt(lyric.LyricStartTime);
@@ -66,6 +79,18 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+
+            double getStartTime()
+            {
+                (double? startTime, double? _) = getWorkingStage()?.GetStartAndEndTime(lyric) ?? new Tuple<double?, double?>(null, null);
+                return startTime ?? 0;
+            }
+
+            double getDuration()
+            {
+                (double? startTime, double? endTime) = getWorkingStage()?.GetStartAndEndTime(lyric) ?? new Tuple<double?, double?>(null, null);
+                return endTime - startTime ?? 0;
             }
         }
 
@@ -86,6 +111,10 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                     throw new ArgumentOutOfRangeException();
             }
         }
+
+        // todo: should use better way to get the correct stage.
+        private StageInfo? getWorkingStage()
+            => Beatmap.StageInfos.FirstOrDefault();
 
         private Lyric? findLyricById(int? id) =>
             id == null ? null : Beatmap.HitObjects.OfType<Lyric>().Single(x => x.ID == id);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandler.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
@@ -120,6 +121,8 @@ public partial class BeatmapClassicStageChangeHandler : BeatmapPropertyChangeHan
         performStageInfoChanged(stageInfo =>
         {
             action(stageInfo.LyricTimingInfo);
+
+            InvalidateAllHitObjectWorkingProperty(LyricWorkingProperty.Timing);
         });
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -21,7 +21,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>
     public bool InvalidateWorkingProperty(LyricWorkingProperty workingProperty)
         => workingPropertyValidator.Invalidate(workingProperty);
 
-    private bool validateWorkingProperty(LyricWorkingProperty workingProperty)
+    private void validateWorkingProperty(LyricWorkingProperty workingProperty)
         => workingPropertyValidator.Validate(workingProperty);
 
     public LyricWorkingProperty[] GetAllInvalidWorkingProperties()
@@ -43,14 +43,29 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>
     public override double StartTime
     {
         get => base.StartTime;
-        set => base.StartTime = value;
+        set
+        {
+            base.StartTime = value;
+            validateWorkingProperty(LyricWorkingProperty.StartTime);
+        }
     }
+
+    [JsonIgnore]
+    public readonly Bindable<double> DurationBindable = new BindableDouble();
 
     /// <summary>
     /// Lyric's duration is created from <see cref="KaraokeBeatmapProcessor"/> and should not be saved.
     /// </summary>
     [JsonIgnore]
-    public double Duration { get; set; }
+    public double Duration
+    {
+        get => DurationBindable.Value;
+        set
+        {
+            DurationBindable.Value = value;
+            validateWorkingProperty(LyricWorkingProperty.Duration);
+        }
+    }
 
     /// <summary>
     /// The time at which the HitObject end.

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
@@ -12,12 +12,27 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
 public enum LyricWorkingProperty
 {
     /// <summary>
+    /// <see cref="Lyric.StartTime"/> is being invalidated.
+    /// </summary>
+    StartTime = 1,
+
+    /// <summary>
+    /// <see cref="Lyric.Duration"/> is being invalidated.
+    /// </summary>
+    Duration = 1 << 1,
+
+    /// <summary>
+    /// <see cref="Lyric.StartTime"/> and <see cref="Lyric.Duration"/> is being invalidated.
+    /// </summary>
+    Timing = StartTime | Duration,
+
+    /// <summary>
     /// <see cref="Lyric.PageIndex"/> is being invalidated.
     /// </summary>
-    Page = 1,
+    Page = 1 << 2,
 
     /// <summary>
     /// <see cref="Lyric.ReferenceLyric"/> is being invalidated.
     /// </summary>
-    ReferenceLyric = 1 << 1,
+    ReferenceLyric = 1 << 3,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -15,6 +15,9 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     protected override bool CanCheckWorkingPropertySync(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
+            LyricWorkingProperty.StartTime => false,
+            LyricWorkingProperty.Duration => false,
+            LyricWorkingProperty.Timing => false,
             LyricWorkingProperty.Page => false, // there's no way to check working page is sync to the page info.
             LyricWorkingProperty.ReferenceLyric => true,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
@@ -23,6 +26,9 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     protected override bool NeedToSyncWorkingProperty(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
+            LyricWorkingProperty.StartTime => false,
+            LyricWorkingProperty.Duration => false,
+            LyricWorkingProperty.Timing => false,
             LyricWorkingProperty.Page => false,
             LyricWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID != hitObject.ReferenceLyricId,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Settings/PageAutoGenerateSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Pages/Settings/PageAutoGenerateSection.cs
@@ -57,7 +57,7 @@ public partial class PageAutoGenerateSection : AutoGenerateSection
                 {
                     bool canGenerate = beatmapPagesChangeHandler.CanGenerate();
 
-                    if (canGenerate)
+                    if (!canGenerate)
                     {
                         dialogOverlay.Push(new OkPopupDialog
                         {


### PR DESCRIPTION
Should invalidate the start time and duration in the `BeatmapClassicStageChangeHandler` if edit the time in the classic stage editor.
Cannot test it because the editor haven't implemented.
But i think should be OK to give it a merge.