### PR TITLE
Change romaji generator return type from array to the dictionaty.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/BaseRomajiGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/BaseRomajiGeneratorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Romajies;
@@ -9,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Asserts;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.Romajis;
 
-public abstract class BaseRomajiGeneratorTest<TRomajiGenerator, TConfig> : BaseLyricGeneratorTest<TRomajiGenerator, RomajiGenerateResult[], TConfig>
+public abstract class BaseRomajiGeneratorTest<TRomajiGenerator, TConfig> : BaseLyricGeneratorTest<TRomajiGenerator, IReadOnlyDictionary<TimeTag, RomajiGenerateResult>, TConfig>
     where TRomajiGenerator : RomajiGenerator<TConfig> where TConfig : RomajiGeneratorConfig, new()
 {
     protected void CheckGenerateResult(Lyric lyric, string[] expectedRubies, TConfig config)
@@ -18,10 +19,9 @@ public abstract class BaseRomajiGeneratorTest<TRomajiGenerator, TConfig> : BaseL
         CheckGenerateResult(lyric, expected, config);
     }
 
-    protected override void AssertEqual(RomajiGenerateResult[] expected, RomajiGenerateResult[] actual)
+    protected override void AssertEqual(IReadOnlyDictionary<TimeTag, RomajiGenerateResult> expected, IReadOnlyDictionary<TimeTag, RomajiGenerateResult> actual)
     {
-        TimeTagAssert.ArePropertyEqual(expected.Select(x => x.TimeTag).ToArray(), actual.Select(x => x.TimeTag).ToArray());
-        Assert.AreEqual(expected.Select(x => x.InitialRomaji), actual.Select(x => x.InitialRomaji));
-        Assert.AreEqual(expected.Select(x => x.RomajiText), actual.Select(x => x.RomajiText));
+        TimeTagAssert.ArePropertyEqual(expected.Select(x => x.Key).ToArray(), actual.Select(x => x.Key).ToArray());
+        Assert.AreEqual(expected.Select(x => x.Value), actual.Select(x => x.Value));
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/Ja/JaRomajiGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/Ja/JaRomajiGeneratorTest.cs
@@ -81,7 +81,7 @@ public class JaRomajiGeneratorTest : BaseRomajiGeneratorTest<JaRomajiGenerator, 
         var romajis = parseRomajiGenerateResults(romajiParams);
 
         var expected = RomajiGenerateResultHelper.ParseRomajiGenerateResults(timeTags, expectedResults);
-        var actual = JaRomajiGenerator.Convert(timeTags, romajis).ToArray();
+        var actual = JaRomajiGenerator.Convert(timeTags, romajis);
 
         AssertEqual(expected, actual);
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/RomajiGenerateResultHelper.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/RomajiGenerateResultHelper.cs
@@ -21,26 +21,25 @@ public class RomajiGenerateResultHelper
     /// <param name="timeTag">Origin time-tag</param>
     /// <param name="str">Generate result string format</param>
     /// <returns><see cref="RomajiGenerateResult"/>Romaji generate result.</returns>
-    public static RomajiGenerateResult ParseRomajiGenerateResult(TimeTag timeTag, string str)
+    public static KeyValuePair<TimeTag, RomajiGenerateResult> ParseRomajiGenerateResult(TimeTag timeTag, string str)
     {
-        bool initialRomaji = str.StartsWith("^", StringComparison.Ordinal);
-
-        return new RomajiGenerateResult
+        var result = new RomajiGenerateResult
         {
-            TimeTag = timeTag,
-            InitialRomaji = initialRomaji,
+            InitialRomaji = str.StartsWith("^", StringComparison.Ordinal),
             RomajiText = str.Replace("^", ""),
         };
+
+        return new KeyValuePair<TimeTag, RomajiGenerateResult>(timeTag, result);
     }
 
-    public static RomajiGenerateResult[] ParseRomajiGenerateResults(IList<TimeTag> timeTags, IList<string> strings)
+    public static IReadOnlyDictionary<TimeTag, RomajiGenerateResult> ParseRomajiGenerateResults(IList<TimeTag> timeTags, IList<string> strings)
     {
         if (timeTags.Count != strings.Count)
             throw new InvalidOperationException();
 
-        return parseRomajiGenerateResults(timeTags, strings).ToArray();
+        return parseRomajiGenerateResults(timeTags, strings).ToDictionary(k => k.Key, v => v.Value);
 
-        static IEnumerable<RomajiGenerateResult> parseRomajiGenerateResults(IList<TimeTag> timeTags, IList<string> strings)
+        static IEnumerable<KeyValuePair<TimeTag, RomajiGenerateResult>> parseRomajiGenerateResults(IList<TimeTag> timeTags, IList<string> strings)
         {
             for (int i = 0; i < timeTags.Count; i++)
             {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/RomajiGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romajis/RomajiGeneratorSelectorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
@@ -12,7 +13,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Generator.Lyrics.Romajis;
 
-public class RomajiTagGeneratorSelectorTest : BaseLyricGeneratorSelectorTest<RomajiGeneratorSelector, RomajiGenerateResult[]>
+public class RomajiTagGeneratorSelectorTest : BaseLyricGeneratorSelectorTest<RomajiGeneratorSelector, IReadOnlyDictionary<TimeTag, RomajiGenerateResult>>
 {
     [TestCase(17, "花火大会", true)]
     [TestCase(17, "我是中文", true)] // only change the language code to decide should be able to generate or not.
@@ -54,10 +55,9 @@ public class RomajiTagGeneratorSelectorTest : BaseLyricGeneratorSelectorTest<Rom
         CheckGenerateResult(lyric, expected, selector);
     }
 
-    protected override void AssertEqual(RomajiGenerateResult[] expected, RomajiGenerateResult[] actual)
+    protected override void AssertEqual(IReadOnlyDictionary<TimeTag, RomajiGenerateResult> expected, IReadOnlyDictionary<TimeTag, RomajiGenerateResult> actual)
     {
-        TimeTagAssert.ArePropertyEqual(expected.Select(x => x.TimeTag).ToArray(), actual.Select(x => x.TimeTag).ToArray());
-        Assert.AreEqual(expected.Select(x => x.InitialRomaji), actual.Select(x => x.InitialRomaji));
-        Assert.AreEqual(expected.Select(x => x.RomajiText), actual.Select(x => x.RomajiText));
+        TimeTagAssert.ArePropertyEqual(expected.Select(x => x.Key).ToArray(), actual.Select(x => x.Key).ToArray());
+        Assert.AreEqual(expected.Select(x => x.Value), actual.Select(x => x.Value));
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGenerateResult.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGenerateResult.cs
@@ -1,14 +1,10 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Objects;
-
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Romajies;
 
 public struct RomajiGenerateResult
 {
-    public TimeTag TimeTag { get; set; }
-
     public bool InitialRomaji { get; set; }
 
     public string? RomajiText { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -8,7 +9,7 @@ using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Romajies;
 
-public abstract class RomajiGenerator<TConfig> : LyricPropertyGenerator<RomajiGenerateResult[], TConfig>
+public abstract class RomajiGenerator<TConfig> : LyricPropertyGenerator<IReadOnlyDictionary<TimeTag, RomajiGenerateResult>, TConfig>
     where TConfig : RomajiGeneratorConfig, new()
 {
     protected RomajiGenerator(TConfig config)

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGeneratorSelector.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/Romajies/RomajiGeneratorSelector.cs
@@ -1,13 +1,15 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Romajies.Ja;
+using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Generator.Lyrics.Romajies;
 
-public class RomajiGeneratorSelector : LyricGeneratorSelector<RomajiGenerateResult[], RomajiGeneratorConfig>
+public class RomajiGeneratorSelector : LyricGeneratorSelector<IReadOnlyDictionary<TimeTag, RomajiGenerateResult>, RomajiGeneratorConfig>
 {
     public RomajiGeneratorSelector(KaraokeRulesetEditGeneratorConfigManager generatorConfigManager)
         : base(generatorConfigManager)


### PR DESCRIPTION
Improvement of #2077.
Change the return type to dictionary for easier to find the result by time-tag.