### PR TITLE
Implement base interface for able to change the end index caret position.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateTest.cs
@@ -211,6 +211,18 @@ public partial class LyricCaretStateTest : OsuTestScene
         movingCaretByLyric(targetLyric, new TextIndex(), () => false);
     }
 
+    [Test]
+    public void AdjustEndCaretPositionWithNotSupportedMode()
+    {
+        changeMode(LyricEditorMode.Texting);
+
+        var targetLyric = getLyricFromBeatmap(1);
+        movingCaretByLyric(targetLyric, () => true);
+
+        // not throw the exception if the caret algorithm does not support the adjust the end index.
+        adjustCaretEndIndex(new TextIndex(), () => true);
+    }
+
     #endregion
 
     #region Moving hover caret by caret position
@@ -301,6 +313,23 @@ public partial class LyricCaretStateTest : OsuTestScene
             try
             {
                 lyricCaretState.MoveCaretToTargetPosition(lyric, item);
+                Assert.IsTrue(expected());
+            }
+            catch
+            {
+                Assert.IsFalse(expected());
+            }
+        });
+    }
+
+    private void adjustCaretEndIndex<TItem>(TItem item, Func<bool> expected)
+        where TItem : notnull
+    {
+        AddStep("Moving caret by caret position", () =>
+        {
+            try
+            {
+                lyricCaretState.AdjustCaretEndIndex(item);
                 Assert.IsTrue(expected());
             }
             catch

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IApplicableToEndIndex.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/IApplicableToEndIndex.cs
@@ -1,0 +1,9 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.Algorithms;
+
+public interface IApplicableToEndIndex
+{
+    IRangeIndexCaretPosition? AdjustEndIndex<TIndex>(IRangeIndexCaretPosition currentPosition, TIndex index) where TIndex : notnull;
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionAlgorithm.cs
@@ -17,8 +17,4 @@ public class TimeTagIndexCaretPositionAlgorithm : CharIndexCaretPositionAlgorith
     }
 
     protected override TimeTagIndexCaretPosition CreateCaretPosition(Lyric lyric, int index, CaretGenerateType generateType = CaretGenerateType.Action) => new(lyric, index, generateType);
-
-    protected override int GetMinIndex(string text) => 0;
-
-    protected override int GetMaxIndex(string text) => text.Length - 1;
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/IRangeIndexCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/IRangeIndexCaretPosition.cs
@@ -1,0 +1,8 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+
+public interface IRangeIndexCaretPosition : IIndexCaretPosition
+{
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/InteractableLyric.cs
@@ -79,7 +79,6 @@ public abstract partial class InteractableLyric : CompositeDrawable, IHasTooltip
             return false;
 
         float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
-
         object? caretIndex = getCaretIndexByPosition(xPosition);
 
         if (caretIndex != null)
@@ -93,6 +92,28 @@ public abstract partial class InteractableLyric : CompositeDrawable, IHasTooltip
         }
 
         return base.OnMouseMove(e);
+    }
+
+    protected override bool OnDragStart(DragStartEvent e)
+    {
+        // should handle the drag event if the caret algorithm is able to handle it.
+        return lyricCaretState.CaretDraggable;
+    }
+
+    protected override void OnDrag(DragEvent e)
+    {
+        if (!lyricCaretState.CaretEnabled)
+            return;
+
+        float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
+        object? caretIndex = getCaretIndexByPosition(xPosition);
+
+        if (caretIndex != null)
+        {
+            lyricCaretState.AdjustCaretEndIndex(caretIndex);
+        }
+
+        base.OnDrag(e);
     }
 
     private object? getCaretIndexByPosition(float position) =>

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -40,4 +40,6 @@ public interface ILyricCaretState
     void SyncSelectedHitObjectWithCaret();
 
     bool CaretEnabled { get; }
+
+    bool CaretDraggable { get; }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -25,11 +25,11 @@ public interface ILyricCaretState
 
     bool MoveCaretToTargetPosition(Lyric lyric);
 
-    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index) where TIndex : notnull;
+    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
 
     bool MoveHoverCaretToTargetPosition(Lyric lyric);
 
-    bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index) where TIndex : notnull;
+    bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
 
     bool ConfirmHoverCaretPosition();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -27,6 +27,8 @@ public interface ILyricCaretState
 
     bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
 
+    bool AdjustCaretEndIndex<TIndex>(TIndex index) where TIndex : notnull;
+
     bool MoveHoverCaretToTargetPosition(Lyric lyric);
 
     bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -274,6 +274,19 @@ public partial class LyricCaretState : Component, ILyricCaretState
         return moveCaretToTargetPosition(caretPosition);
     }
 
+    public bool AdjustCaretEndIndex<TIndex>(TIndex index)
+        where TIndex : notnull
+    {
+        if (algorithm is not IApplicableToEndIndex endIndexCaretPositionAlgorithm)
+            return false;
+
+        if (bindableCaretPosition.Value is not IRangeIndexCaretPosition rangeIndexCaretPosition)
+            throw new InvalidOperationException("Should have the caret position first.");
+
+        var caretPosition = endIndexCaretPositionAlgorithm.AdjustEndIndex(rangeIndexCaretPosition, index);
+        return moveCaretToTargetPosition(caretPosition);
+    }
+
     private bool moveCaretToTargetPosition(ICaretPosition? position)
     {
         if (position == null)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -264,13 +264,10 @@ public partial class LyricCaretState : Component, ILyricCaretState
         return moveCaretToTargetPosition(caretPosition);
     }
 
-    public bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index)
+    public bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index)
         where TIndex : notnull
     {
         if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
-            return false;
-
-        if (index == null)
             return false;
 
         var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);
@@ -296,13 +293,10 @@ public partial class LyricCaretState : Component, ILyricCaretState
         return moveHoverCaretToTargetPosition(caretPosition);
     }
 
-    public bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex? index)
+    public bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index)
         where TIndex : notnull
     {
         if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
-            return false;
-
-        if (index == null)
             return false;
 
         var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -351,6 +351,8 @@ public partial class LyricCaretState : Component, ILyricCaretState
 
     public bool CaretEnabled => algorithm != null;
 
+    public bool CaretDraggable => algorithm is IApplicableToEndIndex;
+
     private void postProcess()
     {
         SyncSelectedHitObjectWithCaret();


### PR DESCRIPTION
Preparation of issue #2007 and #2008.

What's done in this PR:
1. adjust some override things.
2. caret state should not able to assign the null value.
3. define the interface for the caret position/caret algorithm that has end index.
4. lyric caret state should be able to adjust the end position and expose the information that the algorithm is support the drag or not.
5. interactable lyric in the editor now able to support the drag event.