### PR TITLE
Should invlidate the working property in the mod because the stage will apply to the hit-object while selecting them in the song selection.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Preview;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages.Types;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
 
@@ -38,8 +39,12 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps
                 beatmap.CurrentStageInfo = getWorkingStage() ?? createDefaultWorkingStage();
 
                 // should invalidate the working property here because the stage info is changed.
-                beatmap.HitObjects.OfType<IHasWorkingProperty<LyricWorkingProperty>>().ForEach(x => x.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier));
-                beatmap.HitObjects.OfType<IHasWorkingProperty<NoteWorkingProperty>>().ForEach(x => x.InvalidateWorkingProperty(NoteWorkingProperty.EffectApplier));
+                beatmap.HitObjects.OfType<Lyric>().ForEach(x =>
+                {
+                    x.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
+                    x.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier);
+                });
+                beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteWorkingProperty.EffectApplier));
             }
 
             if (beatmap.CurrentStageInfo is IHasCalculatedProperty calculatedProperty)

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -152,6 +152,11 @@ namespace osu.Game.Rulesets.Karaoke
                     new KaraokeModFlashlight(),
                     new MultiMod(new KaraokeModSuddenDeath(), new KaraokeModPerfect(), new KaraokeModWindowsUpdate()),
                 },
+                ModType.Conversion => new Mod[]
+                {
+                    new MultiMod(new KaraokeModPreviewStage(), new KaraokeModClassicStage()),
+                },
+
                 ModType.Automation => new Mod[]
                 {
                     new MultiMod(new KaraokeModAutoplay(), new KaraokeModAutoplayBySinger()),

--- a/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Karaoke.Mods;
@@ -37,6 +40,15 @@ public abstract class ModStage<TStageInfo> : Mod, IApplicableAfterBeatmapConvers
         // trying to create a new one if has no matched stage info.
         // it's ok to like it as null if is not able to create the default one, beatmap processor will handle that.
         karaokeBeatmap.CurrentStageInfo = matchedStageInfo ?? CreateStageInfo(karaokeBeatmap)!;
+
+        // should invalidate the working property here because the stage info is changed.
+        // has the same logic in the beatmap processor.
+        beatmap.HitObjects.OfType<Lyric>().ForEach(x =>
+        {
+            x.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
+            x.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier);
+        });
+        beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteWorkingProperty.EffectApplier));
     }
 
     protected abstract void ApplyToCurrentStageInfo(TStageInfo stageInfo);

--- a/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
@@ -13,17 +13,10 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Karaoke.Mods;
 
-public abstract class ModStage<TStageInfo> : Mod, IApplicableAfterBeatmapConversion
+public abstract class ModStage<TStageInfo> : ModStage, IApplicableAfterBeatmapConversion
     where TStageInfo : StageInfo
 {
-    public sealed override ModType Type => ModType.System;
-
-    /// <summary>
-    /// Change the stage type should not affect the score.
-    /// </summary>
-    public override double ScoreMultiplier => 1;
-
-    public void ApplyToBeatmap(IBeatmap beatmap)
+    public override void ApplyToBeatmap(IBeatmap beatmap)
     {
         if (beatmap is not KaraokeBeatmap karaokeBeatmap)
             throw new InvalidCastException();
@@ -57,4 +50,18 @@ public abstract class ModStage<TStageInfo> : Mod, IApplicableAfterBeatmapConvers
     {
         return null;
     }
+}
+
+public abstract class ModStage : Mod, IApplicableAfterBeatmapConversion
+{
+    public sealed override ModType Type => ModType.Conversion;
+
+    /// <summary>
+    /// Change the stage type should not affect the score.
+    /// </summary>
+    public override double ScoreMultiplier => 1;
+
+    public override Type[] IncompatibleMods => new[] { typeof(ModStage) }.Except(new[] { GetType() }).ToArray();
+
+    public abstract void ApplyToBeatmap(IBeatmap beatmap);
 }


### PR DESCRIPTION
What's done in this issue:
1. Change the mod should invalidate all the working property that is related to the stage info.
2. Adjust some properties in the stage mod.
3. Add the mod into the karaoke ruleset.