### PR TITLE
Fix get the null reference issue if call SetUpKaraokeBeatmap() before PrepareHitObject().

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -153,14 +153,14 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         });
     }
 
-    protected void PrepareHitObject(HitObject hitObject, bool selected = true)
-        => PrepareHitObjects(new[] { hitObject }, selected);
+    protected void PrepareHitObject(Func<HitObject> hitObject, bool selected = true)
+        => PrepareHitObjects(() => new[] { hitObject() }, selected);
 
-    protected void PrepareHitObjects(IEnumerable<HitObject> selectedHitObjects, bool selected = true)
+    protected void PrepareHitObjects(Func<IEnumerable<HitObject>> selectedHitObjects, bool selected = true)
     {
         AddStep("Prepare testing hit objects", () =>
         {
-            var hitobjects = selectedHitObjects.ToList();
+            var hitobjects = selectedHitObjects().ToList();
             var editorBeatmap = Dependencies.Get<EditorBeatmap>();
 
             editorBeatmap.AddRange(hitobjects);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandlerTest.cs
@@ -205,11 +205,11 @@ public partial class BeatmapClassicStageChangeHandlerTest : BaseChangeHandlerTes
             karaokeBeatmap.StageInfos.Add(classicStageInfo);
         });
 
-        Lyric lyric1;
-        Lyric lyric2;
+        Lyric lyric1 = null!;
+        Lyric lyric2 = null!;
 
-        PrepareHitObject(lyric1 = new Lyric { ID = 1 });
-        PrepareHitObject(lyric2 = new Lyric { ID = 2 }, false);
+        PrepareHitObject(() => lyric1 = new Lyric { ID = 1 });
+        PrepareHitObject(() => lyric2 = new Lyric { ID = 2 }, false);
 
         TriggerHandlerChanged(c =>
         {
@@ -232,11 +232,11 @@ public partial class BeatmapClassicStageChangeHandlerTest : BaseChangeHandlerTes
     {
         ClassicLyricTimingPoint timingPoint = null!;
 
-        Lyric lyric1;
-        Lyric lyric2;
+        Lyric lyric1 = null!;
+        Lyric lyric2 = null!;
 
-        PrepareHitObject(lyric1 = new Lyric { ID = 1 });
-        PrepareHitObject(lyric2 = new Lyric { ID = 2 }, false);
+        PrepareHitObject(() => lyric1 = new Lyric { ID = 1 });
+        PrepareHitObject(() => lyric2 = new Lyric { ID = 2 }, false);
 
         SetUpKaraokeBeatmap(karaokeBeatmap =>
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapLanguagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapLanguagesChangeHandlerTest.cs
@@ -71,7 +71,7 @@ public partial class BeatmapLanguagesChangeHandlerTest : BaseChangeHandlerTest<B
             };
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Translates = new Dictionary<CultureInfo, string>
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapPagesChangeHandlerTest.cs
@@ -17,7 +17,7 @@ public partial class BeatmapPagesChangeHandlerTest : BaseChangeHandlerTest<Beatm
     [Test]
     public void TestGeneratePage()
     {
-        PrepareHitObject(TestCaseTagHelper.ParseLyric("[1000,3000]:karaoke"), false);
+        PrepareHitObject(() => TestCaseTagHelper.ParseLyric("[1000,3000]:karaoke"), false);
 
         TriggerHandlerChanged(c => c.AutoGenerate());
 
@@ -36,7 +36,7 @@ public partial class BeatmapPagesChangeHandlerTest : BaseChangeHandlerTest<Beatm
     public void TestGeneratePageWithInvalidCase()
     {
         // there's no time-info inside.
-        PrepareHitObject(new Lyric(), false);
+        PrepareHitObject(() => new Lyric(), false);
 
         TriggerHandlerChangedWithException<GeneratorNotSupportedException>(c => c.AutoGenerate());
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
@@ -115,7 +115,7 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
             lyricLayout = stageInfo.LyricLayoutCategory.AvailableElements.First();
         });
 
-        PrepareHitObject(new Lyric());
+        PrepareHitObject(() => new Lyric());
 
         TriggerHandlerChanged(c =>
         {
@@ -150,8 +150,8 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
             stageInfo.LyricLayoutCategory.AddToMapping(lyricLayout, unSelectedLyric);
         });
 
-        PrepareHitObject(lyric);
-        PrepareHitObject(unSelectedLyric, false);
+        PrepareHitObject(() => lyric);
+        PrepareHitObject(() => unSelectedLyric, false);
 
         TriggerHandlerChanged(c =>
         {
@@ -170,7 +170,7 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
     [Test]
     public void TestOffsetMappingWithZeroValue()
     {
-        PrepareHitObject(new Lyric());
+        PrepareHitObject(() => new Lyric());
 
         // offset value should not be zero.
         TriggerHandlerChangedWithException<InvalidOperationException>(c => c.OffsetMapping(0));
@@ -193,7 +193,7 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
             stageInfo.LyricLayoutCategory.AddToMapping(lyricLayout, lyric);
         });
 
-        PrepareHitObject(lyric);
+        PrepareHitObject(() => lyric);
 
         TriggerHandlerChanged(c =>
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
@@ -14,13 +14,13 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     [Test]
     public void TestLock()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Lock = LockState.None,
         });
 
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
         });
@@ -37,13 +37,13 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     [Test]
     public void TestUnlock()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Lock = LockState.Full,
         });
 
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
         });
@@ -62,7 +62,7 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     {
         var referencedLyric = new Lyric { ID = 2 };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ReferenceLyricId = referencedLyric.ID,

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricAutoGenerateChangeHandlerTest.cs
@@ -24,12 +24,12 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestDetectReferenceLyric()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         }, false);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         });
@@ -46,12 +46,12 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestDetectReferenceLyricWithNonSupportedLyric()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         }, false);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "???"
         });
@@ -66,7 +66,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestDetectLanguage()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         });
@@ -82,7 +82,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestDetectLanguageWithNonSupportedLyric()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "???"
         });
@@ -102,7 +102,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateRubyTags()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -121,7 +121,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateRubyTagsWithNonSupportedLyric()
     {
-        PrepareHitObjects(new[]
+        PrepareHitObjects(() => new[]
         {
             new Lyric
             {
@@ -148,7 +148,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateRomajiTags()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -167,7 +167,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateRomajiTagsWithNonSupportedLyric()
     {
-        PrepareHitObjects(new[]
+        PrepareHitObjects(() => new[]
         {
             new Lyric
             {
@@ -194,7 +194,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateTimeTags()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17)
@@ -211,7 +211,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateTimeTagsWithNonSupportedLyric()
     {
-        PrepareHitObjects(new[]
+        PrepareHitObjects(() => new[]
         {
             new Lyric
             {
@@ -238,7 +238,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateNotes()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -268,7 +268,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     [Test]
     public void TestAutoGenerateNotesWithNonSupportedLyric()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
         });
@@ -296,7 +296,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     {
         if (autoGenerateProperty == LyricAutoGenerateProperty.DetectReferenceLyric)
         {
-            PrepareHitObject(new Lyric
+            PrepareHitObject(() => new Lyric
             {
                 Text = "karaoke"
             }, false);
@@ -332,7 +332,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     {
         if (autoGenerateProperty == LyricAutoGenerateProperty.DetectReferenceLyric)
         {
-            PrepareHitObject(new Lyric
+            PrepareHitObject(() => new Lyric
             {
                 Text = "karaoke"
             }, false);
@@ -369,7 +369,7 @@ public partial class LyricAutoGenerateChangeHandlerTest : LyricPropertyChangeHan
     {
         if (autoGenerateProperty == LyricAutoGenerateProperty.DetectReferenceLyric)
         {
-            PrepareHitObject(new Lyric
+            PrepareHitObject(() => new Lyric
             {
                 Text = "karaoke"
             }, false);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricLanguageChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricLanguageChangeHandlerTest.cs
@@ -14,7 +14,7 @@ public partial class LyricLanguageChangeHandlerTest : LyricPropertyChangeHandler
     public void TestSetLanguageToJapanese()
     {
         var language = new CultureInfo("ja");
-        PrepareHitObject(new Lyric());
+        PrepareHitObject(() => new Lyric());
 
         TriggerHandlerChanged(c => c.SetLanguage(language));
 
@@ -27,7 +27,7 @@ public partial class LyricLanguageChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestSetLanguageToNull()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "???"
         });

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricPropertyChangeHandlerTest.cs
@@ -19,7 +19,7 @@ public abstract partial class LyricPropertyChangeHandlerTest<TChangeHandler> : B
             ReferenceLyricConfig = config ?? new SyncLyricConfig()
         };
 
-        PrepareHitObjects(new[] { lyric }, selected);
+        PrepareHitObjects(() => new[] { lyric }, selected);
 
         return lyric;
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
@@ -18,9 +18,9 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(referencedLyric, false);
+        PrepareHitObject(() => referencedLyric, false);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "I need the reference lyric."
         });
@@ -42,7 +42,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "Lyric",
             ReferenceLyricId = referencedLyric.ID,
@@ -66,7 +66,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "Lyric",
             ReferenceLyricId = referencedLyric.ID,
@@ -90,7 +90,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "Lyric",
             ReferenceLyricId = referencedLyric.ID,
@@ -120,7 +120,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
             Text = "Referenced lyric"
         };
 
-        PrepareHitObject(lyric, false);
+        PrepareHitObject(() => lyric, false);
         PrepareLyricWithSyncConfig(new Lyric());
 
         // should not block the reference language change.

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRomajiTagsChangeHandlerTest.cs
@@ -14,7 +14,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
     [Test]
     public void TestAdd()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -38,7 +38,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
     [Test]
     public void TestAddRange()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -72,7 +72,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
             Text = "kaze",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17),
@@ -100,7 +100,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
             Text = "ka",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -134,7 +134,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
             Text = "ka",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -163,7 +163,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
             Text = "ka",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -192,7 +192,7 @@ public partial class LyricRomajiTagsChangeHandlerTest : LyricPropertyChangeHandl
             Text = "ka",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricRubyTagsChangeHandlerTest.cs
@@ -14,7 +14,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestAdd()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -38,7 +38,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestAddRange()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17)
@@ -72,7 +72,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
             Text = "かぜ",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "風",
             Language = new CultureInfo(17),
@@ -100,7 +100,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
             Text = "か",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -134,7 +134,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
             Text = "か",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -163,7 +163,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
             Text = "か",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),
@@ -192,7 +192,7 @@ public partial class LyricRubyTagsChangeHandlerTest : LyricPropertyChangeHandler
             Text = "か",
         };
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Language = new CultureInfo(17),

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricSingerChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricSingerChangeHandlerTest.cs
@@ -19,7 +19,7 @@ public partial class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTe
         {
             Name = "Singer1",
         };
-        PrepareHitObject(new Lyric());
+        PrepareHitObject(() => new Lyric());
 
         TriggerHandlerChanged(c => c.Add(singer));
 
@@ -38,7 +38,7 @@ public partial class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTe
         {
             Name = "Singer1",
         };
-        PrepareHitObject(new Lyric());
+        PrepareHitObject(() => new Lyric());
 
         TriggerHandlerChanged(c => c.AddRange(new[] { singer }));
 
@@ -61,7 +61,7 @@ public partial class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTe
         {
             Name = "Another singer",
         };
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Singers = new[]
             {
@@ -96,7 +96,7 @@ public partial class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTe
         {
             Name = "Another singer",
         };
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Singers = new[]
             {
@@ -127,7 +127,7 @@ public partial class LyricSingerChangeHandlerTest : LyricPropertyChangeHandlerTe
         {
             Name = "Singer1",
         };
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Singers = new[]
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTextChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTextChangeHandlerTest.cs
@@ -12,7 +12,7 @@ public partial class LyricTextChangeHandlerTest : LyricPropertyChangeHandlerTest
     [Test]
     public void TestInsertText()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラ"
         });
@@ -28,7 +28,7 @@ public partial class LyricTextChangeHandlerTest : LyricPropertyChangeHandlerTest
     [Test]
     public void TestDeleteLyricText()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         });
@@ -44,7 +44,7 @@ public partial class LyricTextChangeHandlerTest : LyricPropertyChangeHandlerTest
     [Test]
     public void TestDeleteAllLyricText()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カ"
         });

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
@@ -19,7 +19,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     public void TestSetTimeTagTime()
     {
         var timeTag = new TimeTag(new TextIndex(), 1000);
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -41,7 +41,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     {
         var timeTag = new TimeTag(new TextIndex());
         var timeTagWithTime = new TimeTag(new TextIndex(), 1000);
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -64,7 +64,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     public void TestClearTimeTagTime()
     {
         var timeTag = new TimeTag(new TextIndex(), 1000);
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -84,7 +84,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestClearAllTimeTagTime()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -106,7 +106,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestAdd()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
         });
@@ -123,7 +123,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestAddRange()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
         });
@@ -142,7 +142,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     {
         var removedTag = new TimeTag(new TextIndex(), 1000);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -164,7 +164,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     {
         var removedTag = new TimeTag(new TextIndex(), 1000);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -184,7 +184,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestAddByPosition()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
         });
@@ -204,7 +204,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestRemoveByPosition()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -231,7 +231,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [Test]
     public void TestRemoveByPositionCase2()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -260,7 +260,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 3)]
     public void TestShifting(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -292,7 +292,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 0)]
     public void TestShiftingToFirst(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -321,7 +321,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 1)]
     public void TestShiftingToLast(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -350,7 +350,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 1)]
     public void TestShiftingWithNoDuplicatedTimeTag(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -380,7 +380,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 0)]
     public void TestShiftingWithOneTimeTag(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -409,7 +409,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 3)]
     public void TestShiftingWithSameTextTag(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             TimeTags = new[]
@@ -441,7 +441,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(TextIndex.IndexState.End, ShiftingDirection.Right, ShiftingType.Index)]
     public void TestShiftingException(TextIndex.IndexState state, ShiftingDirection direction, ShiftingType type)
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "-",
             TimeTags = new[]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTranslateChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTranslateChangeHandlerTest.cs
@@ -14,7 +14,7 @@ public partial class LyricTranslateChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestUpdateTranslateWithNewLanguage()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
         });
@@ -31,7 +31,7 @@ public partial class LyricTranslateChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestUpdateTranslateWithExistLanguage()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Translates = new Dictionary<CultureInfo, string>
@@ -52,7 +52,7 @@ public partial class LyricTranslateChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestUpdateTranslateWithEmptyText()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Translates = new Dictionary<CultureInfo, string>
@@ -72,7 +72,7 @@ public partial class LyricTranslateChangeHandlerTest : LyricPropertyChangeHandle
     [Test]
     public void TestUpdateTranslateWithNullText()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             Translates = new Dictionary<CultureInfo, string>

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricsChangeHandlerTest.cs
@@ -13,7 +13,7 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestSplit()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ"
         });
@@ -41,21 +41,21 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestCombine()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラ",
             ID = 0,
             Order = 1,
         }, false);
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "オケ",
             ID = 1,
             Order = 2,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "karaoke",
             ID = 2,
@@ -83,14 +83,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestCreateAtPosition()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 1,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "karaoke",
             ID = 2,
@@ -121,14 +121,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestCreateAtLast()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 1,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "karaoke",
             ID = 2,
@@ -175,14 +175,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestAddBelowToSelection()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 0,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "Last lyric",
             ID = 1,
@@ -208,14 +208,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestAddRangeBelowToSelection()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 0,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "Last lyric",
             ID = 1,
@@ -244,14 +244,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestRemove()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 1,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "karaoke",
             ID = 2,
@@ -274,14 +274,14 @@ public partial class LyricsChangeHandlerTest : BaseHitObjectChangeHandlerTest<Ly
     [Test]
     public void TestChangeOrder()
     {
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "カラオケ",
             ID = 1,
             Order = 1,
         });
 
-        PrepareHitObject(new Lyric
+        PrepareHitObject(() => new Lyric
         {
             Text = "karaoke",
             ID = 2,

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotePropertyChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotePropertyChangeHandlerTest.cs
@@ -14,7 +14,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestChangeText()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
         });
@@ -30,7 +30,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestChangeRubyText()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             RubyText = "からおけ",
         });
@@ -46,7 +46,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestChangeDisplayStateToVisible()
     {
-        PrepareHitObject(new Note());
+        PrepareHitObject(() => new Note());
 
         TriggerHandlerChanged(c => c.ChangeDisplayState(true));
 
@@ -59,7 +59,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestChangeDisplayStateToNonVisible()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Display = true,
             Tone = new Tone(3)
@@ -78,7 +78,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Ignore("Waiting to implement the lock rules.")]
     public void TestWithReferenceLyric()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
             ReferenceLyric = new Lyric
@@ -94,7 +94,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestOffsetTone()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Display = true,
             Tone = new Tone(3)
@@ -112,7 +112,7 @@ public partial class NotePropertyChangeHandlerTest : BaseHitObjectPropertyChange
     [Test]
     public void TestOffsetToneWithZeroValue()
     {
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Display = true,
             Tone = new Tone(3)

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Notes/NotesChangeHandlerTest.cs
@@ -16,7 +16,7 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
     {
         var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "カラオケ", 1000, 1000);
 
-        PrepareHitObject(new Note
+        PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
             ReferenceLyricId = referencedLyric.ID,
@@ -51,8 +51,8 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
         var referencedLyric = TestCaseNoteHelper.CreateLyricForNote(2, "カラオケ", 1000, 1000);
 
         // note that lyric and notes should in the selection.
-        PrepareHitObject(referencedLyric);
-        PrepareHitObjects(new[]
+        PrepareHitObject(() => referencedLyric);
+        PrepareHitObjects(() => new[]
         {
             new Note
             {
@@ -93,8 +93,8 @@ public partial class NotesChangeHandlerTest : BaseHitObjectChangeHandlerTest<Not
         var referencedLyric = new Lyric { ID = 2 };
 
         // note that lyric and notes should in the selection.
-        PrepareHitObject(referencedLyric);
-        PrepareHitObjects(new[]
+        PrepareHitObject(() => referencedLyric);
+        PrepareHitObjects(() => new[]
         {
             new Note
             {


### PR DESCRIPTION
Inspired from #1896

Will have null reference issue if writing the code like this:
```csharp
Singer singer = null!;
SetUpKaraokeBeatmap(karaokeBeatmap =>
{
    singer = karaokeBeatmap.SingerInfo.AddSinger(s =>
    {
        s.Name = "Singer1";
    });
});

PrepareHitObject(new Lyric
{
    SingerIds = new[]
    {
        // will get the null singer because singer haven't created.
        singer.ID,
    }
});
```
we need to create the singer instance inside the SetUpKaraokeBeatmap(), but `Lyric` created before running the test case, which will get the null singer.

The better solution might be:
```csharp
Singer singer = null!;
SetUpKaraokeBeatmap(karaokeBeatmap =>
{
    singer = karaokeBeatmap.SingerInfo.AddSinger(s =>
    {
        s.Name = "Singer1";
    });
});

// make sure that lyric is created after SetUpKaraokeBeatmap().
PrepareHitObject(() => new Lyric
{
    SingerIds = new[]
    {
        singer.ID,
    }
});
```