### PR TITLE
Fix cannot entry to the gameplay if use legacy skin.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Skinning/Default/KaraokeDefaultSkinTransformer.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Default/KaraokeDefaultSkinTransformer.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.UI.HUD;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Default
@@ -19,5 +23,50 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Default
 
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
             => karaokeSkin.GetConfig<TLookup, TValue>(lookup);
+
+        public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+        {
+            switch (lookup)
+            {
+                case SkinComponentsContainerLookup containerLookup:
+                    // Only handle ruleset level defaults for now.
+                    if (containerLookup.Ruleset == null)
+                        return base.GetDrawableComponent(lookup);
+
+                    switch (containerLookup.Target)
+                    {
+                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
+                            // see the fall-back strategy in the SkinManager.AllSources.
+                            // will receive the:
+                            // 1. Legacy beatmap skin.
+                            // 2. default skin(e.g. argon skin) -> container will not be null only if skin is edited.
+                            // 3. triangle skin
+
+                            // component will not be null only if skin is edited.
+                            var component = base.GetDrawableComponent(lookup) as Container;
+
+                            // todo: technically can return non-null container if current skin is triangle skin.
+                            // but have no idea why still not showing the setting button.
+                            if (component != null && !component.Children.OfType<SettingButtonsDisplay>().Any())
+                            {
+                                // should add the setting button if not in the ruleset hud.
+                                component.Add(new SettingButtonsDisplay
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                });
+                            }
+
+                            return component;
+
+                        case SkinComponentsContainerLookup.TargetArea.SongSelect:
+                        default:
+                            return base.GetDrawableComponent(lookup);
+                    }
+
+                default:
+                    return base.GetDrawableComponent(lookup);
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeClassicSkinTransformer.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeClassicSkinTransformer.cs
@@ -8,8 +8,8 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
 {
     public class KaraokeClassicSkinTransformer : KaraokeLegacySkinTransformer
     {
-        public KaraokeClassicSkinTransformer(ISkin source, IBeatmap beatmap)
-            : base(source, beatmap)
+        public KaraokeClassicSkinTransformer(ISkin skin, IBeatmap beatmap)
+            : base(skin, beatmap)
         {
         }
     }

--- a/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeLegacySkinTransformer.cs
@@ -6,18 +6,24 @@ using System.ComponentModel;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
 {
-    public class KaraokeLegacySkinTransformer : LegacySkinTransformer
+    /// <summary>
+    /// Not inherit the <see cref="LegacySkinTransformer"/> because:
+    /// 1. Karaoke ruleset does not have the legacy skin.
+    /// 2. There's not much logic in the <see cref="LegacySkinTransformer"/>
+    /// </summary>
+    public class KaraokeLegacySkinTransformer : KaraokeDefaultSkinTransformer
     {
         private readonly Lazy<bool> isLegacySkin;
         private readonly KaraokeBeatmapSkin karaokeSkin;
 
-        public KaraokeLegacySkinTransformer(ISkin source, IBeatmap beatmap)
-            : base(source)
+        public KaraokeLegacySkinTransformer(ISkin skin, IBeatmap beatmap)
+            : base(skin, beatmap)
         {
             // we should get config by default karaoke skin.
             // if has resource or texture, then try to get from legacy skin.

--- a/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Karaoke/Skinning/Legacy/KaraokeLegacySkinTransformer.cs
@@ -6,10 +6,8 @@ using System.ComponentModel;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Karaoke.UI.HUD;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
-using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
 {
@@ -31,22 +29,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
         {
             switch (lookup)
             {
-                case SkinComponentsContainerLookup targetComponent:
-                    switch (targetComponent.Target)
-                    {
-                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
-                            var components = base.GetDrawableComponent(lookup) as Container ?? getTargetComponentsContainerFromOtherPlace();
-                            components?.Add(new SettingButtonsDisplay
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                            });
-                            return components;
-
-                        default:
-                            return base.GetDrawableComponent(lookup);
-                    }
-
                 case GameplaySkinComponentLookup<HitResult> resultComponent:
                     return getResult(resultComponent.Component);
 
@@ -67,13 +49,6 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
                 default:
                     return base.GetDrawableComponent(lookup);
             }
-
-            Container? getTargetComponentsContainerFromOtherPlace() =>
-                Skin switch
-                {
-                    LegacySkin legacySkin => new TempLegacySkin(legacySkin.SkinInfo.Value).GetDrawableComponent(lookup) as Container,
-                    _ => throw new InvalidCastException()
-                };
         }
 
         private Drawable? getResult(HitResult result)
@@ -84,14 +59,5 @@ namespace osu.Game.Rulesets.Karaoke.Skinning.Legacy
 
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
             => karaokeSkin.GetConfig<TLookup, TValue>(lookup);
-
-        // it's a temp class for just getting SkinnableTarget.MainHUDComponents
-        private class TempLegacySkin : LegacySkin
-        {
-            public TempLegacySkin(SkinInfo skin)
-                : base(skin, null, null)
-            {
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes issue #1941.
The root cause is due to we want to read the value in the skin info.

The better way should be:
- skin transformer should return default skin container if there's no ruleset HUD container in the skin.
- if has ruleset hud container(usually means this skin is edited by user), then add the setting button if there's no button in the container.

Since it's hard to fix the first one for now, it's still OK to give it a merge.
