### PR TITLE
Adjust caret position usage.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/BaseIndexCaretPositionAlgorithmTest.cs
@@ -59,7 +59,8 @@ public abstract class BaseIndexCaretPositionAlgorithmTest<TAlgorithm, TCaret> : 
         AssertEqual(expected, actual);
     }
 
-    protected void TestMoveToTargetLyric<TIndex>(Lyric[] lyrics, Lyric lyric, TIndex? index, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+    protected void TestMoveToTargetLyric<TIndex>(Lyric[] lyrics, Lyric lyric, TIndex index, TCaret? expected, Action<TAlgorithm>? invokeAlgorithm = null)
+        where TIndex : notnull
     {
         var algorithm = (TAlgorithm?)Activator.CreateInstance(typeof(TAlgorithm), new object[] { lyrics });
         if (algorithm == null)

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -201,13 +201,11 @@ public class TimeTagCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithm
 
     [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 0, 0, 0)]
     [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 4, 0, 4)]
-    [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, -1, null, null)] // will check the invalid case.
-    [TestCase(nameof(singleLyric), MovingTimeTagCaretMode.None, 0, 5, null, null)]
     public void TestMoveToTargetLyric(string sourceName, MovingTimeTagCaretMode mode, int lyricIndex, int timeTagIndex, int? expectedLyricIndex, int? expectedTimeTagIndex)
     {
         var lyrics = GetLyricsByMethodName(sourceName);
         var lyric = lyrics[lyricIndex];
-        var timeTag = lyric.TimeTags.ElementAtOrDefault(timeTagIndex);
+        var timeTag = lyric.TimeTags.ElementAt(timeTagIndex);
         var expected = createExpectedCaretPosition(lyrics, expectedLyricIndex, expectedTimeTagIndex);
 
         // Check move to target position.

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateTest.cs
@@ -293,7 +293,8 @@ public partial class LyricCaretStateTest : OsuTestScene
         });
     }
 
-    private void movingCaretByLyric<TItem>(Lyric lyric, TItem? item, Func<bool> expected)
+    private void movingCaretByLyric<TItem>(Lyric lyric, TItem item, Func<bool> expected)
+        where TItem : notnull
     {
         AddStep("Moving caret by caret position", () =>
         {
@@ -325,7 +326,8 @@ public partial class LyricCaretStateTest : OsuTestScene
         });
     }
 
-    private void movingHoverCaretByLyric<TItem>(Lyric lyric, TItem? item, Func<bool> expected)
+    private void movingHoverCaretByLyric<TItem>(Lyric lyric, TItem item, Func<bool> expected)
+        where TItem : notnull
     {
         AddStep("Moving hover caret by caret position", () =>
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CaretPositionAlgorithm.cs
@@ -21,8 +21,6 @@ public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlg
         Lyrics = lyrics;
     }
 
-    protected abstract void Validate(TCaretPosition input);
-
     protected abstract bool PositionMovable(TCaretPosition position);
 
     protected abstract TCaretPosition? MoveToPreviousLyric(TCaretPosition currentPosition);
@@ -40,7 +38,7 @@ public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlg
         if (currentPosition is not TCaretPosition tCaretPosition)
             throw new InvalidCastException(nameof(currentPosition));
 
-        Validate(tCaretPosition);
+        PreValidate(tCaretPosition);
 
         var movedCaretPosition = MoveToPreviousLyric(tCaretPosition);
         return PostValidate(movedCaretPosition, CaretGenerateType.Action);
@@ -51,7 +49,7 @@ public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlg
         if (currentPosition is not TCaretPosition tCaretPosition)
             throw new InvalidCastException(nameof(currentPosition));
 
-        Validate(tCaretPosition);
+        PreValidate(tCaretPosition);
 
         var movedCaretPosition = MoveToNextLyric(tCaretPosition);
         return PostValidate(movedCaretPosition, CaretGenerateType.Action);
@@ -75,6 +73,11 @@ public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlg
         return PostValidate(movedCaretPosition, CaretGenerateType.TargetLyric);
     }
 
+    protected virtual void PreValidate(TCaretPosition input)
+    {
+        Debug.Assert(PositionMovable(input));
+    }
+
     protected TCaretPosition? PostValidate(TCaretPosition? movedCaretPosition, CaretGenerateType generateType)
     {
         if (movedCaretPosition == null)
@@ -83,7 +86,7 @@ public abstract class CaretPositionAlgorithm<TCaretPosition> : ICaretPositionAlg
         if (!PositionMovable(movedCaretPosition.Value))
             return null;
 
-        Validate(movedCaretPosition.Value);
+        PreValidate(movedCaretPosition.Value);
         Debug.Assert(movedCaretPosition.Value.GenerateType == generateType);
 
         return movedCaretPosition;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -19,11 +18,6 @@ public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaret
     protected CharGapCaretPositionAlgorithm(Lyric[] lyrics)
         : base(lyrics)
     {
-    }
-
-    protected sealed override void Validate(TCaretPosition input)
-    {
-        Debug.Assert(indexInTextRange(input.CharGap, input.Lyric));
     }
 
     protected sealed override bool PositionMovable(TCaretPosition position)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
@@ -13,7 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.A
 /// Base class for those algorithms which use char gap as index.
 /// </summary>
 /// <typeparam name="TCaretPosition"></typeparam>
-public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaretPositionAlgorithm<TCaretPosition> where TCaretPosition : struct, ICharGapCaretPosition
+public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaretPositionAlgorithm<TCaretPosition, int>
+    where TCaretPosition : struct, ICharGapCaretPosition
 {
     protected CharGapCaretPositionAlgorithm(Lyric[] lyrics)
         : base(lyrics)
@@ -116,12 +117,9 @@ public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaret
         return CreateCaretPosition(lyric, index);
     }
 
-    protected override TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+    protected override TCaretPosition? MoveToTargetLyric(Lyric lyric, int index)
     {
-        if (index is not int value)
-            throw new InvalidCastException();
-
-        return CreateCaretPosition(lyric, value, CaretGenerateType.TargetLyric);
+        return CreateCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
     }
 
     private bool lyricMovable(Lyric lyric)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharGapCaretPositionAlgorithm.cs
@@ -77,7 +77,7 @@ public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaret
     }
 
     protected sealed override TCaretPosition? MoveToTargetLyric(Lyric lyric)
-        => MoveToTargetLyric(lyric, GetMinIndex(lyric.Text));
+        => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
 
     protected sealed override TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition)
     {
@@ -117,11 +117,6 @@ public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaret
         return CreateCaretPosition(lyric, index);
     }
 
-    protected override TCaretPosition? MoveToTargetLyric(Lyric lyric, int index)
-    {
-        return CreateCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
-    }
-
     private bool lyricMovable(Lyric lyric)
     {
         int minIndex = GetMinIndex(lyric.Text);
@@ -133,8 +128,6 @@ public abstract class CharGapCaretPositionAlgorithm<TCaretPosition> : IndexCaret
         string text = lyric.Text;
         return index >= GetMinIndex(text) && index <= GetMaxIndex(text);
     }
-
-    protected abstract TCaretPosition CreateCaretPosition(Lyric lyric, int index, CaretGenerateType generateType = CaretGenerateType.Action);
 
     protected abstract int GetMinIndex(string text);
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
@@ -77,7 +77,7 @@ public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCar
     }
 
     protected sealed override TCaretPosition? MoveToTargetLyric(Lyric lyric)
-        => MoveToTargetLyric(lyric, GetMinIndex(lyric.Text));
+        => CreateCaretPosition(lyric, GetMinIndex(lyric.Text), CaretGenerateType.TargetLyric);
 
     protected sealed override TCaretPosition? MoveToPreviousIndex(TCaretPosition currentPosition)
     {
@@ -117,11 +117,6 @@ public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCar
         return CreateCaretPosition(lyric, index);
     }
 
-    protected override TCaretPosition? MoveToTargetLyric(Lyric lyric, int index)
-    {
-        return CreateCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
-    }
-
     private bool lyricMovable(Lyric lyric)
     {
         int minIndex = GetMinIndex(lyric.Text);
@@ -133,8 +128,6 @@ public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCar
         string text = lyric.Text;
         return index >= GetMinIndex(text) && index <= GetMaxIndex(text);
     }
-
-    protected abstract TCaretPosition CreateCaretPosition(Lyric lyric, int index, CaretGenerateType generateType = CaretGenerateType.Action);
 
     protected virtual int GetMinIndex(string text) => 0;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using osu.Game.Rulesets.Karaoke.Extensions;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -19,11 +18,6 @@ public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCar
     protected CharIndexCaretPositionAlgorithm(Lyric[] lyrics)
         : base(lyrics)
     {
-    }
-
-    protected sealed override void Validate(TCaretPosition input)
-    {
-        Debug.Assert(indexInTextRange(input.CharIndex, input.Lyric));
     }
 
     protected sealed override bool PositionMovable(TCaretPosition position)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/CharIndexCaretPositionAlgorithm.cs
@@ -13,7 +13,8 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.A
 /// Base class for those algorithms which use char index as index.
 /// </summary>
 /// <typeparam name="TCaretPosition"></typeparam>
-public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCaretPositionAlgorithm<TCaretPosition> where TCaretPosition : struct, ICharIndexCaretPosition
+public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCaretPositionAlgorithm<TCaretPosition, int>
+    where TCaretPosition : struct, ICharIndexCaretPosition
 {
     protected CharIndexCaretPositionAlgorithm(Lyric[] lyrics)
         : base(lyrics)
@@ -116,12 +117,9 @@ public abstract class CharIndexCaretPositionAlgorithm<TCaretPosition> : IndexCar
         return CreateCaretPosition(lyric, index);
     }
 
-    protected override TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+    protected override TCaretPosition? MoveToTargetLyric(Lyric lyric, int index)
     {
-        if (index is not int value)
-            throw new InvalidCastException();
-
-        return CreateCaretPosition(lyric, value, CaretGenerateType.TargetLyric);
+        return CreateCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
     }
 
     private bool lyricMovable(Lyric lyric)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithm.cs
@@ -15,11 +15,6 @@ public class ClickingCaretPositionAlgorithm : CaretPositionAlgorithm<ClickingCar
     {
     }
 
-    protected override void Validate(ClickingCaretPosition input)
-    {
-        // there's no checking rules in this algorithm.
-    }
-
     protected override bool PositionMovable(ClickingCaretPosition position)
     {
         return true;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IIndexCaretPositionAlgorithm.cs
@@ -15,5 +15,5 @@ public interface IIndexCaretPositionAlgorithm : ICaretPositionAlgorithm
 
     IIndexCaretPosition? MoveToLastIndex(Lyric lyric);
 
-    IIndexCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index);
+    IIndexCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -28,7 +28,7 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition, TCaretIndex> :
 
     protected abstract TCaretPosition? MoveToLastIndex(Lyric lyric);
 
-    protected abstract TCaretPosition? MoveToTargetLyric(Lyric lyric, TCaretIndex index);
+    protected abstract TCaretPosition CreateCaretPosition(Lyric lyric, TCaretIndex index, CaretGenerateType generateType = CaretGenerateType.Action);
 
     public IIndexCaretPosition? MoveToPreviousIndex(IIndexCaretPosition currentPosition)
     {
@@ -69,7 +69,7 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition, TCaretIndex> :
         if (index is not TCaretIndex caretIndex)
             throw new InvalidCastException();
 
-        var movedCaretPosition = MoveToTargetLyric(lyric, caretIndex);
+        var movedCaretPosition = CreateCaretPosition(lyric, caretIndex, CaretGenerateType.TargetLyric);
         return PostValidate(movedCaretPosition, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -10,8 +10,10 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.A
 /// Base class for move the <see cref="ICaretPosition"/> to the previous or next position with target index.
 /// </summary>
 /// <typeparam name="TCaretPosition"></typeparam>
-public abstract class IndexCaretPositionAlgorithm<TCaretPosition> : CaretPositionAlgorithm<TCaretPosition>, IIndexCaretPositionAlgorithm
+/// <typeparam name="TCaretIndex"></typeparam>
+public abstract class IndexCaretPositionAlgorithm<TCaretPosition, TCaretIndex> : CaretPositionAlgorithm<TCaretPosition>, IIndexCaretPositionAlgorithm
     where TCaretPosition : struct, IIndexCaretPosition
+    where TCaretIndex : notnull
 {
     protected IndexCaretPositionAlgorithm(Lyric[] lyrics)
         : base(lyrics)
@@ -26,7 +28,7 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition> : CaretPositio
 
     protected abstract TCaretPosition? MoveToLastIndex(Lyric lyric);
 
-    protected abstract TCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index);
+    protected abstract TCaretPosition? MoveToTargetLyric(Lyric lyric, TCaretIndex index);
 
     public IIndexCaretPosition? MoveToPreviousIndex(IIndexCaretPosition currentPosition)
     {
@@ -62,9 +64,12 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition> : CaretPositio
         return PostValidate(movedCaretPosition, CaretGenerateType.Action);
     }
 
-    IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+    IIndexCaretPosition? IIndexCaretPositionAlgorithm.MoveToTargetLyric<TIndex>(Lyric lyric, TIndex index)
     {
-        var movedCaretPosition = MoveToTargetLyric(lyric, index);
+        if (index is not TCaretIndex caretIndex)
+            throw new InvalidCastException();
+
+        var movedCaretPosition = MoveToTargetLyric(lyric, caretIndex);
         return PostValidate(movedCaretPosition, CaretGenerateType.TargetLyric);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IndexCaretPositionAlgorithm.cs
@@ -35,7 +35,7 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition, TCaretIndex> :
         if (currentPosition is not TCaretPosition tCaretPosition)
             throw new InvalidCastException(nameof(currentPosition));
 
-        Validate(tCaretPosition);
+        PreValidate(tCaretPosition);
 
         var movedCaretPosition = MoveToPreviousIndex(tCaretPosition);
         return PostValidate(movedCaretPosition, CaretGenerateType.Action);
@@ -46,7 +46,7 @@ public abstract class IndexCaretPositionAlgorithm<TCaretPosition, TCaretIndex> :
         if (currentPosition is not TCaretPosition tCaretPosition)
             throw new InvalidCastException(nameof(currentPosition));
 
-        Validate(tCaretPosition);
+        PreValidate(tCaretPosition);
 
         var movedCaretPosition = MoveToNextIndex(tCaretPosition);
         return PostValidate(movedCaretPosition, CaretGenerateType.Action);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithm.cs
@@ -17,11 +17,6 @@ public class NavigateCaretPositionAlgorithm : CaretPositionAlgorithm<NavigateCar
     {
     }
 
-    protected override void Validate(NavigateCaretPosition input)
-    {
-        // there's no checking rules in this algorithm.
-    }
-
     protected override bool PositionMovable(NavigateCaretPosition position)
     {
         return true;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.A
 /// <summary>
 /// Algorithm for navigate to the <see cref="TimeTag"/> position inside the <see cref="Lyric"/>.
 /// </summary>
-public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTagCaretPosition>
+public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTagCaretPosition, TimeTag>
 {
     public MovingTimeTagCaretMode Mode { get; set; }
 
@@ -106,6 +106,8 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
     protected override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric)
     {
         var targetTimeTag = lyric.TimeTags.FirstOrDefault(timeTagMovable);
+        if (targetTimeTag == null)
+            return null;
 
         return MoveToTargetLyric(lyric, targetTimeTag);
     }
@@ -158,16 +160,9 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         return caret;
     }
 
-    protected override TimeTagCaretPosition? MoveToTargetLyric<TIndex>(Lyric lyric, TIndex? index) where TIndex : default
+    protected override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric, TimeTag index)
     {
-        // should not move to lyric if contains no time-tag.
-        if (index is null)
-            return null;
-
-        if (index is not TimeTag timeTag)
-            throw new InvalidCastException();
-
-        return new TimeTagCaretPosition(lyric, timeTag, CaretGenerateType.TargetLyric);
+        return new TimeTagCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
     }
 
     private bool timeTagMovable(TimeTag timeTag)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -55,7 +55,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (upTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(previousLyric, upTimeTag);
+        return CreateCaretPosition(previousLyric, upTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToNextLyric(TimeTagCaretPosition currentPosition)
@@ -74,7 +74,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (downTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(nextLyric, downTimeTag);
+        return CreateCaretPosition(nextLyric, downTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToFirstLyric()
@@ -87,7 +87,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (firstTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(firstLyric, firstTimeTag);
+        return CreateCaretPosition(firstLyric, firstTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToLastLyric()
@@ -100,7 +100,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (lastTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(lastLyric, lastTimeTag);
+        return CreateCaretPosition(lastLyric, lastTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric)
@@ -109,7 +109,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (targetTimeTag == null)
             return null;
 
-        return MoveToTargetLyric(lyric, targetTimeTag);
+        return CreateCaretPosition(lyric, targetTimeTag, CaretGenerateType.TargetLyric);
     }
 
     protected override TimeTagCaretPosition? MoveToPreviousIndex(TimeTagCaretPosition currentPosition)
@@ -120,7 +120,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (previousTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(lyric, previousTimeTag);
+        return CreateCaretPosition(lyric, previousTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToNextIndex(TimeTagCaretPosition currentPosition)
@@ -131,7 +131,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (nextTimeTag == null)
             return null;
 
-        return new TimeTagCaretPosition(lyric, nextTimeTag);
+        return CreateCaretPosition(lyric, nextTimeTag);
     }
 
     protected override TimeTagCaretPosition? MoveToFirstIndex(Lyric lyric)
@@ -140,7 +140,7 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (firstTimeTag == null)
             return null;
 
-        var caret = new TimeTagCaretPosition(lyric, firstTimeTag);
+        var caret = CreateCaretPosition(lyric, firstTimeTag);
         if (!timeTagMovable(firstTimeTag))
             return MoveToNextIndex(caret);
 
@@ -153,17 +153,14 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
         if (lastTimeTag == null)
             return null;
 
-        var caret = new TimeTagCaretPosition(lyric, lastTimeTag);
+        var caret = CreateCaretPosition(lyric, lastTimeTag);
         if (!timeTagMovable(lastTimeTag))
             return MoveToPreviousIndex(caret);
 
         return caret;
     }
 
-    protected override TimeTagCaretPosition? MoveToTargetLyric(Lyric lyric, TimeTag index)
-    {
-        return new TimeTagCaretPosition(lyric, index, CaretGenerateType.TargetLyric);
-    }
+    protected override TimeTagCaretPosition CreateCaretPosition(Lyric lyric, TimeTag index, CaretGenerateType generateType = CaretGenerateType.Action) => new(lyric, index, generateType);
 
     private bool timeTagMovable(TimeTag timeTag)
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithm.cs
@@ -22,11 +22,12 @@ public class TimeTagCaretPositionAlgorithm : IndexCaretPositionAlgorithm<TimeTag
     {
     }
 
-    protected override void Validate(TimeTagCaretPosition input)
+    protected override void PreValidate(TimeTagCaretPosition input)
     {
         var timeTag = input.TimeTag;
         var lyric = input.Lyric;
 
+        // should only check if the time-tag is in the lyric because previous time-tag position might not match to the mode.
         Debug.Assert(lyric.TimeTags.Contains(timeTag));
     }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -78,38 +78,33 @@ public abstract partial class InteractableLyric : CompositeDrawable, IHasTooltip
         if (!lyricCaretState.CaretEnabled)
             return false;
 
-        float position = ToLocalSpace(e.ScreenSpaceMousePosition).X;
+        float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
 
-        switch (lyricCaretState.CaretPosition)
+        object? caretIndex = getCaretIndexByPosition(xPosition);
+
+        if (caretIndex != null)
         {
-            case CuttingCaretPosition:
-                int cuttingLyricStringIndex = karaokeSpriteText.GetCharIndicatorByPosition(position);
-                lyricCaretState.MoveHoverCaretToTargetPosition(lyric, cuttingLyricStringIndex);
-                break;
-
-            case TypingCaretPosition:
-                int typingStringIndex = karaokeSpriteText.GetCharIndicatorByPosition(position);
-                lyricCaretState.MoveHoverCaretToTargetPosition(lyric, typingStringIndex);
-                break;
-
-            case NavigateCaretPosition:
-                lyricCaretState.MoveHoverCaretToTargetPosition(lyric);
-                break;
-
-            case TimeTagIndexCaretPosition:
-                int? charIndex = karaokeSpriteText.GetCharIndexByPosition(position);
-                if (charIndex != null)
-                    lyricCaretState.MoveHoverCaretToTargetPosition(lyric, charIndex);
-                break;
-
-            case TimeTagCaretPosition:
-                var timeTag = karaokeSpriteText.GetTimeTagByPosition(position);
-                lyricCaretState.MoveHoverCaretToTargetPosition(lyric, timeTag);
-                break;
+            lyricCaretState.MoveHoverCaretToTargetPosition(lyric, caretIndex);
+        }
+        else if (lyricCaretState.CaretPosition is not IIndexCaretPosition)
+        {
+            // still need to handle the case with non-index caret position.
+            lyricCaretState.MoveHoverCaretToTargetPosition(lyric);
         }
 
         return base.OnMouseMove(e);
     }
+
+    private object? getCaretIndexByPosition(float position) =>
+        lyricCaretState.CaretPosition switch
+        {
+            CuttingCaretPosition => karaokeSpriteText.GetCharIndicatorByPosition(position),
+            TypingCaretPosition => karaokeSpriteText.GetCharIndicatorByPosition(position),
+            NavigateCaretPosition => null,
+            TimeTagIndexCaretPosition => karaokeSpriteText.GetCharIndexByPosition(position),
+            TimeTagCaretPosition => karaokeSpriteText.GetTimeTagByPosition(position),
+            _ => null
+        };
 
     protected override void OnHoverLost(HoverLostEvent e)
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -25,11 +25,11 @@ public interface ILyricCaretState
 
     bool MoveCaretToTargetPosition(Lyric lyric);
 
-    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index);
+    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index) where TIndex : notnull;
 
     bool MoveHoverCaretToTargetPosition(Lyric lyric);
 
-    bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index);
+    bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index) where TIndex : notnull;
 
     bool ConfirmHoverCaretPosition();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -265,8 +265,12 @@ public partial class LyricCaretState : Component, ILyricCaretState
     }
 
     public bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index)
+        where TIndex : notnull
     {
         if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
+            return false;
+
+        if (index == null)
             return false;
 
         var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);
@@ -293,8 +297,12 @@ public partial class LyricCaretState : Component, ILyricCaretState
     }
 
     public bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index)
+        where TIndex : notnull
     {
         if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
+            return false;
+
+        if (index == null)
             return false;
 
         var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);


### PR DESCRIPTION
What's done in this PR:
- Algorithm should not accept the null caret position index.
- There's no need to implement the pre-validator unless need to make the check not that strict(#2020).
- Separate the get caret position index logic from the `InteractableLyric` because drag to change the caret index might use the same logic.