### PR TITLE
Use the `current stage info` property in the beatmap instead.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandlerTest.cs
@@ -256,10 +256,12 @@ public partial class BeatmapClassicStageChangeHandlerTest : BaseChangeHandlerTes
     {
         base.SetUpKaraokeBeatmap(karaokeBeatmap =>
         {
+            var stageInfo = new ClassicStageInfo();
             karaokeBeatmap.StageInfos = new List<StageInfo>
             {
-                new ClassicStageInfo()
+                stageInfo
             };
+            karaokeBeatmap.CurrentStageInfo = stageInfo;
 
             action(karaokeBeatmap);
         });

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
@@ -227,9 +227,7 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
     }
 
     private static TestCategory getStageCategory(KaraokeBeatmap beatmap)
-    {
-        return beatmap.StageInfos.OfType<TestStageinfo>().First().Category;
-    }
+        => beatmap.StageInfos.OfType<TestStageinfo>().First().Category;
 
     public partial class TestBeatmapStageElementCategoryChangeHandler : BeatmapStageElementCategoryChangeHandler<TestStageElement, Lyric>
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
@@ -217,10 +217,12 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
     {
         base.SetUpKaraokeBeatmap(karaokeBeatmap =>
         {
+            var stageInfo = new TestStageinfo();
             karaokeBeatmap.StageInfos = new List<StageInfo>
             {
-                new TestStageinfo(),
+                stageInfo
             };
+            karaokeBeatmap.CurrentStageInfo = stageInfo;
 
             action(karaokeBeatmap);
         });

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandlerTest.cs
@@ -39,10 +39,12 @@ public partial class BeatmapStagesChangeHandlerTest : BaseChangeHandlerTest<Beat
     {
         SetUpKaraokeBeatmap(karaokeBeatmap =>
         {
+            var stageInfo = new ClassicStageInfo();
             karaokeBeatmap.StageInfos = new List<StageInfo>
             {
-                new ClassicStageInfo()
+                stageInfo
             };
+            karaokeBeatmap.CurrentStageInfo = stageInfo;
         });
 
         TriggerHandlerChanged(c =>

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
@@ -15,7 +15,9 @@ public abstract partial class ClassicStageScreenTestScene<T> : GenericEditorScre
         var karaokeBeatmap = base.CreateBeatmap();
 
         // add classic stage info for testing purpose.
-        karaokeBeatmap.StageInfos.Add(new ClassicStageInfo());
+        var stageInfo = new ClassicStageInfo();
+        karaokeBeatmap.StageInfos.Add(stageInfo);
+        karaokeBeatmap.CurrentStageInfo = stageInfo;
 
         return karaokeBeatmap;
     }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
         /// This property will not be null after <see cref="KaraokeBeatmapProcessor.PreProcess"/> is called.
         /// </summary>
         [JsonIgnore]
-        public StageInfo CurrentStageInfo { get; set; } = null!;
+        public StageInfo? CurrentStageInfo { get; set; }
 
         public NoteInfo NoteInfo { get; set; } = new();
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
         public bool Scorable { get; set; }
 
-        public TStageInfo? GetStageInfo<TStageInfo>() => StageInfos.OfType<TStageInfo>().FirstOrDefault();
-
         public override IEnumerable<BeatmapStatistic> GetStatistics()
         {
             int singers = SingerInfo.GetAllSingers().Count();

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapClassicStageChangeHandler.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
@@ -108,12 +107,11 @@ public partial class BeatmapClassicStageChangeHandler : BeatmapPropertyChangeHan
     {
         PerformBeatmapChanged(beatmap =>
         {
-            var stage = getStageInfo(beatmap);
-            action(stage);
-        });
+            if (beatmap.CurrentStageInfo is not ClassicStageInfo classicStageInfo)
+                throw new NotSupportedException($"Current stage info in the beatmap should be {nameof(ClassicStageInfo)}");
 
-        ClassicStageInfo getStageInfo(KaraokeBeatmap beatmap)
-            => beatmap.StageInfos.OfType<ClassicStageInfo>().First();
+            action(classicStageInfo);
+        });
     }
 
     private void performTimingInfoChanged(Action<ClassicLyricTimingInfo> action)

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 
@@ -31,6 +32,17 @@ public partial class BeatmapStagesChangeHandler : BeatmapPropertyChangeHandler, 
                 throw new InvalidOperationException($"There's no {nameof(TStageInfo)} in the beatmap.");
 
             beatmap.StageInfos.Remove(stage);
+
+            // Should clear the current stage info if stage is removed.
+            // Beatmap processor will load the suitable stage info.
+            if (beatmap.CurrentStageInfo == stage)
+            {
+                beatmap.CurrentStageInfo = null!;
+
+                // todo: should invalidate the working stage element processor also.
+                InvalidateAllHitObjectWorkingProperty(LyricWorkingProperty.StageElements);
+                InvalidateAllHitObjectWorkingProperty(NoteWorkingProperty.StageElements);
+            }
         });
     }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
@@ -33,8 +33,19 @@ public partial class StageScreen : ClassicStageScreen, IStageEditorStateProvider
     [Resolved, AllowNull]
     private EditorBeatmap editorBeatmap { get; set; }
 
-    public ClassicStageInfo StageInfo => EditorBeatmapUtils.GetPlayableBeatmap(editorBeatmap).GetStageInfo<ClassicStageInfo>()
-                                         ?? throw new InvalidOperationException();
+    public ClassicStageInfo StageInfo
+    {
+        get
+        {
+            // we should make sure that current stage info is classic stage info.
+            // otherwise, we might not able to see the edit result in the editor.
+            var currentStageInfo = EditorBeatmapUtils.GetPlayableBeatmap(editorBeatmap).CurrentStageInfo;
+            if (currentStageInfo is not ClassicStageInfo classicStageInfo)
+                throw new NotSupportedException();
+
+            return classicStageInfo;
+        }
+    }
 
     public StageScreen()
         : base(ClassicStageEditorScreenMode.Stage)


### PR DESCRIPTION
For now, `CurrentStageInfo` is the final stage info that working in the gameplay and the editor.

What's done in this PR:
1. Fill the current stage info in the `beatmap processor`, should get the current stage from the karaoke beatmap directly in the gameplay or in the editor.
2. Use the `current stage info` in the change handler.
3. Should mark the `current stage info` as empty if remove the stage info.