### PR TITLE
Implement the drawable to show the beatmap cover and some basic info.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneBeatmapCoverInfo.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/UI/TestSceneBeatmapCoverInfo.cs
@@ -1,0 +1,37 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Karaoke.UI.Components;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.UI;
+
+public partial class TestSceneBeatmapCoverInfo : OsuTestScene
+{
+    [Cached]
+    private readonly OverlayColourProvider colourProvider = new(OverlayColourScheme.Pink);
+
+    private readonly BeatmapCoverInfo beatmapCoverInfo;
+
+    public TestSceneBeatmapCoverInfo()
+    {
+        Add(beatmapCoverInfo = new BeatmapCoverInfo
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre
+        });
+    }
+
+    [Test]
+    public void TestSize()
+    {
+        AddStep("Small size", () => { beatmapCoverInfo.Size = new Vector2(200); });
+        AddStep("Medium size", () => { beatmapCoverInfo.Size = new Vector2(300); });
+        AddStep("Large size", () => { beatmapCoverInfo.Size = new Vector2(400); });
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/UI/Components/BeatmapCoverInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Components/BeatmapCoverInfo.cs
@@ -1,0 +1,121 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Rulesets.Karaoke.UI.Components;
+
+public partial class BeatmapCoverInfo : CompositeDrawable
+{
+    public BeatmapCoverInfo()
+    {
+        Masking = true;
+        CornerRadius = 10;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(IBindable<WorkingBeatmap> beatmap, OverlayColourProvider colourProvider)
+    {
+        var metadata = beatmap.Value.Metadata;
+
+        InternalChildren = new Drawable[]
+        {
+            new BeatmapCover
+            {
+                RelativeSizeAxes = Axes.Both,
+            },
+            new Box
+            {
+                Colour = colourProvider.Background6,
+                Alpha = 0.6f,
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = 64,
+            },
+            new FillFlowContainer
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = 64,
+                Padding = new MarginPadding
+                {
+                    Horizontal = 10,
+                },
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = new RomanisableString(metadata.TitleUnicode, metadata.Title),
+                        Font = OsuFont.Default.With(size: 22.5f, weight: FontWeight.SemiBold),
+                        RelativeSizeAxes = Axes.X,
+                        Truncate = true
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = createArtistText(metadata),
+                        Font = OsuFont.Default.With(size: 17.5f, weight: FontWeight.SemiBold),
+                        RelativeSizeAxes = Axes.X,
+                        Truncate = true
+                    },
+                    new LinkFlowContainer(s =>
+                    {
+                        s.Shadow = false;
+                        s.Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold);
+                    }).With(d =>
+                    {
+                        d.AutoSizeAxes = Axes.Both;
+                        d.Margin = new MarginPadding { Top = 2 };
+                        d.AddText("mapped by ", t => t.Colour = colourProvider.Content2);
+                        d.AddUserLink(metadata.Author);
+                    }),
+                }
+            },
+        };
+    }
+
+    private static LocalisableString createArtistText(IBeatmapMetadataInfo beatmapMetadata)
+    {
+        var romanisableArtist = new RomanisableString(beatmapMetadata.ArtistUnicode, beatmapMetadata.Artist);
+        return BeatmapsetsStrings.ShowDetailsByArtist(romanisableArtist);
+    }
+
+    private partial class BeatmapCover : CompositeDrawable
+    {
+        private const string fallback_texture_name = @"Backgrounds/bg1";
+
+        private readonly Sprite sprite;
+
+        public BeatmapCover()
+        {
+            AddInternal(sprite = new Sprite
+            {
+                RelativeSizeAxes = Axes.Both,
+                FillMode = FillMode.Fill,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IBindable<WorkingBeatmap> beatmap, LargeTextureStore textures)
+        {
+            sprite.Texture = beatmap.Value?.Background ?? textures.Get(fallback_texture_name);
+        }
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/232325235-0fc9a875-28d3-45ca-92e8-5f3bdab1248b.png)
Here's the result.

![image](https://user-images.githubusercontent.com/9100368/232325278-6628d403-cb19-4dc5-a44e-8eba29a3f65c.png)
Small size(200x200).

![image](https://user-images.githubusercontent.com/9100368/232325294-144f1d89-b804-4c5f-8160-6289f87f34c0.png)
Medium size(300x300).

![image](https://user-images.githubusercontent.com/9100368/232325327-47795381-8c6f-4a2e-ab22-9e9583f338db.png)
Large size(400x400).

Small size is not that perfect but i think can ignore it now because this drawable only use in the preview stage for now.