### PR TITLE
Refactor caret position provide method

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/Components/TestSceneInteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/Components/TestSceneInteractableKaraokeSpriteText.cs
@@ -1,7 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
+using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
@@ -22,6 +23,9 @@ public partial class TestSceneInteractableKaraokeSpriteText : OsuTestScene
 {
     private InteractableKaraokeSpriteText karaokeSpriteText = null!;
     private Container mask = null!;
+    private OsuSpriteText spriteText = null!;
+
+    private Action? updateAction;
 
     private readonly Lyric lyric;
 
@@ -34,6 +38,12 @@ public partial class TestSceneInteractableKaraokeSpriteText : OsuTestScene
             RubyTags = TestCaseTagHelper.ParseRubyTags(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }),
             RomajiTags = TestCaseTagHelper.ParseRomajiTags(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }),
         };
+    }
+
+    protected override void Update()
+    {
+        updateAction?.Invoke();
+        base.Update();
     }
 
     [BackgroundDependencyLoader]
@@ -65,6 +75,12 @@ public partial class TestSceneInteractableKaraokeSpriteText : OsuTestScene
                         Colour = colour.RedDarker,
                         Alpha = 0.3f
                     }
+                },
+                spriteText = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Font = OsuFont.GetFont(size: 20),
                 }
             }
         };
@@ -75,34 +91,201 @@ public partial class TestSceneInteractableKaraokeSpriteText : OsuTestScene
     {
         Schedule(() =>
         {
+            updateAction = null;
+
             mask.Hide();
+            spriteText.Hide();
         });
     }
+
+    #region Text char index
+
+    [Test]
+    public void TestGetCharIndexByPosition()
+    {
+        AddStep("Show Char index Position", () =>
+        {
+            triggerUpdate(() =>
+            {
+                var mousePosition = getMousePosition();
+                int? charIndex = karaokeSpriteText.GetCharIndexByPosition(mousePosition.X);
+                updateText(charIndex.ToString());
+
+                if (charIndex == null)
+                {
+                    hidePosition();
+                }
+                else
+                {
+                    var position = karaokeSpriteText.GetRectByCharIndex(charIndex.Value);
+                    showPosition(position);
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void TestGetRectByCharIndex()
+    {
+        for (int i = 0; i < lyric.Text.Length; i++)
+        {
+            int charIndex = i;
+            AddStep($"Show Char index Position {i}", () =>
+            {
+                var position = karaokeSpriteText.GetRectByCharIndex(charIndex);
+                showPosition(position);
+            });
+        }
+    }
+
+    #endregion
+
+    #region Text indicator
+
+    [Test]
+    public void TestGetCharIndicatorByPosition()
+    {
+        AddStep("Show char indicator position", () =>
+        {
+            triggerUpdate(() =>
+            {
+                var mousePosition = getMousePosition();
+                int charIndex = karaokeSpriteText.GetCharIndicatorByPosition(mousePosition.X);
+                updateText(charIndex.ToString());
+
+                var position = karaokeSpriteText.GetRectByCharIndicator(charIndex);
+                showPosition(position);
+            });
+        });
+    }
+
+    [Test]
+    public void TestGetRectByCharIndicator()
+    {
+        for (int i = 0; i <= lyric.Text.Length; i++)
+        {
+            int charIndex = i;
+            AddStep($"Show char indicator position: {i}", () =>
+            {
+                var position = karaokeSpriteText.GetRectByCharIndicator(charIndex);
+                showPosition(position);
+            });
+        }
+    }
+
+    #endregion
+
+    #region Ruby tag
 
     [Test]
     public void TestGetRubyPosition()
     {
         foreach (var rubyTag in lyric.RubyTags)
         {
-            AddStep($"Show Ruby Position {TextTagUtils.PositionFormattedString(rubyTag)}", () =>
+            AddStep($"Show ruby-tag position: {TextTagUtils.PositionFormattedString(rubyTag)}", () =>
             {
-                var position = karaokeSpriteText.GetTextTagPosition(rubyTag);
+                var position = karaokeSpriteText.GetTextTagByPosition(rubyTag);
                 showPosition(position);
             });
         }
     }
 
+    #endregion
+
+    #region Romaji tag
+
     [Test]
-    public void TestGetRomajiPosition()
+    public void TestGetRomajiTagPosition()
     {
         foreach (var romajiTag in lyric.RomajiTags)
         {
-            AddStep($"Show Romaji Position {TextTagUtils.PositionFormattedString(romajiTag)}", () =>
+            AddStep($"Show romaji-tag position: {TextTagUtils.PositionFormattedString(romajiTag)}", () =>
             {
-                var position = karaokeSpriteText.GetTextTagPosition(romajiTag);
+                var position = karaokeSpriteText.GetTextTagByPosition(romajiTag);
                 showPosition(position);
             });
         }
+    }
+
+    #endregion
+
+    #region Time tag
+
+    [Test]
+    public void TestGetTimeTagByPosition()
+    {
+        AddStep("Show time-tag position", () =>
+        {
+            triggerUpdate(() =>
+            {
+                var mousePosition = getMousePosition();
+                var timeTag = karaokeSpriteText.GetTimeTagByPosition(mousePosition.X);
+                updateText(timeTag != null ? TimeTagUtils.FormattedString(timeTag) : null);
+
+                if (timeTag == null)
+                {
+                    hidePosition();
+                }
+                else
+                {
+                    var position = karaokeSpriteText.GetPositionByTimeTag(timeTag);
+                    showPosition(position);
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void TestGetPositionByTimeTag()
+    {
+        foreach (var timeTag in lyric.TimeTags)
+        {
+            AddStep($"Show time-tag position {TimeTagUtils.FormattedString(timeTag)}", () =>
+            {
+                var position = karaokeSpriteText.GetPositionByTimeTag(timeTag);
+                showPosition(position);
+            });
+        }
+    }
+
+    #endregion
+
+    [TearDown]
+    public void TearDown()
+    {
+        Schedule(() =>
+        {
+            updateAction = null;
+        });
+    }
+
+    private Vector2 getMousePosition()
+    {
+        var position = GetContainingInputManager().CurrentState.Mouse.Position;
+        return karaokeSpriteText.ToLocalSpace(position);
+    }
+
+    private void triggerUpdate(Action action)
+    {
+        updateAction = action;
+    }
+
+    private void updateText(string? text)
+    {
+        spriteText.Text = text ?? "-";
+
+        spriteText.Show();
+    }
+
+    private void hidePosition()
+    {
+        mask.Hide();
+    }
+
+    private void showPosition(Vector2 position)
+    {
+        const float sizing = 5;
+        showPosition(new RectangleF(position.X - sizing / 2, position.Y - sizing / 2, sizing, sizing));
     }
 
     private void showPosition(RectangleF position)

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/Components/TestSceneInteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/Components/TestSceneInteractableKaraokeSpriteText.cs
@@ -1,0 +1,115 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics;
+using osu.Game.Rulesets.Karaoke.Tests.Helper;
+using osu.Game.Rulesets.Karaoke.Utils;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Beatmap.Lyrics.Components;
+
+public partial class TestSceneInteractableKaraokeSpriteText : OsuTestScene
+{
+    private InteractableKaraokeSpriteText karaokeSpriteText = null!;
+    private Container mask = null!;
+
+    private readonly Lyric lyric;
+
+    public TestSceneInteractableKaraokeSpriteText()
+    {
+        lyric = new Lyric
+        {
+            Text = "カラオケ",
+            TimeTags = TestCaseTagHelper.ParseTimeTags(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" }),
+            RubyTags = TestCaseTagHelper.ParseRubyTags(new[] { "[0,1]:か", "[1,2]:ら", "[2,3]:お", "[3,4]:け" }),
+            RomajiTags = TestCaseTagHelper.ParseRomajiTags(new[] { "[0,1]:ka", "[1,2]:ra", "[2,3]:o", "[3,4]:ke" }),
+        };
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(OsuColour colour)
+    {
+        Child = new Container
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Scale = new Vector2(2),
+            Width = 200,
+            Height = 100,
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colour.BlueDarker,
+                },
+                karaokeSpriteText = new InteractableKaraokeSpriteText(lyric),
+                mask = new Container
+                {
+                    Masking = true,
+                    BorderThickness = 1,
+                    BorderColour = colour.RedDarker,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colour.RedDarker,
+                        Alpha = 0.3f
+                    }
+                }
+            }
+        };
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        Schedule(() =>
+        {
+            mask.Hide();
+        });
+    }
+
+    [Test]
+    public void TestGetRubyPosition()
+    {
+        foreach (var rubyTag in lyric.RubyTags)
+        {
+            AddStep($"Show Ruby Position {TextTagUtils.PositionFormattedString(rubyTag)}", () =>
+            {
+                var position = karaokeSpriteText.GetTextTagPosition(rubyTag);
+                showPosition(position);
+            });
+        }
+    }
+
+    [Test]
+    public void TestGetRomajiPosition()
+    {
+        foreach (var romajiTag in lyric.RomajiTags)
+        {
+            AddStep($"Show Romaji Position {TextTagUtils.PositionFormattedString(romajiTag)}", () =>
+            {
+                var position = karaokeSpriteText.GetTextTagPosition(romajiTag);
+                showPosition(position);
+            });
+        }
+    }
+
+    private void showPosition(RectangleF position)
+    {
+        mask.Position = position.TopLeft;
+        mask.Size = position.Size;
+
+        mask.Show();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/ITextTagCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/ITextTagCaretPosition.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
-// See the LICENCE file in the repository root for full licence text.
-
-namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
-
-public interface ITextTagCaretPosition : IIndexCaretPosition
-{
-}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagBlueprintContainer.cs
@@ -129,7 +129,7 @@ public abstract partial class TextTagBlueprintContainer<T> : BindableBlueprintCo
         private int calculateNewIndex(T textTag, float offset, Anchor anchor)
         {
             // get real left-side and right-side position
-            var rect = karaokeSpriteText.GetTextTagPosition(textTag);
+            var rect = karaokeSpriteText.GetTextTagByPosition(textTag);
 
             switch (anchor)
             {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagBlueprintContainer.cs
@@ -135,11 +135,11 @@ public abstract partial class TextTagBlueprintContainer<T> : BindableBlueprintCo
             {
                 case Anchor.CentreLeft:
                     float leftPosition = rect.Left + offset;
-                    return TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(leftPosition));
+                    return karaokeSpriteText.GetCharIndicatorByPosition(leftPosition);
 
                 case Anchor.CentreRight:
                     float rightPosition = rect.Right + offset;
-                    return TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(rightPosition));
+                    return karaokeSpriteText.GetCharIndicatorByPosition(rightPosition);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(anchor));

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TextTagSelectionBlueprint.cs
@@ -74,17 +74,17 @@ public abstract partial class TextTagSelectionBlueprint<T> : SelectionBlueprint<
         // wait until lyric update ruby position.
         ScheduleAfterChildren(() =>
         {
-            var textTagRect = karaokeSpriteText.GetTextTagPosition(Item);
+            var textTagRect = karaokeSpriteText.GetTextTagByPosition(Item);
 
-            var startIndexPosition = karaokeSpriteText.GetTextIndexPosition(TextIndexUtils.FromStringIndex(Item.StartIndex, false));
-            var endIndexPosition = karaokeSpriteText.GetTextIndexPosition(TextIndexUtils.FromStringIndex(Item.EndIndex, true));
+            var startRect = karaokeSpriteText.GetRectByCharIndicator(Item.StartIndex);
+            var endRect = karaokeSpriteText.GetRectByCharIndicator(Item.EndIndex);
 
             // update select position
             updateDrawableRect(previewTextArea, textTagRect);
 
             // update index range position.
-            var indexRangePosition = new Vector2(startIndexPosition.X, textTagRect.Y);
-            var indexRangeSize = new Vector2(endIndexPosition.X - startIndexPosition.X, textTagRect.Height);
+            var indexRangePosition = new Vector2(startRect.Right, textTagRect.Y);
+            var indexRangeSize = new Vector2(endRect.Left - startRect.Right, textTagRect.Height);
             updateDrawableRect(indexRangeBackground, new RectangleF(indexRangePosition, indexRangeSize));
         });
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TimeTagSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Blueprints/TimeTagSelectionBlueprint.cs
@@ -33,7 +33,7 @@ public partial class TimeTagSelectionBlueprint : SelectionBlueprint<TimeTag>
     private void updatePosition()
     {
         var size = new Vector2(time_tag_size);
-        var position = karaokeSpriteText.GetTimeTagPosition(Item) - size / 2;
+        var position = karaokeSpriteText.GetPositionByTimeTag(Item) - size / 2;
 
         X = position.X;
         Y = position.Y;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCuttingCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCuttingCaret.cs
@@ -93,8 +93,10 @@ public partial class DrawableCuttingCaret : DrawableTextCaret<CuttingCaretPositi
 
     protected override void Apply(CuttingCaretPosition caret)
     {
-        Position = GetPosition(caret);
-        Height = karaokeSpriteText.LineBaseHeight;
+        var rect = GetRect(caret);
+
+        Position = rect.TopLeft;
+        Height = rect.Height;
     }
 
     public override void TriggerDisallowEditEffect(LyricEditorMode editorMode)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTextCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTextCaret.cs
@@ -4,9 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
-using osu.Game.Rulesets.Karaoke.Utils;
-using osuTK;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics.Carets;
 
@@ -20,11 +19,8 @@ public abstract partial class DrawableTextCaret<TCaretPosition> : DrawableCaret<
     {
     }
 
-    protected Vector2 GetPosition(TCaretPosition caret)
+    protected RectangleF GetRect(TCaretPosition caret)
     {
-        float textHeight = karaokeSpriteText.LineBaseHeight;
-        bool end = caret.Index == caret.Lyric.Text.Length;
-        var originPosition = karaokeSpriteText.GetTextIndexPosition(TextIndexUtils.FromStringIndex(caret.Index, end));
-        return new Vector2(originPosition.X, originPosition.Y - textHeight);
+        return karaokeSpriteText.GetRectByCharIndicator(caret.Index);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTimeTagCaret.cs
@@ -43,7 +43,7 @@ public partial class DrawableTimeTagCaret : DrawableCaret<TimeTagCaretPosition>
     {
         var timeTag = caret.TimeTag;
         var textIndex = timeTag.Index;
-        this.MoveTo(karaokeSpriteText.GetTimeTagPosition(timeTag), getMoveToDuration(Type), Easing.OutCubic);
+        this.MoveTo(karaokeSpriteText.GetPositionByTimeTag(timeTag), getMoveToDuration(Type), Easing.OutCubic);
         Origin = TextIndexUtils.GetValueByState(textIndex, Anchor.BottomLeft, Anchor.BottomRight);
 
         drawableTextIndex.State = textIndex.State;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
@@ -115,8 +115,10 @@ public partial class DrawableTypingCaret : DrawableTextCaret<TypingCaretPosition
     {
         caretPosition = caret;
 
-        Height = karaokeSpriteText.LineBaseHeight;
-        var position = GetPosition(caret);
+        var rect = GetRect(caret);
+
+        Height = rect.Height;
+        var position = rect.TopLeft;
 
         bool displayAnimation = Alpha > 0;
         int time = displayAnimation ? 60 : 0;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
@@ -188,12 +188,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
 
     #endregion
 
-    public TimeTag? GetHoverTimeTag(float position)
-    {
-        var textIndex = GetHoverIndex(position);
-        return HitObject.TimeTags.FirstOrDefault(x => x.Index == textIndex);
-    }
-
+    // todo: will remove this method eventually.
     public TextIndex GetHoverIndex(float position)
     {
         string text = Text;
@@ -211,35 +206,18 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
 
         return new TextIndex(text.Length - 1, TextIndex.IndexState.End);
 
-        // todo : might have a better way to call GetTextIndexPosition just once.
+        // todo : might have a better way to call spriteText.GetTimeTagPosition just once.
         float getTriggerPositionByTimeIndex(TextIndex textIndex)
         {
             int charIndex = textIndex.Index;
-            float startPosition = GetTextIndexPosition(new TextIndex(charIndex)).X;
-            float endPosition = GetTextIndexPosition(new TextIndex(charIndex, TextIndex.IndexState.End)).X;
+            float startPosition = spriteText.GetTimeTagPosition(new TextIndex(charIndex)).X;
+            float endPosition = spriteText.GetTimeTagPosition(new TextIndex(charIndex, TextIndex.IndexState.End)).X;
 
             return TextIndexUtils.GetValueByState(textIndex, () => startPosition + (endPosition - startPosition) / 2, () => endPosition);
         }
     }
 
-    public float LineBaseHeight => spriteText.LineBaseHeight;
-
-    public Vector2 GetTimeTagPosition(TimeTag timeTag)
-    {
-        var basePosition = GetTextIndexPosition(timeTag.Index);
-        float extraPosition = extraSpacing(HitObject.TimeTags, timeTag);
-        return basePosition + new Vector2(extraPosition, 0);
-
-        static float extraSpacing(IList<TimeTag> timeTagsInLyric, TimeTag timeTag)
-        {
-            var textIndex = timeTag.Index;
-            var timeTags = TextIndexUtils.GetValueByState(textIndex, timeTagsInLyric.Reverse, () => timeTagsInLyric);
-            int duplicatedTagAmount = timeTags.SkipWhile(t => t != timeTag).Count(x => x.Index == textIndex) - 1;
-            int spacing = duplicatedTagAmount * time_tag_spacing * TextIndexUtils.GetValueByState(textIndex, 1, -1);
-            return spacing;
-        }
-    }
-
+    // todo: will remove this method eventually.
     public Vector2 GetTextIndexPosition(TextIndex index) => spriteText.GetTimeTagPosition(index);
 
     [BackgroundDependencyLoader(true)]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +26,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
 
     public Lyric HitObject;
 
-    public Action SizeChanged;
+    public Action? SizeChanged = null;
 
     private readonly EditorLyricSpriteText spriteText;
 
@@ -51,10 +49,149 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
         }
     }
 
-    public TimeTag GetHoverTimeTag(float position)
+    #region Text char index
+
+    public int? GetCharIndexByPosition(float position)
+    {
+        for (int i = 0; i < Text.Length; i++)
+        {
+            (double startX, double endX) = getTriggerPositionByTimeIndex(i);
+            if (position >= startX && position <= endX)
+                return i;
+        }
+
+        return null;
+
+        Tuple<double, double> getTriggerPositionByTimeIndex(int charIndex)
+        {
+            var rectangle = spriteText.GetCharacterDrawRectangle(charIndex);
+            return new Tuple<double, double>(rectangle.Left, rectangle.Right);
+        }
+    }
+
+    public RectangleF GetRectByCharIndex(int charIndex)
+    {
+        if (charIndex < 0 || charIndex >= Text.Length)
+            throw new ArgumentOutOfRangeException(nameof(charIndex));
+
+        return spriteText.GetCharacterDrawRectangle(charIndex);
+    }
+
+    #endregion
+
+    #region Text indicator
+
+    public int GetCharIndicatorByPosition(float position)
+    {
+        for (int i = 0; i < Text.Length; i++)
+        {
+            float textCenterPosition = getTriggerPositionByTimeIndex(i);
+            if (position < textCenterPosition)
+                return i;
+        }
+
+        return Text.Length;
+
+        float getTriggerPositionByTimeIndex(int charIndex)
+        {
+            var rectangle = spriteText.GetCharacterDrawRectangle(charIndex);
+            return rectangle.Centre.X;
+        }
+    }
+
+    public RectangleF GetRectByCharIndicator(int charIndex)
+    {
+        if (charIndex < 0 || charIndex > Text.Length)
+            throw new ArgumentOutOfRangeException(nameof(charIndex));
+
+        const float min_spacing_width = 1;
+
+        if (charIndex == 0)
+        {
+            var referenceRectangle = spriteText.GetCharacterDrawRectangle(charIndex);
+            return new RectangleF(referenceRectangle.X - min_spacing_width, referenceRectangle.Y, min_spacing_width, referenceRectangle.Height);
+        }
+
+        if (charIndex == Text.Length)
+        {
+            var referenceRectangle = spriteText.GetCharacterDrawRectangle(charIndex - 1);
+            return new RectangleF(referenceRectangle.Right, referenceRectangle.Top, min_spacing_width, referenceRectangle.Height);
+        }
+
+        var leftRectangle = spriteText.GetCharacterDrawRectangle(charIndex - 1);
+        var rightRectangle = spriteText.GetCharacterDrawRectangle(charIndex);
+        return new RectangleF(leftRectangle.Right, leftRectangle.Top, rightRectangle.X - leftRectangle.Right, leftRectangle.Y);
+    }
+
+    #endregion
+
+    #region Ruby/Romaji tag
+
+    public RectangleF GetTextTagByPosition(ITextTag textTag) =>
+        textTag switch
+        {
+            RubyTag rubyTag => spriteText.GetRubyTagPosition(rubyTag),
+            RomajiTag romajiTag => spriteText.GetRomajiTagPosition(romajiTag),
+            _ => throw new ArgumentOutOfRangeException(nameof(textTag))
+        };
+
+    #endregion
+
+    #region Time tag
+
+    public TimeTag? GetTimeTagByPosition(float position)
+    {
+        // todo: will use better way to get the time-tag
+        var textIndex = getHoverIndex();
+        return HitObject.TimeTags.FirstOrDefault(x => x.Index == textIndex);
+
+        TextIndex getHoverIndex()
+        {
+            for (int i = 0; i < Text.Length; i++)
+            {
+                if (getTriggerPositionByTimeIndex(new TextIndex(i)) > position)
+                    return new TextIndex(i);
+
+                if (getTriggerPositionByTimeIndex(new TextIndex(i, TextIndex.IndexState.End)) > position)
+                    return new TextIndex(i, TextIndex.IndexState.End);
+            }
+
+            return new TextIndex(Text.Length - 1, TextIndex.IndexState.End);
+
+            // todo : might have a better way to call spriteText.GetTimeTagPosition just once.
+            float getTriggerPositionByTimeIndex(TextIndex textIndex)
+            {
+                int charIndex = textIndex.Index;
+                float startPosition = spriteText.GetTimeTagPosition(new TextIndex(charIndex)).X;
+                float endPosition = spriteText.GetTimeTagPosition(new TextIndex(charIndex, TextIndex.IndexState.End)).X;
+
+                return TextIndexUtils.GetValueByState(textIndex, () => startPosition + (endPosition - startPosition) / 2, () => endPosition);
+            }
+        }
+    }
+
+    public Vector2 GetPositionByTimeTag(TimeTag timeTag)
+    {
+        var basePosition = spriteText.GetTimeTagPosition(timeTag.Index);
+        float extraPosition = extraSpacing(HitObject.TimeTags, timeTag);
+        return basePosition + new Vector2(extraPosition, 0);
+
+        static float extraSpacing(IList<TimeTag> timeTagsInLyric, TimeTag timeTag)
+        {
+            var textIndex = timeTag.Index;
+            var timeTags = TextIndexUtils.GetValueByState(textIndex, timeTagsInLyric.Reverse, () => timeTagsInLyric);
+            int duplicatedTagAmount = timeTags.SkipWhile(t => t != timeTag).Count(x => x.Index == textIndex) - 1;
+            int spacing = duplicatedTagAmount * time_tag_spacing * TextIndexUtils.GetValueByState(textIndex, 1, -1);
+            return spacing;
+        }
+    }
+
+    #endregion
+
+    public TimeTag? GetHoverTimeTag(float position)
     {
         var textIndex = GetHoverIndex(position);
-        return HitObject?.TimeTags.FirstOrDefault(x => x.Index == textIndex);
+        return HitObject.TimeTags.FirstOrDefault(x => x.Index == textIndex);
     }
 
     public TextIndex GetHoverIndex(float position)
@@ -86,14 +223,6 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
     }
 
     public float LineBaseHeight => spriteText.LineBaseHeight;
-
-    public RectangleF GetTextTagPosition(ITextTag textTag) =>
-        textTag switch
-        {
-            RubyTag rubyTag => spriteText.GetRubyTagPosition(rubyTag),
-            RomajiTag romajiTag => spriteText.GetRomajiTagPosition(romajiTag),
-            _ => throw new ArgumentOutOfRangeException(nameof(textTag))
-        };
 
     public Vector2 GetTimeTagPosition(TimeTag timeTag)
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableKaraokeSpriteText.cs
@@ -30,6 +30,8 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
 
     public Action SizeChanged;
 
+    private readonly EditorLyricSpriteText spriteText;
+
     public InteractableKaraokeSpriteText(Lyric lyric)
         : base(lyric)
     {
@@ -37,6 +39,16 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
 
         DisplayRuby = true;
         DisplayRomaji = true;
+
+        spriteText = getSpriteText();
+
+        EditorLyricSpriteText getSpriteText()
+        {
+            if (InternalChildren.First() is not Container<EditorLyricSpriteText> lyricSpriteTexts)
+                throw new ArgumentNullException();
+
+            return lyricSpriteTexts.Child;
+        }
     }
 
     public TimeTag GetHoverTimeTag(float position)
@@ -73,31 +85,15 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
         }
     }
 
-    public float LineBaseHeight
-    {
-        get
-        {
-            var spriteText = getSpriteText();
-            if (spriteText == null)
-                throw new ArgumentNullException(nameof(spriteText));
+    public float LineBaseHeight => spriteText.LineBaseHeight;
 
-            return spriteText.LineBaseHeight;
-        }
-    }
-
-    public RectangleF GetTextTagPosition(ITextTag textTag)
-    {
-        var spriteText = getSpriteText();
-        if (spriteText == null)
-            throw new ArgumentNullException(nameof(spriteText));
-
-        return textTag switch
+    public RectangleF GetTextTagPosition(ITextTag textTag) =>
+        textTag switch
         {
             RubyTag rubyTag => spriteText.GetRubyTagPosition(rubyTag),
             RomajiTag romajiTag => spriteText.GetRomajiTagPosition(romajiTag),
             _ => throw new ArgumentOutOfRangeException(nameof(textTag))
         };
-    }
 
     public Vector2 GetTimeTagPosition(TimeTag timeTag)
     {
@@ -115,17 +111,7 @@ public partial class InteractableKaraokeSpriteText : DrawableKaraokeSpriteText<I
         }
     }
 
-    public Vector2 GetTextIndexPosition(TextIndex index)
-    {
-        var spriteText = getSpriteText();
-        if (spriteText == null)
-            throw new ArgumentNullException(nameof(spriteText));
-
-        return spriteText.GetTimeTagPosition(index);
-    }
-
-    private EditorLyricSpriteText getSpriteText()
-        => (InternalChildren.FirstOrDefault() as Container<EditorLyricSpriteText>)?.Child;
+    public Vector2 GetTextIndexPosition(TextIndex index) => spriteText.GetTimeTagPosition(index);
 
     [BackgroundDependencyLoader(true)]
     private void load(ISkinSource skin, ShaderManager shaderManager)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -85,12 +85,12 @@ public abstract partial class InteractableLyric : CompositeDrawable, IHasTooltip
         switch (lyricCaretState.CaretPosition)
         {
             case CuttingCaretPosition:
-                int cuttingLyricStringIndex = Math.Clamp(TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position)), 0, lyric.Text.Length - 1);
+                int cuttingLyricStringIndex = karaokeSpriteText.GetCharIndicatorByPosition(position);
                 lyricCaretState.MoveHoverCaretToTargetPosition(lyric, cuttingLyricStringIndex);
                 break;
 
             case TypingCaretPosition:
-                int typingStringIndex = TextIndexUtils.ToStringIndex(karaokeSpriteText.GetHoverIndex(position));
+                int typingStringIndex = karaokeSpriteText.GetCharIndicatorByPosition(position);
                 lyricCaretState.MoveHoverCaretToTargetPosition(lyric, typingStringIndex);
                 break;
 
@@ -104,7 +104,7 @@ public abstract partial class InteractableLyric : CompositeDrawable, IHasTooltip
                 break;
 
             case TimeTagCaretPosition:
-                var timeTag = karaokeSpriteText.GetHoverTimeTag(position);
+                var timeTag = karaokeSpriteText.GetTimeTagByPosition(position);
                 lyricCaretState.MoveHoverCaretToTargetPosition(lyric, timeTag);
                 break;
         }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/TimeTagLayer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/TimeTagLayer.cs
@@ -34,7 +34,7 @@ public partial class TimeTagLayer : BaseLayer
 
         foreach (var timeTag in timeTagsBindable)
         {
-            var position = karaokeSpriteText.GetTimeTagPosition(timeTag);
+            var position = karaokeSpriteText.GetPositionByTimeTag(timeTag);
             AddInternal(new DrawableTimeTag(timeTag)
             {
                 Position = position


### PR DESCRIPTION
What's done in this PR:
1. Add the test case for the `InteractableKaraokeSpriteText`.
2. Test case is able to show what's get by the position and see the element's rect or position.
3. Re-write the method for able to get the element or element position by different type(see: https://karaoke-dev.notion.site/Refactor-method-in-the-InteractableKaraokeSpriteText-35b05a5a55b64e5cbf5ae30a075f1917)
4. Remove some old interfaces and use the new one.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/9100368/236615923-2c69b138-0d0f-4d35-9d1e-6cdde1558a87.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/9100368/236615932-2c71426e-9b19-4a88-b12d-f34411d9f338.png">
And it's the demo that we can get the rect by character or indicator(spacing between characters).