### PR TITLE
Adjust permit null in dependency injection

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Components/UserInterfaceV2/NoteEditPopover.cs
@@ -103,7 +103,7 @@ public partial class NoteEditPopover : OsuPopover
             });
         }
 
-        [BackgroundDependencyLoader(true)]
+        [BackgroundDependencyLoader]
         private void load(HitObjectComposer composer)
         {
             // todo: not a good way to get change handler, might remove or found another way eventually.

--- a/osu.Game.Rulesets.Karaoke/Edit/EditorNotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/EditorNotePlayfield.cs
@@ -40,7 +40,7 @@ public partial class EditorNotePlayfield : ScrollingNotePlayfield
         });
     }
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load()
     {
         // todo : load data from scoring manager.

--- a/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
@@ -36,7 +36,7 @@ public partial class KaraokeInputManager : RulesetInputManager<KaraokeScoringAct
 
     private IBeatmap beatmap;
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(KaraokeRulesetConfigManager config, IBindable<IReadOnlyList<Mod>> mods, IBindable<WorkingBeatmap> beatmap, KaraokeSessionStatics session, EditorBeatmap editorBeatmap)
     {
         if (editorBeatmap != null)

--- a/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeInputManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,10 +32,10 @@ public partial class KaraokeInputManager : RulesetInputManager<KaraokeScoringAct
         UseParentInput = false;
     }
 
-    private IBeatmap beatmap;
+    private IBeatmap beatmap = null!;
 
     [BackgroundDependencyLoader]
-    private void load(KaraokeRulesetConfigManager config, IBindable<IReadOnlyList<Mod>> mods, IBindable<WorkingBeatmap> beatmap, KaraokeSessionStatics session, EditorBeatmap editorBeatmap)
+    private void load(KaraokeRulesetConfigManager config, IBindable<IReadOnlyList<Mod>> mods, IBindable<WorkingBeatmap> beatmap, KaraokeSessionStatics session, EditorBeatmap? editorBeatmap)
     {
         if (editorBeatmap != null)
         {

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableKaraokeScrollingHitObject.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableKaraokeScrollingHitObject.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -23,8 +22,8 @@ public abstract partial class DrawableKaraokeScrollingHitObject : DrawableHitObj
     {
     }
 
-    [BackgroundDependencyLoader(true)]
-    private void load([NotNull] IScrollingInfo scrollingInfo)
+    [BackgroundDependencyLoader]
+    private void load(IScrollingInfo scrollingInfo)
     {
         Direction.BindTo(scrollingInfo.Direction);
         Direction.BindValueChanged(OnDirectionChanged, true);

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/ChangelogSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/ChangelogSection.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Platform;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/LyricComposer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/LyricComposer.cs
@@ -152,8 +152,8 @@ public partial class LyricComposer : CompositeDrawable
         }
     }
 
-    [BackgroundDependencyLoader(true)]
-    private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager, ILyricEditorState state, ITimeTagModeState timeTagModeState)
+    [BackgroundDependencyLoader]
+    private void load(KaraokeRulesetLyricEditorConfigManager lyricEditorConfigManager, ILyricEditorState state)
     {
         lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.ShowPropertyPanelInComposer, panelStatus[PanelType.Property]);
         lyricEditorConfigManager.BindWith(KaraokeRulesetLyricEditorSetting.ShowInvalidInfoInComposer, panelStatus[PanelType.InvalidInfo]);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/Panel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/Panel.cs
@@ -57,7 +57,7 @@ public abstract partial class Panel : FocusedOverlayContainer
 
     protected abstract IReadOnlyList<Drawable> CreateSections();
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider, AudioManager audio)
     {
         bindableMode.BindTo(state.BindableMode);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/SpecialActionToolbar.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/SpecialActionToolbar.cs
@@ -54,7 +54,7 @@ public partial class SpecialActionToolbar : CompositeDrawable
         };
     }
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider)
     {
         bindableModeAndSubMode.BindTo(state.BindableModeAndSubMode);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/Toolbar/Separator.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/Toolbar/Separator.cs
@@ -25,7 +25,7 @@ public partial class Separator : CompositeDrawable
         };
     }
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(ILyricEditorState state, LyricEditorColourProvider colourProvider)
     {
         bindableMode.BindValueChanged(x =>

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/LyricEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/LyricEditorVerifier.cs
@@ -72,7 +72,7 @@ public partial class LyricEditorVerifier : EditorVerifier<LyricEditorMode>, ILyr
         recalculateIssues();
     }
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(KaraokeRulesetEditCheckerConfigManager? rulesetEditCheckerConfigManager)
     {
         // todo: adjust the config in the config.

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/LyricPlacementRow.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/LyricPlacementRow.cs
@@ -3,14 +3,12 @@
 
 #nullable disable
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
-using osu.Game.Rulesets.Karaoke.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Singers.Rows;
 
@@ -25,8 +23,8 @@ public abstract partial class LyricPlacementColumn : CompositeDrawable
         this.singer = singer;
     }
 
-    [BackgroundDependencyLoader(true)]
-    private void load(OverlayColourProvider colourProvider, [CanBeNull] KaraokeHitObjectComposer composer)
+    [BackgroundDependencyLoader]
+    private void load(OverlayColourProvider colourProvider)
     {
         InternalChildren = new Drawable[]
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/Components/DrawableDragFile.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/Components/DrawableDragFile.cs
@@ -26,7 +26,7 @@ public partial class DrawableDragFile : Container
 
     private RoundedButton importButton;
 
-    [BackgroundDependencyLoader(true)]
+    [BackgroundDependencyLoader]
     private void load(OsuColour colours)
     {
         Masking = true;

--- a/osu.Game.Rulesets.Karaoke/UI/NotePlayfield.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/NotePlayfield.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -211,8 +210,8 @@ public partial class NotePlayfield : ScrollingNotePlayfield, IKeyBindingHandler<
         explosion.Delay(200).Expire(true);
     }
 
-    [BackgroundDependencyLoader(true)]
-    private void load([CanBeNull] KaraokeSessionStatics session)
+    [BackgroundDependencyLoader]
+    private void load(KaraokeSessionStatics? session)
     {
         session?.BindWith(KaraokeRulesetSession.ScoringPitch, scoringPitch);
 


### PR DESCRIPTION
Part of #1986.
Should use `[BackgroundDependencyLoader]` instead of `[BackgroundDependencyLoader(true)]` eventually.

see:
https://github.com/ppy/osu/pull/22233/commits/9b5d6b391bfc70f3d290aea7bceaaf9fc5cb5876

Or see the CreateActivator() inside the BackgroundDependencyLoaderAttribute, it's ok not make the `permitNulls` as true if the param is nullable.
```csharp
bool permitNulls = attribute.permitNulls;
                    var parameterGetters = method.GetParameters()
                                                 .Select(parameter => getDependency(parameter.ParameterType, type, permitNulls || parameter.IsNullable())).ToArray();

```