### PR TITLE
Fix the broken preview area in the setting menu.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/NotePlayfieldPreview.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Lists;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -61,12 +62,23 @@ public partial class NotePlayfieldPreview : SettingsSubsectionPreview
         lastCreateSampleTime = Time.Current;
 
         double startTime = Time.Current + 3000;
+        const double duration = 1000;
         notePlayfield.Add(new Note
         {
-            StartTime = startTime,
-            Duration = 1000,
             Text = "Note",
-            ReferenceLyric = new Lyric(),
+            ReferenceLyricId = 1,
+            ReferenceLyric = new Lyric
+            {
+                ID = 1,
+                StartTime = startTime,
+                Duration = duration,
+                Text = "Note",
+                TimeTags = new List<TimeTag>
+                {
+                    new(new TextIndex(0), startTime),
+                    new(new TextIndex(4), startTime + duration),
+                }
+            },
             HitWindows = new KaraokeNoteHitWindows(),
         });
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricEffectApplier.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricEffectApplier.cs
@@ -1,0 +1,62 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
+using osu.Game.Rulesets.Karaoke.Objects.Drawables;
+using osu.Game.Rulesets.Karaoke.Objects.Stages;
+using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
+using Anchor = osu.Framework.Graphics.Anchor;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay;
+
+/// <summary>
+/// Effect applier for single lyric.
+/// </summary>
+public class PreviewLyricEffectApplier : LyricStageEffectApplier<PreviewLyricStageDefinition>
+{
+    public PreviewLyricEffectApplier()
+        : base(new StageElement[] { new PreviewLyricStageElement() }, new PreviewLyricStageDefinition())
+    {
+    }
+
+    protected override double GetPreemptTime(IEnumerable<StageElement> elements)
+    {
+        return 0;
+    }
+
+    protected override void UpdateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
+    {
+        switch (element)
+        {
+            case PreviewLyricStageElement previewLyricLayout:
+                updateInitialTransforms(transformSequence, previewLyricLayout);
+                break;
+
+            default:
+                throw new NotSupportedException();
+        }
+    }
+
+    private void updateInitialTransforms(TransformSequence<DrawableLyric> transformSequence, PreviewLyricStageElement element)
+    {
+        transformSequence.TransformTo(nameof(DrawableLyric.Anchor), Anchor.Centre)
+                         .TransformTo(nameof(DrawableLyric.Origin), Anchor.Centre)
+                         .TransformTo(nameof(DrawableLyric.Scale), new Vector2(2))
+                         .FadeIn(100);
+    }
+
+    protected override void UpdateStartTimeStateTransforms(TransformSequence<DrawableLyric> transformSequence, StageElement element)
+    {
+        // there's no transformer in here.
+    }
+
+    protected override void UpdateHitStateTransforms(TransformSequence<DrawableLyric> transformSequence, ArmedState state, StageElement element)
+    {
+        transformSequence.FadeOut(100);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricStageDefinition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricStageDefinition.cs
@@ -1,0 +1,13 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay;
+
+/// <summary>
+/// Definition for preview single lyric.
+/// </summary>
+public class PreviewLyricStageDefinition : StageDefinition
+{
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricStageElement.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/PreviewLyricStageElement.cs
@@ -1,0 +1,14 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Beatmaps.Stages;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay;
+
+public class PreviewLyricStageElement : StageElement
+{
+    public PreviewLyricStageElement()
+        : base(0)
+    {
+    }
+}


### PR DESCRIPTION
What's done in this PR:
1. Create the stage applier and stage element for the preview area. This applier can be used to the skin editor if needed.
2. Fix the crash issue in the preview lyric area.
3. Fix the crash issue in the preview note area.