### PR TITLE
Fix `ElementIdConverter` does not accept the nullable property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ElementIdConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/ElementIdConverterTest.cs
@@ -12,7 +12,7 @@ public class ElementIdConverterTest : BaseSingleConverterTest<ElementIdConverter
 {
     [TestCase("1234567", "\"1234567\"")]
     [TestCase("", "\"\"")]
-    [TestCase(null, "null")]
+    [TestCase(null, "null")] // support the case with nullable property.
     public void TestSerialize(string? id, string json)
     {
         var elementId = createElementId(id);
@@ -22,22 +22,19 @@ public class ElementIdConverterTest : BaseSingleConverterTest<ElementIdConverter
 
     [TestCase("\"1234567\"", "1234567")]
     [TestCase("\"\"", "")]
-    [TestCase("null", "")] // should make sure that create the ElementId.Empty if not receive the id.
+    [TestCase("null", null)] // support the case with nullable property.
     public void TestDeserialize(string json, string? id)
     {
         var expected = createElementId(id);
-        var result = JsonConvert.DeserializeObject<ElementId>(json, CreateSettings());
+        var result = JsonConvert.DeserializeObject<ElementId?>(json, CreateSettings());
         Assert.AreEqual(expected, result);
     }
 
-    private static ElementId? createElementId(string? str)
-    {
-        if (str == null)
-            return null;
-
-        if (str == string.Empty)
-            return ElementId.Empty;
-
-        return new ElementId(str);
-    }
+    private static ElementId? createElementId(string? str) =>
+        str switch
+        {
+            null => null,
+            "" => ElementId.Empty,
+            _ => new ElementId(str)
+        };
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/ElementId.cs
@@ -16,7 +16,7 @@ public readonly struct ElementId : IComparable, IComparable<ElementId>, IEquatab
 
     private const int length = 7;
 
-    private readonly string id;
+    private readonly string? id;
 
     public ElementId(string id)
     {
@@ -86,7 +86,7 @@ public readonly struct ElementId : IComparable, IComparable<ElementId>, IEquatab
 
     public override int GetHashCode()
     {
-        return id.GetHashCode();
+        return (id ?? string.Empty).GetHashCode();
     }
 
     public override string ToString()

--- a/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/ElementIdConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/IO/Serialization/Converters/ElementIdConverter.cs
@@ -8,19 +8,27 @@ using osu.Game.Rulesets.Karaoke.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.IO.Serialization.Converters;
 
-public class ElementIdConverter : JsonConverter<ElementId>
+public class ElementIdConverter : JsonConverter<ElementId?>
 {
-    public override ElementId ReadJson(JsonReader reader, Type objectType, ElementId existingValue, bool hasExistingValue, JsonSerializer serializer)
+    public override ElementId? ReadJson(JsonReader reader, Type objectType, ElementId? existingValue, bool hasExistingValue, JsonSerializer serializer)
     {
         var obj = JToken.Load(reader);
         string? value = obj.Value<string?>();
 
-        return string.IsNullOrEmpty(value) ? ElementId.Empty : new ElementId(value);
+        return createElementId(value);
     }
 
-    public override void WriteJson(JsonWriter writer, ElementId value, JsonSerializer serializer)
+    private static ElementId? createElementId(string? str) =>
+        str switch
+        {
+            null => null,
+            "" => ElementId.Empty,
+            _ => new ElementId(str)
+        };
+
+    public override void WriteJson(JsonWriter writer, ElementId? value, JsonSerializer serializer)
     {
-        string id = value.ToString();
+        string? id = value.ToString();
         writer.WriteValue(id);
     }
 }


### PR DESCRIPTION
Fix issue #2051.
Not very sure why fixed but still OK to give it a pass now.