### PR TITLE
Adjust the interface in the stage change handler.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Beatmaps/BeatmapStagesChangeHandlerTest.cs
@@ -16,14 +16,14 @@ public partial class BeatmapStagesChangeHandlerTest : BaseChangeHandlerTest<Beat
     protected override bool IncludeAutoGenerator => true;
 
     [Test]
-    public void TestAddStageInfoToBeatmap()
+    public void TestAutoGenerate()
     {
         PrepareHitObject(() => new Lyric(), false);
         PrepareHitObject(() => new Lyric(), false);
 
         TriggerHandlerChanged(c =>
         {
-            c.AddStageInfoToBeatmap<ClassicStageInfo>();
+            c.AutoGenerate<ClassicStageInfo>();
         });
 
         AssertKaraokeBeatmap(karaokeBeatmap =>
@@ -36,12 +36,12 @@ public partial class BeatmapStagesChangeHandlerTest : BaseChangeHandlerTest<Beat
         // Should not add the same stage again.
         TriggerHandlerChangedWithException<InvalidOperationException>(c =>
         {
-            c.AddStageInfoToBeatmap<ClassicStageInfo>();
+            c.AutoGenerate<ClassicStageInfo>();
         });
     }
 
     [Test]
-    public void TestRemoveStageInfoFromBeatmap()
+    public void TestRemove()
     {
         SetUpKaraokeBeatmap(karaokeBeatmap =>
         {
@@ -55,7 +55,7 @@ public partial class BeatmapStagesChangeHandlerTest : BaseChangeHandlerTest<Beat
 
         TriggerHandlerChanged(c =>
         {
-            c.RemoveStageInfoFromBeatmap<ClassicStageInfo>();
+            c.Remove<ClassicStageInfo>();
         });
 
         AssertKaraokeBeatmap(karaokeBeatmap =>
@@ -67,7 +67,7 @@ public partial class BeatmapStagesChangeHandlerTest : BaseChangeHandlerTest<Beat
         // Should not remove if there's no matched stage info type.
         TriggerHandlerChangedWithException<InvalidOperationException>(c =>
         {
-            c.RemoveStageInfoFromBeatmap<ClassicStageInfo>();
+            c.Remove<ClassicStageInfo>();
         });
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapStagesChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Beatmaps/IBeatmapStagesChangeHandler.cs
@@ -1,13 +1,14 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Beatmaps;
 
-public interface IBeatmapStagesChangeHandler
+public interface IBeatmapStagesChangeHandler : IAutoGenerateChangeHandler<StageInfo>
 {
-    void AddStageInfoToBeatmap<TStageInfo>() where TStageInfo : StageInfo, new();
+    LocalisableString? GetGeneratorNotSupportedMessage<TStageInfo>() where TStageInfo : StageInfo;
 
-    void RemoveStageInfoFromBeatmap<TStageInfo>() where TStageInfo : StageInfo, new();
+    void Remove<TStageInfo>() where TStageInfo : StageInfo;
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/IAutoGenerateChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/IAutoGenerateChangeHandler.cs
@@ -1,19 +1,17 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers;
 
 /// <summary>
 /// This interface is defined checking able to generate or detect the property, and make the change for the property.
 /// </summary>
-/// <typeparam name="TEnum"></typeparam>
-public interface IAutoGenerateChangeHandler<in TEnum> where TEnum : struct, Enum
+/// <typeparam name="TType"></typeparam>
+public interface IAutoGenerateChangeHandler<in TType>
 {
-    bool CanGenerate(TEnum category);
+    bool CanGenerate<T>() where T : TType;
 
-    void AutoGenerate(TEnum category);
+    void AutoGenerate<T>() where T : TType;
 }
 
 /// <summary>


### PR DESCRIPTION
What's done in this PR:
1. Adjust the naming in the `IBeatmapStagesChangeHandler` to make it more generic.
2. `IBeatmapStagesChangeHandler` should inherit the `IAutoGenerateChangeHandler` for let others easier to find the change handler with auto-generator inside.