### PR TITLE
Able to invalidate the stage info.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Types;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -141,6 +142,10 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         // also, technically should not call the change handler if there's no possible to change the properties.
         AssertTransactionOnlyTriggerOnce();
 
+        // We should make sure that the stage info is in the latest state.
+        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
+        AssertCalculatedPropertyInStageInfoValid();
+
         // We should make sure that if the working property is changed by the change handler.
         // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
         AssertWorkingPropertyInHitObjectValid();
@@ -198,6 +203,10 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         // also, technically should not call the change handler if there's no possible to change the properties.
         AssertTransactionOnlyTriggerOnce();
 
+        // We should make sure that the stage info is in the latest state.
+        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
+        AssertCalculatedPropertyInStageInfoValid();
+
         // We should make sure that if the working property is changed by the change handler.
         // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
         AssertWorkingPropertyInHitObjectValid();
@@ -208,6 +217,21 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         AddStep("Transaction should be only triggered once.", () =>
         {
             Assert.AreEqual(1, transactionCount);
+        });
+    }
+
+    protected void AssertCalculatedPropertyInStageInfoValid()
+    {
+        AddWaitStep("Waiting for working property being re-filled in the beatmap processor.", 1);
+        AddAssert("Check if working property in the hit object is valid", () =>
+        {
+            var editorBeatmap = Dependencies.Get<EditorBeatmap>();
+            var karaokeBeatmap = EditorBeatmapUtils.GetPlayableBeatmap(editorBeatmap);
+            if (karaokeBeatmap.CurrentStageInfo is IHasCalculatedProperty calculatedProperty)
+                return calculatedProperty.IsUpdated();
+
+            // ignore check if current stage info no need to calculate the property.
+            return true;
         });
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -137,18 +137,7 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
             assert(editorBeatmap);
         });
 
-        // even if there's no property changed in the lyric editor, should still trigger the change handler.
-        // because every change handler call should cause one undo step.
-        // also, technically should not call the change handler if there's no possible to change the properties.
-        AssertTransactionOnlyTriggerOnce();
-
-        // We should make sure that the stage info is in the latest state.
-        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
-        AssertCalculatedPropertyInStageInfoValid();
-
-        // We should make sure that if the working property is changed by the change handler.
-        // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
-        AssertWorkingPropertyInHitObjectValid();
+        AssertStatus();
     }
 
     protected void AssertKaraokeBeatmap(Action<KaraokeBeatmap> assert)
@@ -198,6 +187,11 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
             assert(editorBeatmap.HitObjects.OfType<THitObject>());
         });
 
+        AssertStatus();
+    }
+
+    protected void AssertStatus()
+    {
         // even if there's no property changed in the lyric editor, should still trigger the change handler.
         // because every change handler call should cause one undo step.
         // also, technically should not call the change handler if there's no possible to change the properties.

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -48,6 +48,10 @@ public abstract partial class BaseHitObjectChangeHandlerTest<TChangeHandler, THi
         // also, technically should not call the change handler if there's no possible to change the properties.
         AssertTransactionOnlyTriggerOnce();
 
+        // We should make sure that the stage info is in the latest state.
+        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
+        AssertCalculatedPropertyInStageInfoValid();
+
         // We should make sure that if the working property is changed by the change handler.
         // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
         AssertWorkingPropertyInHitObjectValid();

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseHitObjectChangeHandlerTest.cs
@@ -43,17 +43,6 @@ public abstract partial class BaseHitObjectChangeHandlerTest<TChangeHandler, THi
             assert(editorBeatmap.SelectedHitObjects.OfType<THitObject>());
         });
 
-        // even if there's no property changed in the lyric editor, should still trigger the change handler.
-        // because every change handler call should cause one undo step.
-        // also, technically should not call the change handler if there's no possible to change the properties.
-        AssertTransactionOnlyTriggerOnce();
-
-        // We should make sure that the stage info is in the latest state.
-        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
-        AssertCalculatedPropertyInStageInfoValid();
-
-        // We should make sure that if the working property is changed by the change handler.
-        // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
-        AssertWorkingPropertyInHitObjectValid();
+        AssertStatus();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -46,7 +46,9 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
 
         private void applyInvalidProperty(KaraokeBeatmap beatmap)
         {
-            foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty>())
+            // should convert to array here because validate the working property might change the start-time and the end time.
+            // which will cause got the wrong item in the array.
+            foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty>().ToArray())
             {
                 hitObject.ValidateWorkingProperty(beatmap);
             }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -6,6 +6,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Patterns;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Preview;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 
@@ -34,7 +35,8 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
             // trying to load the first stage or create a default one.
             beatmap.CurrentStageInfo ??= getWorkingStage() ?? createDefaultWorkingStage();
 
-            beatmap.CurrentStageInfo.ReloadBeatmap(beatmap);
+            if (beatmap.CurrentStageInfo is IHasCalculatedProperty calculatedProperty)
+                calculatedProperty.ValidateCalculatedProperty(beatmap);
 
             StageInfo? getWorkingStage()
                 => Beatmap.StageInfos.FirstOrDefault();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Types;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Preview;
 
-public class PreviewStageInfo : StageInfo
+public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
 {
     #region Category
 
@@ -34,11 +36,34 @@ public class PreviewStageInfo : StageInfo
 
     #endregion
 
-    #region Init
+    #region Validation
 
-    // todo: make the method more generic for those stages that need the beatmap.
-    public override void ReloadBeatmap(IBeatmap beatmap)
+    private bool calcualtedPropertyIsUpdated;
+
+    /// <summary>
+    /// Mark the stage info's calculated property as invalidate.
+    /// </summary>
+    /// <returns></returns>
+    public void TriggerRecalculate()
     {
+        calcualtedPropertyIsUpdated = false;
+    }
+
+    /// <summary>
+    /// Check if the stage info's calculated property is calculated and the value is the latest.
+    /// </summary>
+    /// <returns></returns>
+    public bool IsUpdated() => calcualtedPropertyIsUpdated;
+
+    /// <summary>
+    /// If the calculated property is not updated, then re-calculate the property inside the stage info in the <see cref="KaraokeBeatmapProcessor"/>
+    /// </summary>
+    /// <param name="beatmap"></param>
+    public void ValidateCalculatedProperty(IBeatmap beatmap)
+    {
+        if (IsUpdated())
+            return;
+
         var calculator = new PreviewStageTimingCalculator(beatmap);
 
         // also, clear all mapping in the layout and re-create one.
@@ -55,6 +80,8 @@ public class PreviewStageInfo : StageInfo
             });
             layoutCategory.AddToMapping(element, lyric);
         }
+
+        calcualtedPropertyIsUpdated = true;
     }
 
     #endregion

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
@@ -79,6 +79,10 @@ public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
                 x.Timings = calculator.CalculateTimings(lyric);
             });
             layoutCategory.AddToMapping(element, lyric);
+
+            // Need to invalidate the working property in the lyric to let the property re-fill in the beatmap processor.
+            lyric.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
+            lyric.InvalidateWorkingProperty(LyricWorkingProperty.StageElements);
         }
 
         calcualtedPropertyIsUpdated = true;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/StageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/StageInfo.cs
@@ -3,28 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 
 public abstract class StageInfo
 {
-    #region Init
-
-    /// <summary>
-    /// Should call this method on the <see cref="KaraokeBeatmapProcessor"/> before the <see cref="KaraokeBeatmapProcessor.PreProcess()"/>
-    /// And note that this method is for "patching" the property from the beatmap to the stage.
-    /// So should not keep the reference of the beatmap.
-    /// </summary>
-    /// <param name="beatmap"></param>
-    public virtual void ReloadBeatmap(IBeatmap beatmap)
-    {
-        // for the case that we need to get the properties from the beatmap.
-    }
-
-    #endregion
-
     public IEnumerable<StageElement> GetStageElements(KaraokeHitObject hitObject) =>
         hitObject switch
         {

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Types/IHasCalculatedProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Types/IHasCalculatedProperty.cs
@@ -1,0 +1,27 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Types;
+
+public interface IHasCalculatedProperty
+{
+    /// <summary>
+    /// Mark the stage info's calculated property as invalidate.
+    /// </summary>
+    /// <returns></returns>
+    void TriggerRecalculate();
+
+    /// <summary>
+    /// Check if the stage info's calculated property is calculated and the value is the latest.
+    /// </summary>
+    /// <returns></returns>
+    bool IsUpdated();
+
+    /// <summary>
+    /// If the calculated property is not updated, then re-calculate the property inside the stage info in the <see cref="KaraokeBeatmapProcessor"/>
+    /// </summary>
+    /// <param name="beatmap"></param>
+    void ValidateCalculatedProperty(IBeatmap beatmap);
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
@@ -49,7 +49,7 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
         var lyricTimingInfos = item.HitObjects.OfType<Lyric>().Select(x => new LyricTimingInfo
         {
             StartTime = x.LyricStartTime,
-            EndTime = x.EndTime,
+            EndTime = x.LyricEndTime,
         }).OrderBy(x => x).ToList();
 
         if (lyricTimingInfos.Count == 0)


### PR DESCRIPTION
Prepare for issue #1906 and #1921

Some of the stage info(e.g. default stage info) will calculate the property by hit-object's property(e.g. lyric start time and end time).
If those property changed in some lyrics, need to re-calculate the whole element in the stage.
So we create the interface for those stage infos that will affected by the hit-object.

Also, we should make sure that stage will be re-calculated after mark as invalidate in the change handler.