### PR TITLE
Implement classic stage applier.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Stages/Classic/ClassicLyricTimingInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Stages/Classic/ClassicLyricTimingInfoTest.cs
@@ -208,6 +208,38 @@ public class ClassicLyricTimingInfoTest
     }
 
     [Test]
+    public void TestGetStartTime()
+    {
+        var timingInfo = new ClassicLyricTimingInfo();
+
+        Assert.AreEqual(null, timingInfo.GetStartTime());
+
+        // Test add timing point.
+        timingInfo.AddTimingPoint(x =>
+        {
+            x.Time = 1000;
+        });
+
+        Assert.AreEqual(1000, timingInfo.GetStartTime());
+    }
+
+    [Test]
+    public void TestGetEndTime()
+    {
+        var timingInfo = new ClassicLyricTimingInfo();
+
+        Assert.AreEqual(null, timingInfo.GetEndTime());
+
+        // Test add timing point.
+        timingInfo.AddTimingPoint(x =>
+        {
+            x.Time = 1000;
+        });
+
+        Assert.AreEqual(1000, timingInfo.GetEndTime());
+    }
+
+    [Test]
     public void TestGetMatchedLyricIds()
     {
         var timingInfo = new ClassicLyricTimingInfo();

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/StageInfoConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/StageInfoConverterTest.cs
@@ -18,7 +18,7 @@ public class StageInfoConverterTest : BaseSingleConverterTest<StageInfoConverter
     {
         var stageInfo = new ClassicStageInfo();
 
-        const string expected = "{\"$type\":\"classic\",\"style_category\":{},\"stage_definition\":{},\"lyric_layout_category\":{},\"lyric_timing_info\":{\"timings\":[],\"mappings\":{}}}";
+        const string expected = "{\"$type\":\"classic\",\"style_category\":{},\"stage_definition\":{\"border_width\":25.0,\"border_height\":25.0,\"fade_in_time\":150.0,\"fade_out_time\":150.0,\"fade_in_easing\":22,\"fade_out_easing\":22,\"lyric_scale\":2.0,\"line_height\":72.0,\"first_lyric_start_time_offset\":1000.0,\"lyric_end_time_offset\":300.0,\"last_lyric_end_time_offset\":10000.0},\"lyric_layout_category\":{},\"lyric_timing_info\":{\"timings\":[],\"mappings\":{}}}";
         string actual = JsonConvert.SerializeObject(stageInfo, CreateSettings());
         Assert.AreEqual(expected, actual);
     }
@@ -27,7 +27,7 @@ public class StageInfoConverterTest : BaseSingleConverterTest<StageInfoConverter
     [Ignore("todo: need to implement the serializer for the ClassicLyricTimingInfo")]
     public void TestClassicStageInfoDeserializer()
     {
-        const string json = "{\"$type\":\"classic\",\"style_category\":{},\"stage_definition\":{},\"lyric_layout_category\":{},\"lyric_timing_info\":{\"timings\":[],\"mappings\":{}}}";
+        const string json = "{\"$type\":\"classic\",\"style_category\":{},\"stage_definition\":{\"border_width\":25.0,\"border_height\":25.0,\"fade_in_time\":150.0,\"fade_out_time\":150.0,\"fade_in_easing\":22,\"fade_out_easing\":22,\"lyric_scale\":2.0,\"line_height\":72.0,\"first_lyric_start_time_offset\":1000.0,\"lyric_end_time_offset\":300.0,\"last_lyric_end_time_offset\":10000.0},\"lyric_layout_category\":{},\"lyric_timing_info\":{\"timings\":[],\"mappings\":{}}}";
 
         var expected = new ClassicStageInfo();
         var actual = (ClassicStageInfo)JsonConvert.DeserializeObject<StageInfo>(json, CreateSettings())!;

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcDecoder.cs
@@ -36,18 +36,11 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps.Formats
                 var lrcRubies = lrcLyric.RubyTags.Select(convertRubyTag).ToArray();
                 var lrcRubyTimeTags = lrcLyric.RubyTags.Select(convertTimeTagsFromRubyTags).SelectMany(x => x).ToArray();
 
-                double? startTime = lrcTimeTags.Select(x => x.Time).Min();
-                double? endTime = lrcTimeTags.Select(x => x.Time).Max();
-                double? duration = endTime - startTime;
-
                 var lyric = new Lyric
                 {
                     ID = output.HitObjects.Count, // id is star from zero.
                     Order = output.HitObjects.Count + 1, // should create default order.
                     Text = lrcLyric.Text,
-                    // Start time and end time should be re-assigned
-                    StartTime = startTime ?? 0,
-                    Duration = duration ?? 0,
                     TimeTags = TimeTagsUtils.Sort(lrcTimeTags.Concat(lrcRubyTimeTags)),
                     RubyTags = lrcRubies
                 };

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicLyricTimingInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicLyricTimingInfo.cs
@@ -202,6 +202,16 @@ public class ClassicLyricTimingInfo
         return new Tuple<double?, double?>(matchedStartTime, matchedEndTime);
     }
 
+    public double? GetStartTime()
+    {
+        return Timings.Any() ? Timings.Min(x => x.Time) : default(double?);
+    }
+
+    public double? GetEndTime()
+    {
+        return Timings.Any() ? Timings.Max(x => x.Time) : default(double?);
+    }
+
     public IEnumerable<int> GetMatchedLyricIds(ClassicLyricTimingPoint point)
     {
         return Mappings.Where(x => x.Value.Contains(point.ID)).Select(x => x.Key);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageDefinition.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageDefinition.cs
@@ -1,9 +1,77 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+
 namespace osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Classic;
 
 public class ClassicStageDefinition : StageDefinition
 {
-    public double LineHeight { get; set; }
+    #region Playfield
+
+    /// <summary>
+    /// The border between <see cref="Lyric"/> to the left/right side of the playfield.
+    /// </summary>
+    public float BorderWidth { get; set; } = 25f;
+
+    /// <summary>
+    /// The border between <see cref="Lyric"/> to the bottom side of the playfield.
+    /// </summary>
+    public float BorderHeight { get; set; } = 25;
+
+    #endregion
+
+    #region Fade in/out effect
+
+    /// <summary>
+    /// Fade-in/out time for the lyric showing to the screen or hiding from the screen.
+    /// </summary>
+    public double FadeInTime { get; set; } = 150;
+
+    /// <summary>
+    /// Fade-in/out time for the lyric showing to the screen or hiding from the screen.
+    /// </summary>
+    public double FadeOutTime { get; set; } = 150;
+
+    /// <summary>
+    /// Fade-in easing for the lyric showing to the screen.
+    /// </summary>
+    public Easing FadeInEasing { get; set; } = Easing.OutCirc;
+
+    /// <summary>
+    /// Fade-out easing for the lyric hiding from the screen.
+    /// </summary>
+    public Easing FadeOutEasing { get; set; } = Easing.OutCirc;
+
+    #endregion
+
+    #region Lyrics arrangement
+
+    /// <summary>
+    /// Text scale for the lyric.
+    /// </summary>
+    public float LyricScale { get; set; } = 2;
+
+    /// <summary>
+    /// Line height for the lyric.
+    /// </summary>
+    public float LineHeight { get; set; } = 72;
+
+    /// <summary>
+    /// The delay time after first lyric appear.
+    /// </summary>
+    public double FirstLyricStartTimeOffset { get; set; } = 1000;
+
+    /// <summary>
+    /// The delay disappear time after touch to the <see cref="Lyric"/>'s <see cref="Lyric.LyricEndTime"/>
+    /// </summary>
+    public double LyricEndTimeOffset { get; set; } = 300;
+
+    /// <summary>
+    /// The delay disappear time after touch to the last <see cref="Lyric"/>'s <see cref="Lyric.LyricEndTime"/>
+    /// </summary>
+    public double LastLyricEndTimeOffset { get; set; } = 10000;
+
+    #endregion
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Stages/Classic/ClassicStageInfo.cs
@@ -69,7 +69,33 @@ public class ClassicStageInfo : StageInfo
 
     protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
     {
-        return LyricTimingInfo.GetStartAndEndTime(lyric);
+        (double? startTime, double? endTime) = LyricTimingInfo.GetStartAndEndTime(lyric);
+        return new Tuple<double?, double?>(startTime + getStartTimeOffset(startTime), endTime + getEndTimeOffset(endTime));
+    }
+
+    private double? getStartTimeOffset(double? lyricStartTime)
+    {
+        if (lyricStartTime == null)
+            return null;
+
+        bool isFirstAppearLyric = lyricStartTime.Value == LyricTimingInfo.GetStartTime();
+
+        if (isFirstAppearLyric)
+        {
+            return StageDefinition.FirstLyricStartTimeOffset + StageDefinition.FadeOutTime;
+        }
+
+        // should add the previous lyric's end time offset.
+        return StageDefinition.LyricEndTimeOffset + StageDefinition.FadeOutTime + StageDefinition.FadeInTime;
+    }
+
+    private double? getEndTimeOffset(double? lyricEndTime)
+    {
+        if (lyricEndTime == null)
+            return null;
+
+        bool isLastDisappearLyric = lyricEndTime.Value == LyricTimingInfo.GetEndTime();
+        return isLastDisappearLyric ? StageDefinition.LastLyricEndTimeOffset : StageDefinition.LyricEndTimeOffset;
     }
 
     #endregion

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapClassicStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapClassicStageInfo.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
 
 public class CheckBeatmapClassicStageInfo : CheckBeatmapStageInfo<ClassicStageInfo>
 {
-    public const double MIN_ROW_HEIGHT = 30;
-    public const double MAX_ROW_HEIGHT = 200;
+    public const float MIN_ROW_HEIGHT = 30;
+    public const float MAX_ROW_HEIGHT = 200;
 
     public const int MIN_LINE_SIZE = 0;
     public const int MAX_LINE_SIZE = 4;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Stages/Classic/ClassicLyricLayoutCategoryGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Stages/Classic/ClassicLyricLayoutCategoryGenerator.cs
@@ -58,23 +58,23 @@ public class ClassicLyricLayoutCategoryGenerator : BeatmapPropertyGenerator<Clas
         switch (amount)
         {
             case 4:
-                yield return addElementWithLine(category, 4, ClassicLyricLayoutAlignment.Left);
-                yield return addElementWithLine(category, 3, ClassicLyricLayoutAlignment.Right);
-                yield return addElementWithLine(category, 2, ClassicLyricLayoutAlignment.Left);
-                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Right);
+                yield return addElementWithLine(category, 3, ClassicLyricLayoutAlignment.Left);
+                yield return addElementWithLine(category, 2, ClassicLyricLayoutAlignment.Right);
+                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Left);
+                yield return addElementWithLine(category, 0, ClassicLyricLayoutAlignment.Right);
 
                 yield break;
 
             case 3:
-                yield return addElementWithLine(category, 3, ClassicLyricLayoutAlignment.Left);
-                yield return addElementWithLine(category, 2, ClassicLyricLayoutAlignment.Center);
-                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Right);
+                yield return addElementWithLine(category, 2, ClassicLyricLayoutAlignment.Left);
+                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Center);
+                yield return addElementWithLine(category, 0, ClassicLyricLayoutAlignment.Right);
 
                 yield break;
 
             case 2:
-                yield return addElementWithLine(category, 2, ClassicLyricLayoutAlignment.Left);
-                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Right);
+                yield return addElementWithLine(category, 1, ClassicLyricLayoutAlignment.Left);
+                yield return addElementWithLine(category, 0, ClassicLyricLayoutAlignment.Right);
 
                 yield break;
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Stages/Classic/ClassicLyricLayoutCategoryGeneratorConfig.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Stages/Classic/ClassicLyricLayoutCategoryGeneratorConfig.cs
@@ -28,7 +28,7 @@ public class ClassicLyricLayoutCategoryGeneratorConfig : GeneratorConfig
     /// Adjust the <see cref="ClassicLyricLayout.HorizontalMargin"/> in the <see cref="ClassicLyricLayout"/>
     /// </summary>
     [ConfigSource("Horizontal margin", "The margin between lyric and the border of the playfield.")]
-    public BindableFloat HorizontalMargin { get; } = new(50)
+    public BindableFloat HorizontalMargin { get; } = new()
     {
         MinValue = 32,
         MaxValue = 100

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/LyricClassicStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Classic/LyricClassicStageEffectApplier.cs
@@ -1,12 +1,15 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Objects.Stages.Classic;
 
@@ -19,22 +22,79 @@ public class LyricClassicStageEffectApplier : LyricStageEffectApplier<ClassicSta
 
     protected override double GetPreemptTime(IEnumerable<StageElement> elements)
     {
-        // todo: implementation needed.
-        return 0;
+        return Definition.FadeInTime;
     }
 
     protected override void UpdateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
     {
-        throw new System.NotImplementedException();
+        switch (element)
+        {
+            case ClassicLyricLayout previewLyricLayout:
+                updateInitialTransforms(transformSequence, previewLyricLayout);
+                break;
+
+            case ClassicStyle:
+                // todo: should load the lyric style.
+                break;
+
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
+    private void updateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, ClassicLyricLayout layout)
+    {
+        transformSequence.TransformTo(nameof(DrawableLyric.Anchor), getLyricAnchor(layout.Alignment))
+                         .TransformTo(nameof(DrawableLyric.Origin), getLyricAnchor(layout.Alignment))
+                         .TransformTo(nameof(DrawableLyric.Padding), getPosition(Definition, layout))
+                         .TransformTo(nameof(DrawableLyric.Scale), new Vector2(Definition.LyricScale))
+                         .FadeTo(1, Definition.FadeInTime, Definition.FadeInEasing);
+
+        static Anchor getLyricAnchor(ClassicLyricLayoutAlignment alignment) =>
+            alignment switch
+            {
+                ClassicLyricLayoutAlignment.Left => Anchor.BottomLeft,
+                ClassicLyricLayoutAlignment.Center => Anchor.BottomCentre,
+                ClassicLyricLayoutAlignment.Right => Anchor.BottomRight,
+                _ => throw new ArgumentOutOfRangeException(nameof(alignment), alignment, null)
+            };
+
+        static MarginPadding getPosition(ClassicStageDefinition definition, ClassicLyricLayout layout)
+        {
+            float paddingX = definition.BorderWidth + layout.HorizontalMargin;
+            float paddingY = definition.BorderHeight + definition.LineHeight * layout.Line;
+
+            var padding = new MarginPadding
+            {
+                Bottom = paddingY,
+            };
+
+            switch (layout.Alignment)
+            {
+                case ClassicLyricLayoutAlignment.Left:
+                    padding.Left = paddingX;
+                    return padding;
+
+                case ClassicLyricLayoutAlignment.Center:
+                    return padding;
+
+                case ClassicLyricLayoutAlignment.Right:
+                    padding.Right = paddingX;
+                    return padding;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 
     protected override void UpdateStartTimeStateTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
     {
-        throw new System.NotImplementedException();
+        // there's no transformer in here.
     }
 
     protected override void UpdateHitStateTransforms(TransformSequence<DrawableLyric> transformSequence, ArmedState state, StageElement element)
     {
-        throw new System.NotImplementedException();
+        transformSequence.FadeOut(Definition.FadeOutTime, Definition.FadeOutEasing);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/LyricPreviewStageEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Stages/Preview/LyricPreviewStageEffectApplier.cs
@@ -46,8 +46,8 @@ public class LyricPreviewStageEffectApplier : LyricStageEffectApplier<PreviewSta
     {
         float initialPosition = getStartPosition(Definition, layout) + Definition.FadingOffsetPosition;
         float startPosition = getStartPosition(Definition, layout);
-        float alpha = getAlpha(layout, Definition);
-        double duration = fadeInDuration(layout, Definition);
+        float alpha = getAlpha(Definition, layout);
+        double duration = fadeInDuration(Definition, layout);
 
         transformSequence.MoveToY(initialPosition).Then()
                          .MoveToY(startPosition, duration, Definition.MovingInEasing)
@@ -63,7 +63,7 @@ public class LyricPreviewStageEffectApplier : LyricStageEffectApplier<PreviewSta
             return definition.LyricHeight * layout.Timings.Count;
         }
 
-        static float getAlpha(PreviewLyricLayout layout, PreviewStageDefinition definition)
+        static float getAlpha(PreviewStageDefinition definition, PreviewLyricLayout layout)
         {
             if (layout.Timings.Any())
             {
@@ -73,7 +73,7 @@ public class LyricPreviewStageEffectApplier : LyricStageEffectApplier<PreviewSta
             return 1;
         }
 
-        static double fadeInDuration(PreviewLyricLayout layout, PreviewStageDefinition definition)
+        static double fadeInDuration(PreviewStageDefinition definition, PreviewLyricLayout layout)
         {
             if (layout.StartTime != 0)
             {

--- a/osu.Game.Rulesets.Karaoke/UI/Stages/Classic/PlayfieldClassicStageApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/Stages/Classic/PlayfieldClassicStageApplier.cs
@@ -17,12 +17,13 @@ public class PlayfieldClassicStageApplier : PlayfieldStageApplier<ClassicStageDe
 
     protected override void UpdatePlayfieldArrangement(TransformSequence<KaraokePlayfield> transformSequence, bool displayNotePlayfield)
     {
-        // there's no need to do anything here.
+        transformSequence.FadeIn(300);
     }
 
     protected override void UpdateLyricPlayfieldArrangement(TransformSequence<LyricPlayfield> transformSequence, bool displayNotePlayfield)
     {
         // todo: adjust the lyric playfield size if contains note playfield.
+        transformSequence.FadeIn(100);
     }
 
     protected override void UpdateNotePlayfieldArrangement(TransformSequence<ScrollingNotePlayfield> transformSequence)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/233847264-b40f207a-e958-4cf4-bda9-49bc23e494df.png)
Seems able to make the PR because most of the part in the hit-object/playfield stage applier has been implemented.

What's done in this PR:
- Adjust some small part in the classic layout/timing auto-generator.
- Add more params in the classic stage definition.
- Implement the hit-object applier.
- Implement the playfield applier.