### PR TITLE
`GeneratorConfig` -> `GeneratorEmptyConfig` in the generator test.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyDetectorTest.cs
@@ -12,7 +12,7 @@ public abstract class BasePropertyDetectorTest<TDetector, TItem, TProperty, TCon
     where TDetector : PropertyDetector<TItem, TProperty>
     where TConfig : GeneratorConfig, new()
 {
-    protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
+    protected static TConfig GeneratorEmptyConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
         GeneratorConfigHelper.ClearValue(config);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/BasePropertyGeneratorTest.cs
@@ -12,7 +12,7 @@ public abstract class BasePropertyGeneratorTest<TGenerator, TItem, TProperty, TC
     where TGenerator : PropertyGenerator<TItem, TProperty>
     where TConfig : GeneratorConfig, new()
 {
-    protected static TConfig GeneratorConfig(Action<TConfig>? action = null)
+    protected static TConfig GeneratorEmptyConfig(Action<TConfig>? action = null)
     {
         var config = new TConfig();
         GeneratorConfigHelper.ClearValue(config);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Language/LanguageDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Language/LanguageDetectorTest.cs
@@ -18,7 +18,7 @@ public class LanguageDetectorTest : BaseLyricDetectorTest<LanguageDetector, Cult
     public void TestCanDetect(string text, bool canDetect)
     {
         var lyric = new Lyric { Text = text };
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanDetect(lyric, canDetect, config);
     }
 
@@ -30,7 +30,7 @@ public class LanguageDetectorTest : BaseLyricDetectorTest<LanguageDetector, Cult
     public void TestDetect(string text, string language)
     {
         var lyric = new Lyric { Text = text };
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         var expected = new CultureInfo(language);
         CheckDetectResult(lyric, expected, config);
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Notes/NoteGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Notes/NoteGeneratorTest.cs
@@ -21,7 +21,7 @@ public class NoteGeneratorTest : BaseLyricGeneratorTest<NoteGenerator, Note[], N
     [TestCase(new string[] { }, false)]
     public void TestCanGenerate(string[] timeTags, bool canGenerate)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         var lyric = new Lyric
         {
             Text = "カラオケ",
@@ -36,7 +36,7 @@ public class NoteGeneratorTest : BaseLyricGeneratorTest<NoteGenerator, Note[], N
     [TestCase(new[] { "[0,start]:1000", "[1,start]:1000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }, new[] { "カラ", "オ", "ケ" })] // will combine the note if time is duplicated.
     public void TestGenerate(string[] timeTags, string[] expectedNotes)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         var lyric = new Lyric
         {
             Text = "カラオケ",

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/ReferenceLyric/ReferenceLyricDetectorTest.cs
@@ -30,7 +30,7 @@ public class ReferenceLyricDetectorTest : BaseLyricDetectorTest<ReferenceLyricDe
             },
             detectedLyric
         };
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanDetect(lyrics, detectedLyric, canDetect, config);
     }
 
@@ -60,7 +60,7 @@ public class ReferenceLyricDetectorTest : BaseLyricDetectorTest<ReferenceLyricDe
             },
             detectedLyric
         };
-        var config = GeneratorConfig(x => x.IgnorePrefixAndPostfixSymbol.Value = true);
+        var config = GeneratorEmptyConfig(x => x.IgnorePrefixAndPostfixSymbol.Value = true);
         CheckCanDetect(lyrics, detectedLyric, canDetect, config);
     }
 
@@ -78,7 +78,7 @@ public class ReferenceLyricDetectorTest : BaseLyricDetectorTest<ReferenceLyricDe
             Order = 2
         };
 
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
 
         // first lyric cannot referenced by second lyric.
         CheckDetectResult(new[] { firstLyric, secondLyric }, firstLyric, null, config);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RomajiTags/Ja/JaRomajiTagGeneratorTest.cs
@@ -14,7 +14,7 @@ public class JaRomajiTagGeneratorTest : BaseRomajiTagGeneratorTest<JaRomajiTagGe
     [TestCase(null, false)]
     public void TestCanGenerate(string text, bool canGenerate)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanGenerate(text, canGenerate, config);
     }
 
@@ -23,7 +23,7 @@ public class JaRomajiTagGeneratorTest : BaseRomajiTagGeneratorTest<JaRomajiTagGe
     [TestCase("枯れた世界に輝く", new[] { "[0,3]:kareta", "[3,6]:sekaini", "[6,8]:kagayaku" })]
     public void TestGenerate(string text, string[] expectedRomajies)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckGenerateResult(text, expectedRomajies, config);
     }
 
@@ -31,7 +31,7 @@ public class JaRomajiTagGeneratorTest : BaseRomajiTagGeneratorTest<JaRomajiTagGe
     [TestCase("はなび", new[] { "[0,3]:HANABI" })]
     public void TestGenerateWithUppercase(string text, string[] expectedRomajies)
     {
-        var config = GeneratorConfig(x => x.Uppercase.Value = true);
+        var config = GeneratorEmptyConfig(x => x.Uppercase.Value = true);
         CheckGenerateResult(text, expectedRomajies, config);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/Ja/JaRubyTagGeneratorTest.cs
@@ -15,7 +15,7 @@ public class JaRubyTagGeneratorTest : BaseRubyTagGeneratorTest<JaRubyTagGenerato
     [TestCase(null, false)]
     public void TestCanGenerate(string text, bool canGenerate)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanGenerate(text, canGenerate, config);
     }
 
@@ -23,7 +23,7 @@ public class JaRubyTagGeneratorTest : BaseRubyTagGeneratorTest<JaRubyTagGenerato
     [TestCase("はなび", new string[] { })]
     public void TestGenerate(string text, string[] expectedRubies)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckGenerateResult(text, expectedRubies, config);
     }
 
@@ -31,7 +31,7 @@ public class JaRubyTagGeneratorTest : BaseRubyTagGeneratorTest<JaRubyTagGenerato
     [TestCase("ハナビ", new string[] { })]
     public void TestGenerateWithRubyAsKatakana(string text, string[] expectedRubies)
     {
-        var config = GeneratorConfig(x => x.RubyAsKatakana.Value = true);
+        var config = GeneratorEmptyConfig(x => x.RubyAsKatakana.Value = true);
         CheckGenerateResult(text, expectedRubies, config);
     }
 
@@ -39,7 +39,7 @@ public class JaRubyTagGeneratorTest : BaseRubyTagGeneratorTest<JaRubyTagGenerato
     [TestCase("ハナビ", new[] { "[0,3]:はなび" })]
     public void TestGenerateWithEnableDuplicatedRuby(string text, string[] expectedRubies)
     {
-        var config = GeneratorConfig(x => x.EnableDuplicatedRuby.Value = true);
+        var config = GeneratorEmptyConfig(x => x.EnableDuplicatedRuby.Value = true);
         CheckGenerateResult(text, expectedRubies, config);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Ja/JaTimeTagGeneratorTest.cs
@@ -17,7 +17,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase(null, false)]
     public void TestCanGenerate(string text, bool canGenerate)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanGenerate(text, canGenerate, config);
     }
 
@@ -25,7 +25,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("がんばって", new[] { "[0,start]:", "[1,start]:", "[2,start]:", "[4,start]:" }, true)]
     public void TestGenerateWithCheckWhiteCheckん(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x => x.Checkん.Value = applyConfig);
+        var config = GeneratorEmptyConfig(x => x.Checkん.Value = applyConfig);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 
@@ -33,7 +33,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("買って", new[] { "[0,start]:", "[1,start]:", "[2,start]:" }, true)]
     public void TestGenerateWithCheckっ(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x => x.Checkっ.Value = applyConfig);
+        var config = GeneratorEmptyConfig(x => x.Checkっ.Value = applyConfig);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 
@@ -41,7 +41,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase(" ", new[] { "[0,start]:" }, true)]
     public void TestGenerateWithCheckBlankLine(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x => x.CheckBlankLine.Value = applyConfig);
+        var config = GeneratorEmptyConfig(x => x.CheckBlankLine.Value = applyConfig);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 
@@ -49,7 +49,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("か", new[] { "[0,start]:", "[0,end]:" }, true)]
     public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x => x.CheckLineEndKeyUp.Value = applyConfig);
+        var config = GeneratorEmptyConfig(x => x.CheckLineEndKeyUp.Value = applyConfig);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 
@@ -57,7 +57,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("か     ", new[] { "[0,start]:", "[1,start]:" }, true)]
     public void TestGenerateWithCheckWhiteSpace(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x => x.CheckWhiteSpace.Value = applyConfig);
+        var config = GeneratorEmptyConfig(x => x.CheckWhiteSpace.Value = applyConfig);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 
@@ -65,7 +65,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("か ", new[] { "[0,start]:", "[0,end]:" }, true)]
     public void TestGenerateWithCheckWhiteSpaceKeyUp(string lyric, string[] expectedTimeTags, bool applyConfig)
     {
-        var config = GeneratorConfig(x =>
+        var config = GeneratorEmptyConfig(x =>
         {
             x.CheckWhiteSpace.Value = true;
             x.CheckWhiteSpaceKeyUp.Value = applyConfig;
@@ -81,7 +81,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("Ａ　Ｂ　Ｃ", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
     public void TestGenerateWithCheckWhiteSpaceAlphabet(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
     {
-        var config = GeneratorConfig(x =>
+        var config = GeneratorEmptyConfig(x =>
         {
             x.CheckWhiteSpace.Value = true;
             x.CheckWhiteSpaceAlphabet.Value = applyConfig;
@@ -98,7 +98,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("０　１　２", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
     public void TestGenerateWithCheckWhiteSpaceDigit(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
     {
-        var config = GeneratorConfig(x =>
+        var config = GeneratorEmptyConfig(x =>
         {
             x.CheckWhiteSpace.Value = true;
             x.CheckWhiteSpaceDigit.Value = applyConfig;
@@ -112,7 +112,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [TestCase("!　!　!", new[] { "[0,start]:", "[0,end]:", "[2,start]:", "[2,end]:", "[4,start]:" }, true, true)]
     public void TestGenerateWitCheckWhiteSpaceAsciiSymbol(string lyric, string[] expectedTimeTags, bool applyConfig, bool keyUp)
     {
-        var config = GeneratorConfig(x =>
+        var config = GeneratorEmptyConfig(x =>
         {
             x.CheckWhiteSpace.Value = true;
             x.CheckWhiteSpaceAsciiSymbol.Value = applyConfig;
@@ -124,7 +124,7 @@ public class JaTimeTagGeneratorTest : BaseTimeTagGeneratorTest<JaTimeTagGenerato
     [Test]
     public void TestGenerateWithRubyLyric()
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         var lyric = new Lyric
         {
             Text = "明日いっしょに遊びましょう！",

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/TimeTags/Zh/ZhTimeTagGeneratorTest.cs
@@ -16,7 +16,7 @@ public class ZhTimeTagGeneratorTest : BaseTimeTagGeneratorTest<ZhTimeTagGenerato
     [TestCase(null, false)]
     public void TestCanGenerate(string text, bool canGenerate)
     {
-        var config = GeneratorConfig();
+        var config = GeneratorEmptyConfig();
         CheckCanGenerate(text, canGenerate, config);
     }
 
@@ -25,7 +25,7 @@ public class ZhTimeTagGeneratorTest : BaseTimeTagGeneratorTest<ZhTimeTagGenerato
     [TestCase("拉~拉~拉~", new[] { "[0,start]:", "[2,start]:", "[4,start]:", "[5,end]:" })]
     public void TestGenerateWithCheckLineEndKeyUp(string lyric, string[] expectedTimeTags)
     {
-        var config = GeneratorConfig(x => x.CheckLineEndKeyUp.Value = true);
+        var config = GeneratorEmptyConfig(x => x.CheckLineEndKeyUp.Value = true);
         CheckGenerateResult(lyric, expectedTimeTags, config);
     }
 }


### PR DESCRIPTION
Inspired from #1950.
Rename the method to let easily know that config is empty, not the default value.