### PR TITLE
Should validate the property as default.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
@@ -14,6 +14,13 @@ public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag>
     where THitObject : KaraokeHitObject, IHasWorkingProperty<TFlag>, new()
 {
     [Test]
+    public void ChecnInitialState([Values] TFlag flag)
+    {
+        // should be valid on the first load.
+        AssetIsValid(new THitObject(), flag, true);
+    }
+
+    [Test]
     public void RunAllInvalidateTest([Values] TFlag flag)
     {
         // run this test case just make sure that all working property are checked.

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -14,8 +14,8 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be invalid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.StartTime, false);
+        // should be valid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.StartTime, true);
 
         // state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.StartTime = 1000);
@@ -27,8 +27,8 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be invalid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Duration, false);
+        // should be valid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.Duration, true);
 
         // state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.Duration = 1000);
@@ -40,12 +40,12 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be invalid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
+        // should be valid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
 
-        // state is still invalid because not assign all timing properties.
+        // state is still valid because not assign all timing properties.
         Assert.DoesNotThrow(() => lyric.StartTime = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
 
         // ok, should be valid now.
         Assert.DoesNotThrow(() => lyric.Duration = 1000);
@@ -57,8 +57,8 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be invalid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Page, false);
+        // should be valid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.Page, true);
 
         // page state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.PageIndex = 1);
@@ -70,8 +70,8 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be invalid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.ReferenceLyric, false);
+        // should be valid on the first load.
+        AssetIsValid(lyric, LyricWorkingProperty.ReferenceLyric, true);
 
         // should be valid if change the reference lyric id.
         Assert.DoesNotThrow(() =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -14,9 +14,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be valid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.StartTime, true);
-
         // state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.StartTime = 1000);
         AssetIsValid(lyric, LyricWorkingProperty.StartTime, true);
@@ -27,9 +24,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be valid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Duration, true);
-
         // state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.Duration = 1000);
         AssetIsValid(lyric, LyricWorkingProperty.Duration, true);
@@ -39,9 +33,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     public void TestTiming()
     {
         var lyric = new Lyric();
-
-        // should be valid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
 
         // state is still valid because not assign all timing properties.
         Assert.DoesNotThrow(() => lyric.StartTime = 1000);
@@ -57,9 +48,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // should be valid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.Page, true);
-
         // page state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.PageIndex = 1);
         AssetIsValid(lyric, LyricWorkingProperty.Page, true);
@@ -69,9 +57,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     public void TestReferenceLyric()
     {
         var lyric = new Lyric();
-
-        // should be valid on the first load.
-        AssetIsValid(lyric, LyricWorkingProperty.ReferenceLyric, true);
 
         // should be valid if change the reference lyric id.
         Assert.DoesNotThrow(() =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -14,8 +14,8 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
     {
         var note = new Note();
 
-        // should be invalid on the first load.
-        AssetIsValid(note, NoteWorkingProperty.Page, false);
+        // should be valid on the first load.
+        AssetIsValid(note, NoteWorkingProperty.Page, true);
 
         // page state is valid because assign the property.
         Assert.DoesNotThrow(() => note.PageIndex = 1);
@@ -27,8 +27,8 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
     {
         var note = new Note();
 
-        // should be invalid on the first load.
-        AssetIsValid(note, NoteWorkingProperty.ReferenceLyric, false);
+        // should be valid on the first load.
+        AssetIsValid(note, NoteWorkingProperty.ReferenceLyric, true);
 
         // should be valid if change the reference lyric id.
         Assert.DoesNotThrow(() =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -14,9 +14,6 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
     {
         var note = new Note();
 
-        // should be valid on the first load.
-        AssetIsValid(note, NoteWorkingProperty.Page, true);
-
         // page state is valid because assign the property.
         Assert.DoesNotThrow(() => note.PageIndex = 1);
         AssetIsValid(note, NoteWorkingProperty.Page, true);
@@ -26,9 +23,6 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
     public void TestReferenceLyric()
     {
         var note = new Note();
-
-        // should be valid on the first load.
-        AssetIsValid(note, NoteWorkingProperty.ReferenceLyric, true);
 
         // should be valid if change the reference lyric id.
         Assert.DoesNotThrow(() =>

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
@@ -22,6 +22,7 @@ public abstract class HitObjectWorkingPropertyValidator<THitObject, TFlag> : Fla
     protected HitObjectWorkingPropertyValidator(THitObject hitObject)
     {
         this.hitObject = hitObject;
+        ValidateAll();
     }
 
     /// <summary>


### PR DESCRIPTION
Initial working property sync state should be valid.
Because there's not reason to mark the property as invalid if data property and working property are all empty.