### PR TITLE
Rename the drawable caret.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/CaretLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/CaretLayer.cs
@@ -56,13 +56,13 @@ public partial class CaretLayer : BaseLayer
             caretPositionAlgorithm switch
             {
                 // cutting lyric
-                CuttingCaretPosition => new DrawableLyricSplitterCaret(type),
+                CuttingCaretPosition => new DrawableCuttingCaret(type),
                 // typing
-                TypingCaretPosition => new DrawableLyricInputCaret(type),
+                TypingCaretPosition => new DrawableTypingCaret(type),
                 // creat time-tag
-                TimeTagIndexCaretPosition => new DrawableTimeTagEditCaret(type),
+                TimeTagIndexCaretPosition => new DrawableTimeTagIndexCaret(type),
                 // record time-tag
-                TimeTagCaretPosition => new DrawableTimeTagRecordCaret(type),
+                TimeTagCaretPosition => new DrawableTimeTagCaret(type),
                 _ => null
             };
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCuttingCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCuttingCaret.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
-public partial class DrawableLyricSplitterCaret : DrawableLyricTextCaret<CuttingCaretPosition>
+public partial class DrawableCuttingCaret : DrawableTextCaret<CuttingCaretPosition>
 {
     private readonly Container splitter;
     private readonly SpriteIcon splitIcon;
@@ -26,7 +26,7 @@ public partial class DrawableLyricSplitterCaret : DrawableLyricTextCaret<Cutting
     [Resolved]
     private InteractableKaraokeSpriteText karaokeSpriteText { get; set; }
 
-    public DrawableLyricSplitterCaret(DrawableCaretType type)
+    public DrawableCuttingCaret(DrawableCaretType type)
         : base(type)
     {
         Width = 10;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTextCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTextCaret.cs
@@ -10,12 +10,12 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
-public abstract partial class DrawableLyricTextCaret<TCaretPosition> : DrawableCaret<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
+public abstract partial class DrawableTextCaret<TCaretPosition> : DrawableCaret<TCaretPosition> where TCaretPosition : struct, ITextCaretPosition
 {
     [Resolved]
     private InteractableKaraokeSpriteText karaokeSpriteText { get; set; }
 
-    protected DrawableLyricTextCaret(DrawableCaretType type)
+    protected DrawableTextCaret(DrawableCaretType type)
         : base(type)
     {
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagCaret.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
@@ -13,7 +14,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
-public partial class DrawableTimeTagEditCaret : DrawableCaret<TimeTagIndexCaretPosition>
+public partial class DrawableTimeTagCaret : DrawableCaret<TimeTagCaretPosition>
 {
     private const float triangle_width = 8;
 
@@ -25,7 +26,7 @@ public partial class DrawableTimeTagEditCaret : DrawableCaret<TimeTagIndexCaretP
 
     private readonly DrawableTextIndex drawableTextIndex;
 
-    public DrawableTimeTagEditCaret(DrawableCaretType type)
+    public DrawableTimeTagCaret(DrawableCaretType type)
         : base(type)
     {
         AutoSizeAxes = Axes.Both;
@@ -38,14 +39,23 @@ public partial class DrawableTimeTagEditCaret : DrawableCaret<TimeTagIndexCaretP
         };
     }
 
-    protected override void Apply(TimeTagIndexCaretPosition caret)
+    protected override void Apply(TimeTagCaretPosition caret)
     {
-        var textIndex = caret.Index;
-        Position = karaokeSpriteText.GetTextIndexPosition(textIndex);
+        var timeTag = caret.TimeTag;
+        var textIndex = timeTag.Index;
+        this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), getMoveToDuration(Type), Easing.OutCubic);
         Origin = TextIndexUtils.GetValueByState(textIndex, Anchor.BottomLeft, Anchor.BottomRight);
 
         drawableTextIndex.State = textIndex.State;
-        drawableTextIndex.Colour = colours.GetEditTimeTagCaretColour();
+        drawableTextIndex.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
+
+        static double getMoveToDuration(DrawableCaretType type) =>
+            type switch
+            {
+                DrawableCaretType.Caret => 100,
+                DrawableCaretType.HoverCaret => 0,
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
     }
 
     public override void TriggerDisallowEditEffect(LyricEditorMode editorMode)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagIndexCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagIndexCaret.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
@@ -14,7 +13,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
-public partial class DrawableTimeTagRecordCaret : DrawableCaret<TimeTagCaretPosition>
+public partial class DrawableTimeTagIndexCaret : DrawableCaret<TimeTagIndexCaretPosition>
 {
     private const float triangle_width = 8;
 
@@ -26,7 +25,7 @@ public partial class DrawableTimeTagRecordCaret : DrawableCaret<TimeTagCaretPosi
 
     private readonly DrawableTextIndex drawableTextIndex;
 
-    public DrawableTimeTagRecordCaret(DrawableCaretType type)
+    public DrawableTimeTagIndexCaret(DrawableCaretType type)
         : base(type)
     {
         AutoSizeAxes = Axes.Both;
@@ -39,23 +38,14 @@ public partial class DrawableTimeTagRecordCaret : DrawableCaret<TimeTagCaretPosi
         };
     }
 
-    protected override void Apply(TimeTagCaretPosition caret)
+    protected override void Apply(TimeTagIndexCaretPosition caret)
     {
-        var timeTag = caret.TimeTag;
-        var textIndex = timeTag.Index;
-        this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), getMoveToDuration(Type), Easing.OutCubic);
+        var textIndex = caret.Index;
+        Position = karaokeSpriteText.GetTextIndexPosition(textIndex);
         Origin = TextIndexUtils.GetValueByState(textIndex, Anchor.BottomLeft, Anchor.BottomRight);
 
         drawableTextIndex.State = textIndex.State;
-        drawableTextIndex.Colour = colours.GetRecordingTimeTagCaretColour(timeTag);
-
-        static double getMoveToDuration(DrawableCaretType type) =>
-            type switch
-            {
-                DrawableCaretType.Caret => 100,
-                DrawableCaretType.HoverCaret => 0,
-                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-            };
+        drawableTextIndex.Colour = colours.GetEditTimeTagCaretColour();
     }
 
     public override void TriggerDisallowEditEffect(LyricEditorMode editorMode)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
@@ -19,7 +19,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
-public partial class DrawableLyricInputCaret : DrawableLyricTextCaret<TypingCaretPosition>
+public partial class DrawableTypingCaret : DrawableTextCaret<TypingCaretPosition>
 {
     private const float caret_move_time = 60;
     private const float caret_width = 3;
@@ -35,7 +35,7 @@ public partial class DrawableLyricInputCaret : DrawableLyricTextCaret<TypingCare
 
     private TypingCaretPosition? caretPosition;
 
-    public DrawableLyricInputCaret(DrawableCaretType type)
+    public DrawableTypingCaret(DrawableCaretType type)
         : base(type)
     {
         Width = caret_width;


### PR DESCRIPTION
One caret position should match exactly one drawable caret.

Should use the `ILyricEditorState` to get the mode and sub-mode inside the drawable caret if want to change the style by edit mode.
The reason is that `CaretLayer` should not know the edit mode type. It just need to create the drawable caret by the caret object and detect if need to change the drawable caret.