### PR TITLE
Should mark the working property to invalidate as default if the working property does not have the data property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStageElementCategoryChangeHandlerTest.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Stages;
 using osu.Game.Rulesets.Karaoke.UI.Stages;
 using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Beatmaps;
 
@@ -259,27 +260,27 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
 
         protected override IEnumerable<StageElement> GetLyricStageElements(Lyric lyric)
         {
-            throw new NotImplementedException();
+            return Array.Empty<StageElement>();
         }
 
         protected override IEnumerable<StageElement> GetNoteStageElements(Note note)
         {
-            throw new NotImplementedException();
+            return Array.Empty<StageElement>();
         }
 
         protected override IStageEffectApplier ConvertToLyricStageAppliers(IEnumerable<StageElement> elements)
         {
-            throw new NotImplementedException();
+            return new TestApplier();
         }
 
         protected override IStageEffectApplier ConvertToNoteStageAppliers(IEnumerable<StageElement> elements)
         {
-            throw new NotImplementedException();
+            return new TestApplier();
         }
 
         protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
         {
-            throw new NotImplementedException();
+            return new Tuple<double?, double?>(lyric.LyricStartTime, lyric.LyricEndTime);
         }
     }
 
@@ -300,6 +301,26 @@ public partial class BeatmapStageElementCategoryChangeHandlerTest : BaseChangeHa
             return ComparableUtils.CompareByProperty(this, other,
                 x => x.Name,
                 x => x.ID);
+        }
+    }
+
+    private class TestApplier : IStageEffectApplier
+    {
+        public double PreemptTime { get; } = 0;
+
+        public void UpdateInitialTransforms(DrawableHitObject drawableHitObject)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UpdateStartTimeStateTransforms(DrawableHitObject drawableHitObject)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UpdateHitStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/LockChangeHandlerTest.cs
@@ -14,15 +14,19 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     [Test]
     public void TestLock()
     {
-        PrepareHitObject(() => new Lyric
+        var referencedLyric = new Lyric
         {
+            ID = 1,
             Text = "カラオケ",
             Lock = LockState.None,
-        });
+        };
+
+        PrepareHitObject(() => referencedLyric);
 
         PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
+            ReferenceLyricId = referencedLyric.ID
         });
 
         TriggerHandlerChanged(c => c.Lock(LockState.Full));
@@ -37,15 +41,19 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     [Test]
     public void TestUnlock()
     {
-        PrepareHitObject(() => new Lyric
+        var referencedLyric = new Lyric
         {
+            ID = 1,
             Text = "カラオケ",
             Lock = LockState.Full,
-        });
+        };
+
+        PrepareHitObject(() => referencedLyric);
 
         PrepareHitObject(() => new Note
         {
             Text = "カラオケ",
+            ReferenceLyricId = referencedLyric.ID
         });
 
         TriggerHandlerChanged(c => c.Unlock());
@@ -61,6 +69,7 @@ public partial class LockChangeHandlerTest : BaseHitObjectPropertyChangeHandlerT
     public void TestLockToReferenceLyric()
     {
         var referencedLyric = new Lyric { ID = 2 };
+        PrepareHitObject(() => referencedLyric, false);
 
         PrepareHitObject(() => new Lyric
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
@@ -17,7 +17,7 @@ public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag>
     public void CheckInitialState([Values] TFlag flag)
     {
         // should be valid on the first load.
-        AssetIsValid(new THitObject(), flag, true);
+        AssetInitialStateIsValid(new THitObject(), flag);
     }
 
     [Test]
@@ -27,8 +27,16 @@ public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag>
         Assert.DoesNotThrow(() => new THitObject().InvalidateWorkingProperty(flag));
     }
 
+    protected void AssetInitialStateIsValid(THitObject hitObject, TFlag flag)
+    {
+        bool isValid = IsInitialStateValid(flag);
+        AssetIsValid(hitObject, flag, isValid);
+    }
+
     protected void AssetIsValid(THitObject hitObject, TFlag flag, bool isValid)
     {
         Assert.AreEqual(isValid, !hitObject.GetAllInvalidWorkingProperties().Contains(flag));
     }
+
+    protected abstract bool IsInitialStateValid(TFlag flag);
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -40,9 +40,9 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
     {
         var lyric = new Lyric();
 
-        // state is still valid because not assign all timing properties.
+        // state is still invalid because duration is not assign.
         Assert.DoesNotThrow(() => lyric.StartTime = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
+        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
 
         // ok, should be valid now.
         Assert.DoesNotThrow(() => lyric.Duration = 1000);
@@ -188,5 +188,10 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
         // state is valid because assign the property.
         Assert.DoesNotThrow(() => lyric.EffectApplier = new LyricClassicStageEffectApplier(Array.Empty<StageElement>(), new ClassicStageDefinition()));
         AssetIsValid(lyric, LyricWorkingProperty.EffectApplier, true);
+    }
+
+    protected override bool IsInitialStateValid(LyricWorkingProperty flag)
+    {
+        return new LyricWorkingPropertyValidator(new Lyric()).IsValid(flag);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -80,4 +80,9 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
         Assert.DoesNotThrow(() => note.EffectApplier = new NoteClassicStageEffectApplier(Array.Empty<StageElement>(), new ClassicStageDefinition()));
         AssetIsValid(note, NoteWorkingProperty.EffectApplier, true);
     }
+
+    protected override bool IsInitialStateValid(NoteWorkingProperty flag)
+    {
+        return new NoteWorkingPropertyValidator(new Note()).IsValid(flag);
+    }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
@@ -35,7 +35,7 @@ public abstract class HitObjectWorkingPropertyValidator<THitObject, TFlag> : Fla
     {
         foreach (TFlag flag in Enum.GetValues(typeof(TFlag)))
         {
-            if (CanCheckWorkingPropertySync(flag))
+            if (HasDataProperty(flag))
                 continue;
 
             Invalidate(flag);
@@ -74,12 +74,12 @@ public abstract class HitObjectWorkingPropertyValidator<THitObject, TFlag> : Fla
     }
 
     protected sealed override bool CanInvalidate(TFlag flags)
-        => !CanCheckWorkingPropertySync(flags) || NeedToSyncWorkingProperty(hitObject, flags);
+        => !HasDataProperty(flags) || !IsWorkingPropertySynced(hitObject, flags);
 
     protected sealed override bool CanValidate(TFlag flags)
-        => !CanCheckWorkingPropertySync(flags) || !NeedToSyncWorkingProperty(hitObject, flags);
+        => !HasDataProperty(flags) || IsWorkingPropertySynced(hitObject, flags);
 
-    protected abstract bool CanCheckWorkingPropertySync(TFlag flags);
+    protected abstract bool HasDataProperty(TFlag flags);
 
-    protected abstract bool NeedToSyncWorkingProperty(THitObject hitObject, TFlag flags);
+    protected abstract bool IsWorkingPropertySynced(THitObject hitObject, TFlag flags);
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
@@ -57,12 +57,12 @@ public abstract class HitObjectWorkingPropertyValidator<THitObject, TFlag> : Fla
     }
 
     protected sealed override bool CanInvalidate(TFlag flags)
-        => !CanCheckWorkingPropertySync(hitObject, flags) || NeedToSyncWorkingProperty(hitObject, flags);
+        => !CanCheckWorkingPropertySync(flags) || NeedToSyncWorkingProperty(hitObject, flags);
 
     protected sealed override bool CanValidate(TFlag flags)
-        => !CanCheckWorkingPropertySync(hitObject, flags) || !NeedToSyncWorkingProperty(hitObject, flags);
+        => !CanCheckWorkingPropertySync(flags) || !NeedToSyncWorkingProperty(hitObject, flags);
 
-    protected abstract bool CanCheckWorkingPropertySync(THitObject hitObject, TFlag flags);
+    protected abstract bool CanCheckWorkingPropertySync(TFlag flags);
 
     protected abstract bool NeedToSyncWorkingProperty(THitObject hitObject, TFlag flags);
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/HitObjectWorkingPropertyValidator.cs
@@ -22,7 +22,24 @@ public abstract class HitObjectWorkingPropertyValidator<THitObject, TFlag> : Fla
     protected HitObjectWorkingPropertyValidator(THitObject hitObject)
     {
         this.hitObject = hitObject;
+
         ValidateAll();
+        invalidateCannotCheckSyncProperties();
+    }
+
+    /// <summary>
+    /// We need to invalidate the properties that can't check working property sync.
+    /// For able to apply the value in the <see cref="KaraokeBeatmapProcessor"/>
+    /// </summary>
+    private void invalidateCannotCheckSyncProperties()
+    {
+        foreach (TFlag flag in Enum.GetValues(typeof(TFlag)))
+        {
+            if (CanCheckWorkingPropertySync(flag))
+                continue;
+
+            Invalidate(flag);
+        }
     }
 
     /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -14,7 +14,7 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     {
     }
 
-    protected override bool CanCheckWorkingPropertySync(LyricWorkingProperty flags) =>
+    protected override bool HasDataProperty(LyricWorkingProperty flags) =>
         flags switch
         {
             LyricWorkingProperty.StartTime => false,
@@ -27,16 +27,16 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 
-    protected override bool NeedToSyncWorkingProperty(Lyric hitObject, LyricWorkingProperty flags) =>
+    protected override bool IsWorkingPropertySynced(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
-            LyricWorkingProperty.StartTime => false,
-            LyricWorkingProperty.Duration => false,
-            LyricWorkingProperty.Timing => false,
-            LyricWorkingProperty.Singers => !isWorkingSingerSynced(hitObject),
-            LyricWorkingProperty.Page => false,
-            LyricWorkingProperty.ReferenceLyric => !isReferenceLyricSynced(hitObject),
-            LyricWorkingProperty.EffectApplier => false,
+            LyricWorkingProperty.StartTime => true,
+            LyricWorkingProperty.Duration => true,
+            LyricWorkingProperty.Timing => true,
+            LyricWorkingProperty.Singers => isWorkingSingerSynced(hitObject),
+            LyricWorkingProperty.Page => true,
+            LyricWorkingProperty.ReferenceLyric => isReferenceLyricSynced(hitObject),
+            LyricWorkingProperty.EffectApplier => true,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -14,7 +14,7 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     {
     }
 
-    protected override bool CanCheckWorkingPropertySync(Lyric hitObject, LyricWorkingProperty flags) =>
+    protected override bool CanCheckWorkingPropertySync(LyricWorkingProperty flags) =>
         flags switch
         {
             LyricWorkingProperty.StartTime => false,

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
@@ -12,7 +12,7 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
     {
     }
 
-    protected override bool CanCheckWorkingPropertySync(NoteWorkingProperty flags) =>
+    protected override bool HasDataProperty(NoteWorkingProperty flags) =>
         flags switch
         {
             NoteWorkingProperty.Page => false,
@@ -21,12 +21,12 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 
-    protected override bool NeedToSyncWorkingProperty(Note hitObject, NoteWorkingProperty flags) =>
+    protected override bool IsWorkingPropertySynced(Note hitObject, NoteWorkingProperty flags) =>
         flags switch
         {
-            NoteWorkingProperty.Page => false,
-            NoteWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID != hitObject.ReferenceLyricId,
-            NoteWorkingProperty.EffectApplier => false,
+            NoteWorkingProperty.Page => true,
+            NoteWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID == hitObject.ReferenceLyricId,
+            NoteWorkingProperty.EffectApplier => true,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null)
         };
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
@@ -12,7 +12,7 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
     {
     }
 
-    protected override bool CanCheckWorkingPropertySync(Note hitObject, NoteWorkingProperty flags) =>
+    protected override bool CanCheckWorkingPropertySync(NoteWorkingProperty flags) =>
         flags switch
         {
             NoteWorkingProperty.Page => false,


### PR DESCRIPTION
As title.
Also note that all change handler tests will actually create the hit-object stage applier, so should fix the failed test cases. 