### PR TITLE
Add stage element as working property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -4,7 +4,9 @@
 using System;
 using J2N.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -175,5 +177,15 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
         // should throw the exception if assign the working reference lyric to the unmatched reference lyric id.
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => lyric.ReferenceLyric = new Lyric { ID = 3 });
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => lyric.ReferenceLyric = null);
+    }
+
+    [Test]
+    public void TestStageElements()
+    {
+        var lyric = new Lyric();
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.StageElements = new BindableList<StageElement>());
+        AssetIsValid(lyric, LyricWorkingProperty.StageElements, true);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -65,5 +67,15 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
         // should throw the exception if assign the working reference lyric to the unmatched reference lyric id.
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => note.ReferenceLyric = new Lyric { ID = 3 });
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => note.ReferenceLyric = null);
+    }
+
+    [Test]
+    public void TestStageElements()
+    {
+        var note = new Note();
+
+        // page state is valid because assign the property.
+        Assert.DoesNotThrow(() => note.StageElements = new BindableList<StageElement>());
+        AssetIsValid(note, NoteWorkingProperty.StageElements, true);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
@@ -82,6 +84,10 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                     lyric.ReferenceLyric = findLyricById(lyric.ReferenceLyricId);
                     break;
 
+                case LyricWorkingProperty.StageElements:
+                    lyric.StageElements = getStageElements();
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -97,6 +103,9 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                 (double? startTime, double? endTime) = getWorkingStage()?.GetStartAndEndTime(lyric) ?? new Tuple<double?, double?>(null, null);
                 return endTime - startTime ?? 0;
             }
+
+            IList<StageElement> getStageElements()
+                => getWorkingStage()?.GetStageElements(lyric).ToList() ?? new List<StageElement>();
         }
 
         private void applyInvalidProperty(Note note, NoteWorkingProperty flag)
@@ -112,9 +121,16 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                     note.ReferenceLyric = findLyricById(note.ReferenceLyricId);
                     break;
 
+                case NoteWorkingProperty.StageElements:
+                    note.StageElements = getStageElements();
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
+            IList<StageElement> getStageElements()
+                => getWorkingStage()?.GetStageElements(note).ToList() ?? new List<StageElement>();
         }
 
         private SingerInfo getSingerInfo()

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -126,6 +127,27 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>
         {
             ReferenceLyricBindable.Value = value;
             updateStateByWorkingProperty(LyricWorkingProperty.ReferenceLyric);
+        }
+    }
+
+    [JsonIgnore]
+    public readonly BindableList<StageElement> StageElementsBindable = new();
+
+    /// <summary>
+    /// Stage elements.
+    /// Will save all the elements that related to the lyric.
+    /// The element might include something like style or layout info.
+    /// </summary>
+    [JsonIgnore]
+    public IList<StageElement> StageElements
+    {
+        get => StageElementsBindable;
+        set
+        {
+            StageElementsBindable.Clear();
+            StageElementsBindable.AddRange(value);
+
+            updateStateByWorkingProperty(LyricWorkingProperty.StageElements);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -113,6 +114,27 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty>
         {
             ReferenceLyricBindable.Value = value;
             updateStateByWorkingProperty(NoteWorkingProperty.ReferenceLyric);
+        }
+    }
+
+    [JsonIgnore]
+    public readonly BindableList<StageElement> StageElementsBindable = new();
+
+    /// <summary>
+    /// Stage elements.
+    /// Will save all the elements that related to the note.
+    /// The element might include something like style or layout info.
+    /// </summary>
+    [JsonIgnore]
+    public IList<StageElement> StageElements
+    {
+        get => StageElementsBindable;
+        set
+        {
+            StageElementsBindable.Clear();
+            StageElementsBindable.AddRange(value);
+
+            updateStateByWorkingProperty(NoteWorkingProperty.StageElements);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
@@ -40,4 +40,9 @@ public enum LyricWorkingProperty
     /// <see cref="Lyric.ReferenceLyric"/> is being invalidated.
     /// </summary>
     ReferenceLyric = 1 << 4,
+
+    /// <summary>
+    /// <see cref="Lyric.StageElements"/> is being invalidated.
+    /// </summary>
+    StageElements = 1 << 5,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -23,6 +23,7 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
             LyricWorkingProperty.Singers => true,
             LyricWorkingProperty.Page => false,
             LyricWorkingProperty.ReferenceLyric => true,
+            LyricWorkingProperty.StageElements => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 
@@ -35,6 +36,7 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
             LyricWorkingProperty.Singers => !isWorkingSingerSynced(hitObject),
             LyricWorkingProperty.Page => false,
             LyricWorkingProperty.ReferenceLyric => !isReferenceLyricSynced(hitObject),
+            LyricWorkingProperty.StageElements => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
@@ -20,4 +20,9 @@ public enum NoteWorkingProperty
     /// <see cref="Note.ReferenceLyric"/> is being invalidated.
     /// </summary>
     ReferenceLyric = 1 << 1,
+
+    /// <summary>
+    /// <see cref="Note.StageElements"/> is being invalidated.
+    /// </summary>
+    StageElements = 1 << 2,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
@@ -15,8 +15,9 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
     protected override bool CanCheckWorkingPropertySync(Note hitObject, NoteWorkingProperty flags) =>
         flags switch
         {
-            NoteWorkingProperty.Page => false, // there's no way to check working page is sync to the page info.
+            NoteWorkingProperty.Page => false,
             NoteWorkingProperty.ReferenceLyric => true,
+            NoteWorkingProperty.StageElements => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 
@@ -25,6 +26,7 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
         {
             NoteWorkingProperty.Page => false,
             NoteWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID != hitObject.ReferenceLyricId,
+            NoteWorkingProperty.StageElements => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 }


### PR DESCRIPTION
What's done in this PR:
- Add the stage elements as working property in the note and lyric.

The property will be used to:
1. let the stage editor know the element mapping result.
2. in the gameplay, will use the elements and the stage info to generate the layout, style or animation effect.(maybe get the stage info from karaoke beatmap by injection or another working property i think?)