### PR TITLE
Implement the stage applier for the preview stage.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/UI/Components/BeatmapCoverInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Components/BeatmapCoverInfo.cs
@@ -14,10 +14,11 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Karaoke.UI.Stages;
 
 namespace osu.Game.Rulesets.Karaoke.UI.Components;
 
-public partial class BeatmapCoverInfo : CompositeDrawable
+public partial class BeatmapCoverInfo : CompositeDrawable, IStageComponent
 {
     public BeatmapCoverInfo()
     {

--- a/osu.Game.Rulesets.Karaoke/UI/IAcceptStageComponent.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/IAcceptStageComponent.cs
@@ -1,0 +1,14 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Rulesets.Karaoke.UI.Stages;
+
+namespace osu.Game.Rulesets.Karaoke.UI;
+
+public interface IAcceptStageComponent : ITransformable
+{
+    void Add(IStageComponent component);
+
+    bool Remove(IStageComponent component);
+}

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokePlayfield.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Karaoke.UI.Scrolling;
+using osu.Game.Rulesets.Karaoke.UI.Stages;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -21,7 +22,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.UI
 {
-    public partial class KaraokePlayfield : ScrollingPlayfield
+    public partial class KaraokePlayfield : ScrollingPlayfield, IAcceptStageComponent
     {
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; }
@@ -187,6 +188,22 @@ namespace osu.Game.Rulesets.Karaoke.UI
             session.BindWith(KaraokeRulesetSession.Pitch, bindablePitch);
             session.BindWith(KaraokeRulesetSession.VocalPitch, bindableVocalPitch);
             session.BindWith(KaraokeRulesetSession.PlaybackSpeed, bindablePlayback);
+        }
+
+        public void Add(IStageComponent component)
+        {
+            if (component is not Drawable drawableComponent)
+                throw new ArgumentException($"Component must be {nameof(Drawable)}");
+
+            AddInternal(drawableComponent);
+        }
+
+        public bool Remove(IStageComponent component)
+        {
+            if (component is not Drawable drawableComponent)
+                throw new ArgumentException($"Component must be {nameof(Drawable)}");
+
+            return RemoveInternal(drawableComponent, true);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/Classic/PlayfieldClassicStageApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/Classic/PlayfieldClassicStageApplier.cs
@@ -14,6 +14,11 @@ public class PlayfieldClassicStageApplier : PlayfieldStageApplier<ClassicStageDe
     {
     }
 
+    protected override void UpdatePlayfieldArrangement(TransformSequence<KaraokePlayfield> transformSequence, bool displayNotePlayfield)
+    {
+        throw new System.NotImplementedException();
+    }
+
     protected override void UpdateLyricPlayfieldArrangement(TransformSequence<LyricPlayfield> transformSequence, bool displayNotePlayfield)
     {
         throw new System.NotImplementedException();

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/IStageComponent.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/IStageComponent.cs
@@ -1,0 +1,56 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+
+namespace osu.Game.Rulesets.Karaoke.UI.Stages;
+
+public interface IStageComponent : IDrawable
+{
+}
+
+internal class TransformAddStageComponent<TStageComponent> : Transform<TStageComponent, IAcceptStageComponent>
+    where TStageComponent : class, IStageComponent
+{
+    public override string TargetMember => nameof(IAcceptStageComponent.Add);
+
+    private bool added;
+
+    protected override void Apply(IAcceptStageComponent d, double time)
+    {
+        if (time >= StartTime && !added)
+        {
+            d.Add(EndValue);
+            added = true;
+        }
+        else if (time <= StartTime && added)
+        {
+            d.Remove(EndValue);
+            added = false;
+        }
+    }
+
+    protected override void ReadIntoStartValue(IAcceptStageComponent d) => StartValue = null!;
+}
+
+internal static class AcceptStageComponentExtensions
+{
+    /// <summary>
+    /// Add the <see cref="IStageComponent"/> into the drawable which implement the <see cref="IAcceptStageComponent"/>
+    /// </summary>
+    /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+    public static TransformSequence<T> TransformAddStageComponent<T, TStageComponent>(this TransformSequence<T> t, TStageComponent component, double duration = 0)
+        where T : class, IAcceptStageComponent
+        where TStageComponent : class, IStageComponent
+        => t.Append(o => o.TransformAddStageComponent(component, duration));
+
+    /// <summary>
+    /// Add the <see cref="IStageComponent"/> into the drawable which implement the <see cref="IAcceptStageComponent"/>
+    /// </summary>
+    /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+    public static TransformSequence<T> TransformAddStageComponent<T, TStageComponent>(this T acceptStageComponent, TStageComponent component, double duration = 0)
+        where T : class, IAcceptStageComponent
+        where TStageComponent : class, IStageComponent
+        => acceptStageComponent.TransformTo(acceptStageComponent.PopulateTransform(new TransformAddStageComponent<TStageComponent>(), component, duration));
+}

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/PlayfieldStageApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/PlayfieldStageApplier.cs
@@ -23,13 +23,16 @@ public abstract class PlayfieldStageApplier<TStageDefinition> : IPlayfieldStageA
         var lyricPlayfield = playfield.LyricPlayfield;
         var notePlayfield = playfield.NotePlayfield;
 
+        playfield.ClearTransforms();
         lyricPlayfield.ClearTransforms();
         notePlayfield.ClearTransforms();
 
         // Note that we should handle the fade-in effect in here.
+        var playfieldTransformSequence = playfield.FadeOut().Then();
         var lyricPlayfieldTransformSequence = lyricPlayfield.FadeOut().Then();
         var notePlayfieldTransformSequence = notePlayfield.FadeOut().Then();
 
+        UpdatePlayfieldArrangement(playfieldTransformSequence, displayNotePlayfield);
         UpdateLyricPlayfieldArrangement(lyricPlayfieldTransformSequence, displayNotePlayfield);
 
         if (displayNotePlayfield)
@@ -37,6 +40,8 @@ public abstract class PlayfieldStageApplier<TStageDefinition> : IPlayfieldStageA
             UpdateNotePlayfieldArrangement(notePlayfieldTransformSequence);
         }
     }
+
+    protected abstract void UpdatePlayfieldArrangement(TransformSequence<KaraokePlayfield> transformSequence, bool displayNotePlayfield);
 
     protected abstract void UpdateLyricPlayfieldArrangement(TransformSequence<LyricPlayfield> transformSequence, bool displayNotePlayfield);
 

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/Preview/PlayfieldPreviewStageApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/Preview/PlayfieldPreviewStageApplier.cs
@@ -1,9 +1,12 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Preview;
+using osu.Game.Rulesets.Karaoke.UI.Components;
 using osu.Game.Rulesets.Karaoke.UI.Scrolling;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.UI.Stages.Preview;
 
@@ -16,16 +19,29 @@ public class PlayfieldPreviewStageApplier : PlayfieldStageApplier<PreviewStageDe
 
     protected override void UpdatePlayfieldArrangement(TransformSequence<KaraokePlayfield> transformSequence, bool displayNotePlayfield)
     {
-        throw new System.NotImplementedException();
+        transformSequence.TransformAddStageComponent(new BeatmapCoverInfo
+        {
+            Size = new Vector2(displayNotePlayfield ? 200 : 300),
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            X = -200,
+            Y = displayNotePlayfield ? 100 : 0,
+        }).FadeIn(300);
     }
 
     protected override void UpdateLyricPlayfieldArrangement(TransformSequence<LyricPlayfield> transformSequence, bool displayNotePlayfield)
     {
-        throw new System.NotImplementedException();
+        transformSequence.TransformTo(nameof(LyricPlayfield.Anchor), Anchor.BottomRight)
+                         .TransformTo(nameof(LyricPlayfield.Origin), Anchor.BottomRight)
+                         .TransformTo(nameof(LyricPlayfield.Size), new Vector2(0.5f))
+                         .Then()
+                         .FadeIn(100);
     }
 
     protected override void UpdateNotePlayfieldArrangement(TransformSequence<ScrollingNotePlayfield> transformSequence)
     {
-        throw new System.NotImplementedException();
+        transformSequence.TransformTo(nameof(LyricPlayfield.Padding), new MarginPadding(50))
+                         .Then()
+                         .FadeIn(100);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/Preview/PlayfieldPreviewStageApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/Preview/PlayfieldPreviewStageApplier.cs
@@ -14,6 +14,11 @@ public class PlayfieldPreviewStageApplier : PlayfieldStageApplier<PreviewStageDe
     {
     }
 
+    protected override void UpdatePlayfieldArrangement(TransformSequence<KaraokePlayfield> transformSequence, bool displayNotePlayfield)
+    {
+        throw new System.NotImplementedException();
+    }
+
     protected override void UpdateLyricPlayfieldArrangement(TransformSequence<LyricPlayfield> transformSequence, bool displayNotePlayfield)
     {
         throw new System.NotImplementedException();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/233524260-77b34a65-e478-4927-933b-e9aa5c555b48.png)
What's done in this PR:
- Define the stage component interface and the `beatmap cover` should be a part of stage component.
- Implement the transform for able to add the stage component to the drawable which able to add the stage component.
- Implement the `PlayfieldPreviewStageApplier`.

Ignore the text in the right-side because it will be adjust after fully migrate after adjust the whole property by the stage applier.