### PR TITLE
Remove assign language in the main setting overlay.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/ConfigSection.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/ConfigSection.cs
@@ -25,6 +25,7 @@ public partial class ConfigSection : KaraokeSettingsSection
             new NoteSettings(),
             new LyricSettings(),
             new TranslateSettings(),
+            new PracticeSettings(),
         };
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/PracticeSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/PracticeSettings.cs
@@ -1,0 +1,30 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Localisation;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Sections.Gameplay;
+
+public partial class PracticeSettings : KaraokeSettingsSubsection
+{
+    protected override LocalisableString Header => "Practice mode";
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Children = new Drawable[]
+        {
+            new SettingsSlider<double, TimeSlider>
+            {
+                LabelText = KaraokeSettingsSubsectionStrings.PracticePreemptTime,
+                Current = Config.GetBindable<double>(KaraokeRulesetSetting.PracticePreemptTime)
+            },
+        };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -73,11 +73,6 @@ public partial class KaraokeSettingsSubsection : RulesetSettingsSubsection
                 Current = config.GetBindable<string>(KaraokeRulesetSetting.MicrophoneDevice)
             },
             // Practice
-            new SettingsSlider<double, TimeSlider>
-            {
-                LabelText = KaraokeSettingsSubsectionStrings.PracticePreemptTime,
-                Current = config.GetBindable<double>(KaraokeRulesetSetting.PracticePreemptTime)
-            },
             new DangerousSettingsButton
             {
                 Text = KaraokeSettingsSubsectionStrings.OpenRulesetSettings,

--- a/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/KaraokeSettingsSubsection.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Globalization;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -65,12 +64,6 @@ public partial class KaraokeSettingsSubsection : RulesetSettingsSubsection
                 LabelText = KaraokeSettingsSubsectionStrings.Translate,
                 TooltipText = KaraokeSettingsSubsectionStrings.TranslateTooltip,
                 Current = config.GetBindable<bool>(KaraokeRulesetSetting.UseTranslate)
-            },
-            new SettingsLanguage
-            {
-                LabelText = KaraokeSettingsSubsectionStrings.PreferLanguage,
-                TooltipText = KaraokeSettingsSubsectionStrings.PreferLanguageTooltip,
-                Current = config.GetBindable<CultureInfo>(KaraokeRulesetSetting.PreferLanguage)
             },
             // Device
             new SettingsMicrophoneDeviceDropdown


### PR DESCRIPTION
What's done in this PR:
1. Remove the assign language in the main setting.
2. Move the preempt time setting into ruleset's own setting overlay.