### PR TITLE
Create element id struct.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/TestElementId.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/TestElementId.cs
@@ -1,0 +1,115 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using J2N.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Beatmaps;
+
+public class TestElementId
+{
+    [Test]
+    public void TestEmptyElementId()
+    {
+        var emptyElementId = ElementId.Empty;
+
+        // Should get empty string if the element is empty.
+        Assert.IsEmpty(emptyElementId.ToString());
+
+        // Should be equal to empty element id.
+        Assert.IsTrue(emptyElementId.Equals(ElementId.Empty));
+        Assert.IsFalse(emptyElementId.Equals(ElementId.NewElementId()));
+    }
+
+    [TestCase("1234567", true)] // number is OK
+    [TestCase("0abcdef", true)] // alphabet is OK
+    [TestCase("0ABCDEF", false)] // upper case is not allowed.
+    [TestCase("abcdefg", false)] // alphabet should be within a~f
+    [TestCase("xyz7890", false)] // alphabet should be within a~f
+    [TestCase("123456", false)] // should be 7 digits
+    [TestCase("abcdefgh", false)] // should be 7 digits
+    [TestCase("", false)] // should be 7 digits
+    public void TestCreateElementId(string id, bool created)
+    {
+        if (created)
+        {
+            Assert.DoesNotThrow(() => new ElementId(id));
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => new ElementId(id));
+        }
+    }
+
+    [Test]
+    public void TestNewElementIdShouldNotDuplicated()
+    {
+        const int create_amount = 1000;
+
+        // Arrange
+        HashSet<ElementId> idSet = new HashSet<ElementId>();
+
+        for (int i = 0; i < create_amount; i++)
+        {
+            var elementId = ElementId.NewElementId();
+            idSet.Add(elementId);
+        }
+
+        Assert.AreEqual(idSet.Count, create_amount);
+    }
+
+    [TestCase("1234567", "1234567", true)]
+    [TestCase("1234567", "7654321", false)]
+    public void TestEqual(string a, string b, bool expected)
+    {
+        var elementIdA = new ElementId(a);
+        var elementIdB = new ElementId(b);
+
+        bool actual = elementIdA.Equals(elementIdB);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase("1234567", "1234567", true)]
+    [TestCase("1234567", "7654321", false)]
+    public void TestEqualWithEqualityComparer(string a, string b, bool expected)
+    {
+        var elementIdA = new ElementId(a);
+        var elementIdB = new ElementId(b);
+
+        bool actual = EqualityComparer<object>.Default.Equals(elementIdA, elementIdB);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase("1234567", "1234567", true)]
+    [TestCase("1234567", "7654321", false)]
+    public void TestEqualOperator(string a, string b, bool expected)
+    {
+        var elementIdA = new ElementId(a);
+        var elementIdB = new ElementId(b);
+
+        bool actual = elementIdA == elementIdB;
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase("1234567", "1234567", false)]
+    [TestCase("1234567", "7654321", true)]
+    public void TestNotEqualOperator(string a, string b, bool expected)
+    {
+        var elementIdA = new ElementId(a);
+        var elementIdB = new ElementId(b);
+
+        bool actual = elementIdA != elementIdB;
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestCase("1234567", "1234567")]
+    [TestCase("7654321", "7654321")]
+    public void TestToString(string a, string expected)
+    {
+        var elementId = new ElementId(a);
+
+        Assert.AreEqual(expected, elementId.ToString());
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/TestElementId.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/TestElementId.cs
@@ -60,6 +60,29 @@ public class TestElementId
         Assert.AreEqual(idSet.Count, create_amount);
     }
 
+    [TestCase("1234567", "1234567", 0)]
+    [TestCase("1234567", "2345678", -1)]
+    [TestCase("2345678", "1234567", 1)]
+    public void TestCompareTo(string a, string b, int expected)
+    {
+        var elementIdA = new ElementId(a);
+        var elementIdB = new ElementId(b);
+
+        int actual = elementIdA.CompareTo(elementIdB);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void TestCompareToOther()
+    {
+        var elementId = new ElementId("1234567");
+
+        Assert.AreEqual(elementId.CompareTo(null), 1);
+        Assert.Throws<ArgumentException>(() => elementId.CompareTo(3)); // should not compare to other type
+        Assert.Throws<ArgumentException>(() => elementId.CompareTo("123")); // should not compare to the string also.
+        Assert.DoesNotThrow(() => elementId.CompareTo(new ElementId("1234567")));
+    }
+
     [TestCase("1234567", "1234567", true)]
     [TestCase("1234567", "7654321", false)]
     public void TestEqual(string a, string b, bool expected)

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ElementIdConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ElementIdConverterTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.IO.Serialization.Converters;
+
+public class ElementIdConverterTest : BaseSingleConverterTest<ElementIdConverter>
+{
+    [TestCase("1234567", "\"1234567\"")]
+    [TestCase("", "\"\"")]
+    [TestCase(null, "null")]
+    public void TestSerialize(string? id, string json)
+    {
+        var elementId = createElementId(id);
+        string actual = JsonConvert.SerializeObject(elementId, CreateSettings());
+        Assert.AreEqual(json, actual);
+    }
+
+    [TestCase("\"1234567\"", "1234567")]
+    [TestCase("\"\"", "")]
+    [TestCase("null", "")] // should make sure that create the ElementId.Empty if not receive the id.
+    public void TestDeserialize(string json, string? id)
+    {
+        var expected = createElementId(id);
+        var result = JsonConvert.DeserializeObject<ElementId>(json, CreateSettings());
+        Assert.AreEqual(expected, result);
+    }
+
+    private static ElementId? createElementId(string? str)
+    {
+        if (str == null)
+            return null;
+
+        if (str == string.Empty)
+            return ElementId.Empty;
+
+        return new ElementId(str);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Karaoke.Beatmaps;
 /// As unique identifier for the elements in the <see cref="KaraokeBeatmap"/>
 /// Like how <see cref="Guid"/> works.
 /// </summary>
-public readonly struct ElementId : IEquatable<ElementId>
+public readonly struct ElementId : IComparable, IComparable<ElementId>, IEquatable<ElementId>
 {
     public static readonly ElementId Empty;
 
@@ -48,6 +48,26 @@ public readonly struct ElementId : IEquatable<ElementId>
         string str = Guid.NewGuid().ToString("N");
         string id = str[..length];
         return new ElementId(id);
+    }
+
+    public int CompareTo(ElementId other)
+    {
+        return string.Compare(id, other.id, StringComparison.Ordinal);
+    }
+
+    public int CompareTo(object? obj)
+    {
+        if (obj == null)
+        {
+            return 1;
+        }
+
+        if (obj is not ElementId elementId)
+        {
+            throw new ArgumentException("Compared object should be the same type.", nameof(obj));
+        }
+
+        return CompareTo(elementId);
     }
 
     public bool Equals(ElementId other)

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
@@ -1,0 +1,76 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+
+namespace osu.Game.Rulesets.Karaoke.Beatmaps;
+
+/// <summary>
+/// As unique identifier for the elements in the <see cref="KaraokeBeatmap"/>
+/// Like how <see cref="Guid"/> works.
+/// </summary>
+public readonly struct ElementId : IEquatable<ElementId>
+{
+    public static readonly ElementId Empty;
+
+    private const int length = 7;
+
+    private readonly string id;
+
+    public ElementId(string id)
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            throw new ArgumentException($"id should not be empty", nameof(id));
+        }
+
+        if (id.Length != length)
+        {
+            throw new ArgumentException($"id length must be {length}.", nameof(id));
+        }
+
+        if (!checkFormat(id))
+        {
+            throw new ArgumentException($"id format is not correct", nameof(id));
+        }
+
+        this.id = id;
+    }
+
+    // char should be 0~9 and a~f
+    private static bool checkFormat(string id)
+        => id.Where(c => c is < '0' or > '9').All(c => c >= 'a' && c <= 'f');
+
+    public static ElementId NewElementId()
+    {
+        // take 7 digits
+        string str = Guid.NewGuid().ToString("N");
+        string id = str[..length];
+        return new ElementId(id);
+    }
+
+    public bool Equals(ElementId other)
+    {
+        return id == other.id;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ElementId other && Equals(other);
+    }
+
+    public static bool operator ==(ElementId id1, ElementId id2) => id1.Equals(id2);
+
+    public static bool operator !=(ElementId id1, ElementId id2) => !id1.Equals(id2);
+
+    public override int GetHashCode()
+    {
+        return id.GetHashCode();
+    }
+
+    public override string ToString()
+    {
+        return id ?? string.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/ElementIdConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/ElementIdConverter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+
+namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
+
+public class ElementIdConverter : JsonConverter<ElementId>
+{
+    public override ElementId ReadJson(JsonReader reader, Type objectType, ElementId existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        var obj = JToken.Load(reader);
+        string? value = obj.Value<string?>();
+
+        return string.IsNullOrEmpty(value) ? ElementId.Empty : new ElementId(value);
+    }
+
+    public override void WriteJson(JsonWriter writer, ElementId value, JsonSerializer serializer)
+    {
+        string id = value.ToString();
+        writer.WriteValue(id);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/KaraokeJsonSerializableExtensions.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/KaraokeJsonSerializableExtensions.cs
@@ -18,6 +18,7 @@ public static class KaraokeJsonSerializableExtensions
 
         // hit-object
         globalSetting.Converters.Add(new CultureInfoConverter());
+        globalSetting.Converters.Add(new ElementIdConverter());
         globalSetting.Converters.Add(new RomajiTagConverter());
         globalSetting.Converters.Add(new RomajiTagsConverter());
         globalSetting.Converters.Add(new RubyTagConverter());


### PR DESCRIPTION
First implementation of #2040.
Create the struct like `Guid` to define karaoke ruleset's own id format.

The format idea is from the git commit sha, the main goal is:
1. Easy to create the id. 
    - It's easy to make the mistake if need to get all related objects if want to create the new id.
    - Able to generate the id everytime object created.
2. No need to write the algorithm to refresh(or called re-calculate) the ids(e.g. [1,4,5] -> [1,2,3]). 
3. (not very important) Id should not include the information about create order.

and we should avoid:
1. the id is not easy to conflict.

The algorithm in the `ElementId.NewElementId()` can be changed at any time, just need to make sure that the id should be 7 digits and within `0~9` or `a~f`.