### PR TITLE
Fix some weird assert null usage.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/KaraokeLegacyBeatmapDecoderTest.cs
@@ -157,7 +157,7 @@ public class KaraokeLegacyBeatmapDecoderTest
         }
         else
         {
-            Assert.IsNull(expected);
+            Assert.Catch(() => KaraokeLegacyBeatmapDecoder.SliceNote(note, startPercentage, durationPercentage));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ColourConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ColourConverterTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Extensions.Color4Extensions;
@@ -27,17 +28,17 @@ public class ColourConverterTest : BaseSingleConverterTest<ColourConverter>
     [TestCase("#AAAAAAAA", "#AAAAAAAA")]
     [TestCase("", null)] // should throw exception
     [TestCase(null, null)] // should throw exception
-    public void TestDeserialize(string? json, string hex)
+    public void TestDeserialize(string? json, string? hex)
     {
-        try
+        if (hex != null)
         {
             var expected = Color4Extensions.FromHex(hex);
             var actual = JsonConvert.DeserializeObject<Color4>($"\"{json}\"", CreateSettings());
             Assert.AreEqual(expected, actual);
         }
-        catch
+        else
         {
-            Assert.IsNull(hex);
+            Assert.Catch(() => JsonConvert.DeserializeObject<Color4>($"\"{json}\"", CreateSettings()));
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricUtilsTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -23,15 +24,16 @@ public class LyricUtilsTest
     [TestCase("", 0, 0, "")]
     public void TestRemoveText(string text, int position, int count, string? expected)
     {
+        var lyric = new Lyric { Text = text };
+
         if (expected != null)
         {
-            var lyric = new Lyric { Text = text };
             LyricUtils.RemoveText(lyric, position, count);
             Assert.AreEqual(expected, lyric.Text);
         }
         else
         {
-            Assert.IsNull(expected);
+            Assert.Catch(() => LyricUtils.RemoveText(lyric, position, count));
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/LyricsUtilsTest.cs
@@ -32,8 +32,7 @@ public class LyricsUtilsTest
         }
         else
         {
-            Assert.IsNull(expectedFirstText);
-            Assert.IsNull(expectedSecondText);
+            Assert.Catch(() => LyricsUtils.SplitLyric(lyric, splitIndex));
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/NotesUtilsTest.cs
@@ -39,8 +39,7 @@ public class NotesUtilsTest
         }
         else
         {
-            Assert.IsNull(firstTime);
-            Assert.IsNull(secondTime);
+            Assert.Catch(() => NotesUtils.SplitNote(note, percentage));
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TimeTagsUtilsTest.cs
@@ -25,20 +25,20 @@ public class TimeTagsUtilsTest
     [TestCase("[1,start]:", null, 2, null)] // should not be null.
     public void GenerateTimeTag(string startTag, string? endTag, int index, string? result)
     {
+        var startTimeTag = TestCaseTagHelper.ParseTimeTag(startTag);
+        var endTimeTag = TestCaseTagHelper.ParseTimeTag(endTag);
+
         if (result != null)
         {
             var expectedTimeTag = TestCaseTagHelper.ParseTimeTag(result);
-            var actualTimeTag = TimeTagsUtils.GenerateCenterTimeTag(
-                TestCaseTagHelper.ParseTimeTag(startTag),
-                TestCaseTagHelper.ParseTimeTag(endTag),
-                index);
+            var actualTimeTag = TimeTagsUtils.GenerateCenterTimeTag(startTimeTag, endTimeTag, index);
 
             Assert.AreEqual(expectedTimeTag.Index, actualTimeTag.Index);
             Assert.AreEqual(expectedTimeTag.Time, actualTimeTag.Time);
         }
         else
         {
-            Assert.IsNull(result);
+            Assert.Catch(() => TimeTagsUtils.GenerateCenterTimeTag(startTimeTag, endTimeTag, index));
         }
     }
 


### PR DESCRIPTION
Close issue  #1657.
Instead of check the expect value in the assert, should be better to make sure that will throw the exception in the utils if the input value is not valid.