### PR TITLE
Move preempt time into applier

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
@@ -277,16 +277,6 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
             throw new NotImplementedException();
         }
 
-        protected override double GetPreemptTime(Lyric lyric)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override double GetPreemptTime(Note note)
-        {
-            throw new NotImplementedException();
-        }
-
         protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
         {
             throw new NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -16,16 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty>
 {
     [Test]
-    public void TestPreemptTime()
-    {
-        var lyric = new Lyric();
-
-        // state is valid because assign the property.
-        Assert.DoesNotThrow(() => lyric.PreemptTime = 300);
-        AssetIsValid(lyric, LyricWorkingProperty.PreemptTime, true);
-    }
-
-    [Test]
     public void TestStartTime()
     {
         var lyric = new Lyric();

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -14,16 +14,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Note, NoteWorkingProperty>
 {
     [Test]
-    public void TestPreemptTime()
-    {
-        var note = new Note();
-
-        // page state is valid because assign the property.
-        Assert.DoesNotThrow(() => note.PreemptTime = 300);
-        AssetIsValid(note, NoteWorkingProperty.PreemptTime, true);
-    }
-
-    [Test]
     public void TestPage()
     {
         var note = new Note();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageInfo.cs
@@ -67,18 +67,6 @@ public class ClassicStageInfo : StageInfo
         return new NoteClassicStageEffectApplier(elements, StageDefinition);
     }
 
-    protected override double GetPreemptTime(Lyric lyric)
-    {
-        // todo: should have the time if having loading effect with duration.
-        return 0;
-    }
-
-    protected override double GetPreemptTime(Note note)
-    {
-        // todo: should have the time if having loading effect with duration.
-        return 0;
-    }
-
     protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
     {
         return LyricTimingInfo.GetStartAndEndTime(lyric);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Preview/PreviewStageInfo.cs
@@ -123,17 +123,6 @@ public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
         return new NotePreviewStageEffectApplier(elements, StageDefinition);
     }
 
-    protected override double GetPreemptTime(Lyric lyric)
-    {
-        return StageDefinition.FadingTime;
-    }
-
-    protected override double GetPreemptTime(Note note)
-    {
-        // todo: should have the time if having loading effect with duration.
-        return 0;
-    }
-
     protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
     {
         var element = layoutCategory.GetElementByItem(lyric);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/StageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/StageInfo.cs
@@ -34,14 +34,6 @@ public abstract class StageInfo
             _ => Array.Empty<StageElement>()
         };
 
-    public double GetPreemptTime(KaraokeHitObject hitObject) =>
-        hitObject switch
-        {
-            Lyric lyric => GetPreemptTime(lyric),
-            Note note => GetPreemptTime(note),
-            _ => throw new InvalidOperationException()
-        };
-
     public Tuple<double?, double?> GetStartAndEndTime(KaraokeHitObject hitObject) =>
         hitObject switch
         {
@@ -60,10 +52,6 @@ public abstract class StageInfo
     protected abstract IStageEffectApplier ConvertToLyricStageAppliers(IEnumerable<StageElement> elements);
 
     protected abstract IStageEffectApplier ConvertToNoteStageAppliers(IEnumerable<StageElement> elements);
-
-    protected abstract double GetPreemptTime(Lyric lyric);
-
-    protected abstract double GetPreemptTime(Note note);
 
     protected abstract Tuple<double?, double?> GetStartAndEndTime(Lyric lyric);
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -41,10 +41,6 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
         {
             switch (flag)
             {
-                case LyricWorkingProperty.PreemptTime:
-                    PreemptTime = getPreemptTime(beatmap, this);
-                    break;
-
                 case LyricWorkingProperty.StartTime:
                     StartTime = getStartTime(beatmap, this);
                     break;
@@ -76,16 +72,6 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-        }
-
-        static double getPreemptTime(KaraokeBeatmap beatmap, KaraokeHitObject lyric)
-        {
-            var stageInfo = beatmap.CurrentStageInfo;
-            if (stageInfo == null)
-                throw new InvalidCastException();
-
-            double preemptTime = stageInfo.GetPreemptTime(lyric);
-            return preemptTime;
         }
 
         static double getStartTime(KaraokeBeatmap beatmap, KaraokeHitObject lyric)
@@ -135,22 +121,6 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
 
     [JsonIgnore]
     public double LyricDuration => LyricEndTime - LyricStartTime;
-
-    private double preemptTime;
-
-    /// <summary>
-    /// Lyric's preempt time is created from <see cref="StageInfo"/> and should not be saved.
-    /// </summary>
-    [JsonIgnore]
-    public double PreemptTime
-    {
-        get => preemptTime;
-        set
-        {
-            preemptTime = value;
-            updateStateByWorkingProperty(LyricWorkingProperty.PreemptTime);
-        }
-    }
 
     /// <summary>
     /// Lyric's start time is created from <see cref="StageInfo"/> and should not be saved.

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -10,7 +10,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
-using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Objects.Stages;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
@@ -41,10 +40,6 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty>, IHasEffect
         {
             switch (flag)
             {
-                case NoteWorkingProperty.PreemptTime:
-                    PreemptTime = getPreemptTime(beatmap, this);
-                    break;
-
                 case NoteWorkingProperty.Page:
                     PageIndex = getPageIndex(beatmap, StartTime);
                     break;
@@ -60,16 +55,6 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty>, IHasEffect
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-        }
-
-        static double getPreemptTime(KaraokeBeatmap beatmap, KaraokeHitObject lyric)
-        {
-            var stageInfo = beatmap.CurrentStageInfo;
-            if (stageInfo == null)
-                throw new InvalidCastException();
-
-            double preemptTime = stageInfo.GetPreemptTime(lyric);
-            return preemptTime;
         }
 
         static int? getPageIndex(KaraokeBeatmap beatmap, double startTime)
@@ -102,22 +87,6 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty>, IHasEffect
         {
             PageIndexBindable.Value = value;
             updateStateByWorkingProperty(NoteWorkingProperty.Page);
-        }
-    }
-
-    private double preemptTime;
-
-    /// <summary>
-    /// Note's preempt time is created from <see cref="StageInfo"/> and should not be saved.
-    /// </summary>
-    [JsonIgnore]
-    public double PreemptTime
-    {
-        get => preemptTime;
-        set
-        {
-            preemptTime = value;
-            updateStateByWorkingProperty(NoteWorkingProperty.PreemptTime);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/LyricClassicStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/LyricClassicStageEffectApplier.cs
@@ -17,6 +17,12 @@ public class LyricClassicStageEffectApplier : LyricStageEffectApplier<ClassicSta
     {
     }
 
+    protected override double GetPreemptTime(IEnumerable<StageElement> elements)
+    {
+        // todo: implementation needed.
+        return 0;
+    }
+
     protected override void UpdateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
     {
         throw new System.NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/NoteClassicStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/NoteClassicStageEffectApplier.cs
@@ -17,6 +17,12 @@ public class NoteClassicStageEffectApplier : NoteStageEffectApplier<ClassicStage
     {
     }
 
+    protected override double GetPreemptTime(IEnumerable<StageElement> elements)
+    {
+        // todo: implementation needed.
+        return 0;
+    }
+
     protected override void UpdateInitialTransforms(TransformSequence<DrawableNote> transformSequence, StageElement element)
     {
         throw new System.NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/LyricPreviewStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/LyricPreviewStageEffectApplier.cs
@@ -20,6 +20,11 @@ public class LyricPreviewStageEffectApplier : LyricStageEffectApplier<PreviewSta
     {
     }
 
+    protected override double GetPreemptTime(IEnumerable<StageElement> elements)
+    {
+        return Definition.FadingTime;
+    }
+
     protected override void UpdateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
     {
         switch (element)

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/NotePreviewStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/NotePreviewStageEffectApplier.cs
@@ -17,6 +17,12 @@ public class NotePreviewStageEffectApplier : NoteStageEffectApplier<PreviewStage
     {
     }
 
+    protected override double GetPreemptTime(IEnumerable<StageElement> elements)
+    {
+        // todo: implementation needed.
+        return 0;
+    }
+
     protected override void UpdateInitialTransforms(TransformSequence<DrawableNote> transformSequence, StageElement element)
     {
         throw new System.NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/StageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/StageEffectApplier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
@@ -14,14 +15,17 @@ public abstract class StageEffectApplier<TStageDefinition, TDrawableHitObject> :
     where TStageDefinition : StageDefinition
     where TDrawableHitObject : DrawableHitObject
 {
-    private readonly IEnumerable<StageElement> elements;
+    private readonly StageElement[] elements;
 
     protected readonly TStageDefinition Definition;
+    public readonly double PreemptTime;
 
     protected StageEffectApplier(IEnumerable<StageElement> elements, TStageDefinition definition)
     {
-        this.elements = elements;
+        this.elements = elements.ToArray();
         Definition = definition;
+
+        PreemptTime = GetPreemptTime(this.elements);
     }
 
     /// <summary>
@@ -87,6 +91,8 @@ public abstract class StageEffectApplier<TStageDefinition, TDrawableHitObject> :
 
         transform.Then().FadeOut();
     }
+
+    protected abstract double GetPreemptTime(IEnumerable<StageElement> elements);
 
     protected abstract void UpdateInitialTransforms(TransformSequence<TDrawableHitObject> transformSequence, StageElement element);
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/IHasEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/IHasEffectApplier.cs
@@ -7,7 +7,5 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Types;
 
 public interface IHasEffectApplier
 {
-    double PreemptTime { get; }
-
     IStageEffectApplier EffectApplier { get; }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
@@ -12,42 +12,37 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
 public enum LyricWorkingProperty
 {
     /// <summary>
-    /// <see cref="Lyric.PreemptTime"/> is being invalidated.
-    /// </summary>
-    PreemptTime = 1,
-
-    /// <summary>
     /// <see cref="Lyric.StartTime"/> is being invalidated.
     /// </summary>
-    StartTime = 1 << 1,
+    StartTime = 1,
 
     /// <summary>
     /// <see cref="Lyric.Duration"/> is being invalidated.
     /// </summary>
-    Duration = 1 << 2,
+    Duration = 1 << 1,
 
     /// <summary>
     /// <see cref="Lyric.StartTime"/> and <see cref="Lyric.Duration"/> is being invalidated.
     /// </summary>
-    Timing = PreemptTime | StartTime | Duration,
+    Timing = StartTime | Duration,
 
     /// <summary>
     /// <see cref="Lyric.Singers"/> is being invalidated.
     /// </summary>
-    Singers = 1 << 3,
+    Singers = 1 << 2,
 
     /// <summary>
     /// <see cref="Lyric.PageIndex"/> is being invalidated.
     /// </summary>
-    Page = 1 << 4,
+    Page = 1 << 3,
 
     /// <summary>
     /// <see cref="Lyric.ReferenceLyric"/> is being invalidated.
     /// </summary>
-    ReferenceLyric = 1 << 5,
+    ReferenceLyric = 1 << 4,
 
     /// <summary>
     /// <see cref="Lyric.EffectApplier"/> is being invalidated.
     /// </summary>
-    EffectApplier = 1 << 6,
+    EffectApplier = 1 << 5,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -17,7 +17,6 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     protected override bool CanCheckWorkingPropertySync(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
-            LyricWorkingProperty.PreemptTime => false,
             LyricWorkingProperty.StartTime => false,
             LyricWorkingProperty.Duration => false,
             LyricWorkingProperty.Timing => false,
@@ -31,7 +30,6 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     protected override bool NeedToSyncWorkingProperty(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
-            LyricWorkingProperty.PreemptTime => false,
             LyricWorkingProperty.StartTime => false,
             LyricWorkingProperty.Duration => false,
             LyricWorkingProperty.Timing => false,

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
@@ -12,22 +12,17 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
 public enum NoteWorkingProperty
 {
     /// <summary>
-    /// <see cref="Note.PreemptTime"/> is being invalidated.
-    /// </summary>
-    PreemptTime = 1,
-
-    /// <summary>
     /// <see cref="Note.PageIndex"/> is being invalidated.
     /// </summary>
-    Page = 1 << 1,
+    Page = 1,
 
     /// <summary>
     /// <see cref="Note.ReferenceLyric"/> is being invalidated.
     /// </summary>
-    ReferenceLyric = 1 << 2,
+    ReferenceLyric = 1 << 1,
 
     /// <summary>
     /// <see cref="Note.EffectApplier"/> is being invalidated.
     /// </summary>
-    EffectApplier = 1 << 3,
+    EffectApplier = 1 << 2,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
@@ -15,7 +15,6 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
     protected override bool CanCheckWorkingPropertySync(Note hitObject, NoteWorkingProperty flags) =>
         flags switch
         {
-            NoteWorkingProperty.PreemptTime => false,
             NoteWorkingProperty.Page => false,
             NoteWorkingProperty.ReferenceLyric => true,
             NoteWorkingProperty.EffectApplier => false,
@@ -25,7 +24,6 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
     protected override bool NeedToSyncWorkingProperty(Note hitObject, NoteWorkingProperty flags) =>
         flags switch
         {
-            NoteWorkingProperty.PreemptTime => false,
             NoteWorkingProperty.Page => false,
             NoteWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID != hitObject.ReferenceLyricId,
             NoteWorkingProperty.EffectApplier => false,


### PR DESCRIPTION
Revert most changes in the #1936 because the preempt time should be easily calculated in the stage applier.