### PR TITLE
Change handler should trigger update beatmap if needed.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -216,8 +216,6 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
 
     protected void AssertWorkingPropertyInHitObjectValid()
     {
-        // todo: will open this check once we are able to trigger `UpdateState()` in the change handler.
-        /*
         AddWaitStep("Waiting for working property being re-filled in the beatmap processor.", 1);
         AddAssert("Check if working property in the hit object is valid", () =>
         {
@@ -230,7 +228,6 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
                 _ => throw new NotSupportedException()
             });
         });
-        */
     }
 
     private partial class MockEditorChangeHandler : TransactionalCommitComponent, IEditorChangeHandler

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricReferenceChangeHandlerTest.cs
@@ -15,6 +15,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
     {
         var referencedLyric = new Lyric
         {
+            ID = 1,
             Text = "Referenced lyric"
         };
 
@@ -22,6 +23,7 @@ public partial class LyricReferenceChangeHandlerTest : LyricPropertyChangeHandle
 
         PrepareHitObject(() => new Lyric
         {
+            ID = 2,
             Text = "I need the reference lyric."
         });
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
@@ -53,6 +53,16 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
 
         TriggerHandlerChanged(c => c.ShiftingTimeTagTime(new[] { timeTag, timeTagWithTime }, 2000));
 
+        // use this temp way to trigger transaction count increase.
+        AddStep("Prepare testing beatmap", () =>
+        {
+            var editorBeatmap = Dependencies.Get<EditorBeatmap>();
+            editorBeatmap.PerformOnSelection(h =>
+            {
+                editorBeatmap.Update(h);
+            });
+        });
+
         AssertSelectedHitObject(_ =>
         {
             Assert.AreEqual(null, timeTag.Time);

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -94,5 +94,7 @@ public partial class BeatmapPropertyChangeHandler : Component
         {
             hitObject.InvalidateWorkingProperty(property);
         }
+
+        beatmap.UpdateAllHitObjects();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/HitObjectChangeHandler.cs
@@ -160,6 +160,11 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers
             }
         }
 
+        protected void TriggerHitObjectUpdate<T>(T hitObject) where T : HitObject
+        {
+            beatmap.Update(hitObject);
+        }
+
         public class AddOrRemoveForbiddenException : Exception
         {
             public AddOrRemoveForbiddenException()

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricReferenceChangeHandler.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
 
                 lyric.ReferenceLyricId = referenceLyric?.ID;
 
-                // technically this property should be assigned by beatmap processor, but should be OK to assign here for testing purpose.
-                lyric.ReferenceLyric = referenceLyric;
-
                 if (lyric.ReferenceLyricId == null)
                 {
                     lyric.ReferenceLyricConfig = null;
@@ -38,6 +35,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                     // todo: not really sure should use sync config if lyric text are similar.
                     lyric.ReferenceLyricConfig = new ReferenceLyricConfig();
                 }
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricSingerChangeHandler.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             PerformOnSelection(lyric =>
             {
                 lyric.SingerIds.Add(singer.ID);
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 
@@ -28,6 +30,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                 {
                     lyric.SingerIds.Add(singer.ID);
                 }
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 
@@ -36,6 +40,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             PerformOnSelection(lyric =>
             {
                 lyric.SingerIds.Remove(singer.ID);
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 
@@ -48,6 +54,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
                 {
                     lyric.SingerIds.Remove(singer.ID);
                 }
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 
@@ -56,6 +64,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
             PerformOnSelection(lyric =>
             {
                 lyric.SingerIds.Clear();
+
+                TriggerHitObjectUpdate(lyric);
             });
         }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandler.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics
         public void ShiftingTimeTagTime(IEnumerable<TimeTag> timeTags, double offset)
         {
             CheckExactlySelectedOneHitObject();
+            NotTriggerSaveStateOnThisChange();
 
             PerformOnSelection(lyric =>
             {


### PR DESCRIPTION
Closes issue #1900.

What's done in this PR:
- Should trigger the `UpdateState()` in the `beatmap property change handler` if invalidate the hit-object working property.
- Because we did not have the injection for able to check if there's active transaction(e.g.: start save while dragging the time-tag), so use the flag in the change handler instead.
- Implement method for able to force trigger the `UpdateState()` in the editor beatmap for able to trigger the beatmap processor to re-fill the working property.

So we use this method instead.