### PR TITLE
Should add the preempt time into the preview stage timing calculator because the "start time" means finish the preempt effect.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Stages/Preview/PreviewStageTimingCalculatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Stages/Preview/PreviewStageTimingCalculatorTest.cs
@@ -34,7 +34,7 @@ public class PreviewStageTimingCalculatorTest
     [TestCase(lyric_2_id, 0)]
     [TestCase(lyric_3_id, 0)]
     [TestCase(lyric_4_id, 0)]
-    [TestCase(lyric_5_id, 2000 + line_moving_offset_time * 4)] // it's the time first lyric should be disappeared.
+    [TestCase(lyric_5_id, 2000 + line_moving_offset_time * 4 + fading_time)] // it's the time first lyric should be disappeared.
     public void TestGetStartTime(int lyricId, double expected)
     {
         var beatmap = createBeatmap();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageTimingCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageTimingCalculator.cs
@@ -15,6 +15,9 @@ public class PreviewStageTimingCalculator
     // lyrics in the stage.
     private readonly int numberOfLyrics;
 
+    // offset time in the fade in/out
+    private readonly double fadingTime;
+
     // offset time in the Lyrics arrangement.
     private readonly double lineMovingOffsetTime;
 
@@ -22,6 +25,7 @@ public class PreviewStageTimingCalculator
     {
         orderedLyrics = beatmap.HitObjects.OfType<Lyric>().OrderBy(x => x.LyricStartTime).ToArray();
         numberOfLyrics = definition.NumberOfLyrics;
+        fadingTime = definition.FadingTime;
         lineMovingOffsetTime = definition.LineMovingOffsetTime;
     }
 
@@ -31,7 +35,14 @@ public class PreviewStageTimingCalculator
 
         // if true, means those lyrics show at the screening at the beginning.
         bool showAtBeginning = matchedLyrics.Length <= numberOfLyrics;
-        return showAtBeginning ? 0 : matchedLyrics.Min(x => x.LyricEndTime) + numberOfLyrics * lineMovingOffsetTime;
+
+        if (showAtBeginning)
+        {
+            return 0;
+        }
+
+        double startEffectTime = matchedLyrics.Min(x => x.LyricEndTime) + numberOfLyrics * lineMovingOffsetTime;
+        return startEffectTime + fadingTime;
     }
 
     public double CalculateEndTime(Lyric lyric)


### PR DESCRIPTION
Fix the missing part in the #1934.