### PR TITLE
Some property like element id need extra convertor in the `DeepClone()` method.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -3,9 +3,9 @@
 
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
-using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.IO.Serialization;
 using osu.Game.Rulesets.Karaoke.Judgements;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
@@ -137,8 +137,9 @@ public partial class Note : KaraokeHitObject, IHasPage, IHasDuration, IHasText, 
 
     public Note DeepClone()
     {
-        string serializeString = this.Serialize();
-        var note = serializeString.Deserialize<Note>();
+        string serializeString = JsonConvert.SerializeObject(this, KaraokeJsonSerializableExtensions.CreateGlobalSettings());
+        var note = JsonConvert.DeserializeObject<Note>(serializeString, KaraokeJsonSerializableExtensions.CreateGlobalSettings())!;
+
         note.ReferenceLyric = ReferenceLyric;
 
         return note;


### PR DESCRIPTION
Fix ticket #2050.
Follow `Lyric.cs` to use the customized json serialize config in the `DeepClone()` method.
