### PR TITLE
Use utils to get the value by state.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextIndexUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextIndexUtilsTest.cs
@@ -106,6 +106,12 @@ public class TextIndexUtilsTest
 
         object valueByState = TextIndexUtils.GetValueByState(state, startValue, endValue);
         Assert.AreEqual(expected, valueByState);
+
+        object valueByTextIndexWithFunction = TextIndexUtils.GetValueByState(textIndex, () => startValue, () => endValue);
+        Assert.AreEqual(expected, valueByTextIndexWithFunction);
+
+        object valueByStateWithFunction = TextIndexUtils.GetValueByState(state, () => startValue, () => endValue);
+        Assert.AreEqual(expected, valueByStateWithFunction);
     }
 
     [TestCase(0, TextIndex.IndexState.Start, "0")]

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/TextIndexUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/TextIndexUtilsTest.cs
@@ -101,8 +101,11 @@ public class TextIndexUtilsTest
     {
         var textIndex = new TextIndex(0, state);
 
-        object actual = TextIndexUtils.GetValueByState(textIndex, startValue, endValue);
-        Assert.AreEqual(expected, actual);
+        object valueByTextIndex = TextIndexUtils.GetValueByState(textIndex, startValue, endValue);
+        Assert.AreEqual(expected, valueByTextIndex);
+
+        object valueByState = TextIndexUtils.GetValueByState(state, startValue, endValue);
+        Assert.AreEqual(expected, valueByState);
     }
 
     [TestCase(0, TextIndex.IndexState.Start, "0")]

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcEncoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcEncoder.cs
@@ -74,7 +74,7 @@ public class LrcEncoder
 
         // convert to dictionary, will get start's smallest time and end's largest time.
         return sortedTimeTags.Where(x => x.Time != null).GroupBy(x => x.Index)
-                             .Select(x => TextIndexUtils.GetValueByState(x.Key, x.FirstOrDefault(), x.LastOrDefault()))
+                             .Select(x => TextIndexUtils.GetValueByState(x.Key, x.FirstOrDefault, x.LastOrDefault))
                              .ToDictionary(
                                  k => k?.Index ?? throw new ArgumentNullException(nameof(k)),
                                  v => v?.Time ?? throw new ArgumentNullException(nameof(v)));

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcEncoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/LrcEncoder.cs
@@ -44,7 +44,7 @@ public class LrcEncoder
         static LrcParser.Model.TextIndex convertTextIndex(TextIndex textIndex)
         {
             int index = textIndex.Index;
-            var state = textIndex.State == TextIndex.IndexState.Start ? IndexState.Start : IndexState.End;
+            var state = TextIndexUtils.GetValueByState(textIndex, IndexState.Start, IndexState.End);
 
             return new LrcParser.Model.TextIndex(index, state);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableTextIndex.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/Sprites/DrawableTextIndex.cs
@@ -1,11 +1,9 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Graphics.Shapes;
+using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
 
@@ -20,12 +18,7 @@ public partial class DrawableTextIndex : RightTriangle
         {
             state = value;
 
-            RightAngleDirection = state switch
-            {
-                TextIndex.IndexState.Start => TriangleRightAngleDirection.BottomLeft,
-                TextIndex.IndexState.End => TriangleRightAngleDirection.BottomRight,
-                _ => throw new ArgumentOutOfRangeException(nameof(value))
-            };
+            RightAngleDirection = TextIndexUtils.GetValueByState(state, TriangleRightAngleDirection.BottomLeft, TriangleRightAngleDirection.BottomRight);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
@@ -69,7 +69,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
             float startPosition = GetTextIndexPosition(new TextIndex(charIndex)).X;
             float endPosition = GetTextIndexPosition(new TextIndex(charIndex, TextIndex.IndexState.End)).X;
 
-            return TextIndexUtils.GetValueByState(textIndex, startPosition + (endPosition - startPosition) / 2, endPosition);
+            return TextIndexUtils.GetValueByState(textIndex, () => startPosition + (endPosition - startPosition) / 2, () => endPosition);
         }
     }
 
@@ -108,7 +108,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
         static float extraSpacing(IList<TimeTag> timeTagsInLyric, TimeTag timeTag)
         {
             var textIndex = timeTag.Index;
-            var timeTags = TextIndexUtils.GetValueByState(textIndex, timeTagsInLyric.Reverse(), timeTagsInLyric);
+            var timeTags = TextIndexUtils.GetValueByState(textIndex, timeTagsInLyric.Reverse, () => timeTagsInLyric);
             int duplicatedTagAmount = timeTags.SkipWhile(t => t != timeTag).Count(x => x.Index == textIndex) - 1;
             int spacing = duplicatedTagAmount * time_tag_spacing * TextIndexUtils.GetValueByState(textIndex, 1, -1);
             return spacing;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
@@ -69,10 +69,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
             float startPosition = GetTextIndexPosition(new TextIndex(charIndex)).X;
             float endPosition = GetTextIndexPosition(new TextIndex(charIndex, TextIndex.IndexState.End)).X;
 
-            if (textIndex.State == TextIndex.IndexState.Start)
-                return startPosition + (endPosition - startPosition) / 2;
-
-            return endPosition;
+            return TextIndexUtils.GetValueByState(textIndex, startPosition + (endPosition - startPosition) / 2, endPosition);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -135,27 +135,19 @@ public static class LyricUtils
 
         var timeTags = lyric.TimeTags;
 
-        switch (index.State)
+        return TextIndexUtils.GetValueByState(index, () =>
         {
-            case TextIndex.IndexState.Start:
-            {
-                var nextTimeTag = timeTags.FirstOrDefault(x => x.Index > index);
-                int startIndex = index.Index;
-                int endIndex = TextIndexUtils.ToStringIndex(nextTimeTag?.Index ?? new TextIndex(text.Length));
-                return $"{text.Substring(startIndex, endIndex - startIndex)}-";
-            }
-
-            case TextIndex.IndexState.End:
-            {
-                var previousTimeTag = timeTags.Reverse().FirstOrDefault(x => x.Index < index);
-                int startIndex = previousTimeTag?.Index.Index ?? 0;
-                int endIndex = index.Index + 1;
-                return $"-{text.Substring(startIndex, endIndex - startIndex)}";
-            }
-
-            default:
-                throw new InvalidEnumArgumentException(nameof(index.State));
-        }
+            var nextTimeTag = timeTags.FirstOrDefault(x => x.Index > index);
+            int startIndex = index.Index;
+            int endIndex = TextIndexUtils.ToStringIndex(nextTimeTag?.Index ?? new TextIndex(text.Length));
+            return $"{text.Substring(startIndex, endIndex - startIndex)}-";
+        }, () =>
+        {
+            var previousTimeTag = timeTags.Reverse().FirstOrDefault(x => x.Index < index);
+            int startIndex = previousTimeTag?.Index.Index ?? 0;
+            int endIndex = index.Index + 1;
+            return $"-{text.Substring(startIndex, endIndex - startIndex)}";
+        });
     }
 
     public static string GetTimeTagDisplayText(Lyric lyric, TimeTag timeTag)
@@ -175,13 +167,9 @@ public static class LyricUtils
         var matchRuby = lyric.RubyTags.Where(x =>
         {
             int stringIndex = TextIndexUtils.ToStringIndex(timeTag.Index);
-
-            return state switch
-            {
-                TextIndex.IndexState.Start => x.StartIndex <= stringIndex && x.EndIndex > stringIndex,
-                TextIndex.IndexState.End => x.StartIndex < stringIndex && x.EndIndex >= stringIndex,
-                _ => throw new InvalidEnumArgumentException(nameof(state))
-            };
+            return TextIndexUtils.GetValueByState(state,
+                () => x.StartIndex <= stringIndex && x.EndIndex > stringIndex,
+                () => x.StartIndex < stringIndex && x.EndIndex >= stringIndex);
         }).FirstOrDefault();
 
         if (matchRuby == null || string.IsNullOrEmpty(matchRuby.Text))

--- a/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/LyricUtils.cs
@@ -202,12 +202,7 @@ public static class LyricUtils
         string subtext = timeTagsWithSameIndex.Count == 1 ? text : text.Substring(Math.Min(text.Length - 1, index), 1);
 
         // return substring with format.
-        return state switch
-        {
-            TextIndex.IndexState.Start => $"({subtext})-",
-            TextIndex.IndexState.End => $"-({subtext})",
-            _ => throw new InvalidEnumArgumentException(nameof(state))
-        };
+        return TextIndexUtils.GetValueByState(state, $"({subtext})-", $"-({subtext})");
     }
 
     #endregion

--- a/osu.Game.Rulesets.Karaoke/Utils/TextIndexUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextIndexUtils.cs
@@ -18,7 +18,7 @@ public static class TextIndexUtils
 
     public static TextIndex.IndexState ReverseState(TextIndex.IndexState state)
     {
-        return state == TextIndex.IndexState.Start ? TextIndex.IndexState.End : TextIndex.IndexState.Start;
+        return GetValueByState(state, TextIndex.IndexState.End, TextIndex.IndexState.Start);
     }
 
     public static TextIndex GetPreviousIndex(TextIndex originIndex)
@@ -47,11 +47,14 @@ public static class TextIndexUtils
     }
 
     public static T GetValueByState<T>(TextIndex index, T startValue, T endValue) =>
-        index.State switch
+        GetValueByState(index.State, startValue, endValue);
+
+    public static T GetValueByState<T>(TextIndex.IndexState state, T startValue, T endValue) =>
+        state switch
         {
             TextIndex.IndexState.Start => startValue,
             TextIndex.IndexState.End => endValue,
-            _ => throw new ArgumentOutOfRangeException(nameof(index))
+            _ => throw new ArgumentOutOfRangeException(nameof(state))
         };
 
     /// <summary>

--- a/osu.Game.Rulesets.Karaoke/Utils/TextIndexUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/TextIndexUtils.cs
@@ -57,6 +57,17 @@ public static class TextIndexUtils
             _ => throw new ArgumentOutOfRangeException(nameof(state))
         };
 
+    public static T GetValueByState<T>(TextIndex index, Func<T> startValue, Func<T> endValue) =>
+        GetValueByState(index.State, startValue, endValue);
+
+    public static T GetValueByState<T>(TextIndex.IndexState state, Func<T> startValue, Func<T> endValue) =>
+        state switch
+        {
+            TextIndex.IndexState.Start => startValue(),
+            TextIndex.IndexState.End => endValue(),
+            _ => throw new ArgumentOutOfRangeException(nameof(state))
+        };
+
     /// <summary>
     /// Display string with position format
     /// </summary>


### PR DESCRIPTION
Should use:
```csharp
var value = TextIndexUtils.GetValueByState(textIndex, startValue, endValue);
```

to replace:
```csharp
var value =  state switch
{
    TextIndex.IndexState.Start => startValue,
    TextIndex.IndexState.End => endValue,
    _ => throw new ArgumentOutOfRangeException(nameof(state))
};
```