### PR TITLE
Remove the override function because it can use object equality check instead.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/BaseCaretPositionAlgorithmTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -98,11 +99,9 @@ public abstract class BaseCaretPositionAlgorithmTest<TAlgorithm, TCaret> where T
         }
         else
         {
-            AssertEqual(expected.Value, actual.Value);
+            Assert.IsTrue(EqualityComparer<TCaret>.Default.Equals(expected.Value, actual.Value));
         }
     }
-
-    protected abstract void AssertEqual(TCaret expected, TCaret actual);
 
     protected Lyric[] GetLyricsByMethodName(string methodName)
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/ClickingCaretPositionAlgorithmTest.cs
@@ -94,11 +94,6 @@ public class ClickingCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest
 
     #endregion
 
-    protected override void AssertEqual(ClickingCaretPosition expected, ClickingCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-    }
-
     private static ClickingCaretPosition createCaretPosition(IEnumerable<Lyric> lyrics, int lyricIndex)
     {
         var lyric = lyrics.ElementAtOrDefault(lyricIndex);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/CreateRubyTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/CreateRubyTagCaretPositionAlgorithmTest.cs
@@ -13,10 +13,4 @@ public class CreateRubyTagCaretPositionAlgorithmTest : BaseCharIndexCaretPositio
 {
     protected override CreateRubyTagCaretPosition CreateCaret(Lyric lyric, int index)
         => new(lyric, index);
-
-    protected override void AssertEqual(CreateRubyTagCaretPosition expected, CreateRubyTagCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-        Assert.AreEqual(expected.CharIndex, actual.CharIndex);
-    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/CuttingCaretPositionAlgorithmTest.cs
@@ -174,12 +174,6 @@ public class CuttingCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithm
 
     #endregion
 
-    protected override void AssertEqual(CuttingCaretPosition expected, CuttingCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-        Assert.AreEqual(expected.CharGap, actual.CharGap);
-    }
-
     private static CuttingCaretPosition createCaretPosition(IEnumerable<Lyric> lyrics, int lyricIndex, int index)
     {
         var lyric = lyrics.ElementAtOrDefault(lyricIndex);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/NavigateCaretPositionAlgorithmTest.cs
@@ -94,11 +94,6 @@ public class NavigateCaretPositionAlgorithmTest : BaseCaretPositionAlgorithmTest
 
     #endregion
 
-    protected override void AssertEqual(NavigateCaretPosition expected, NavigateCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-    }
-
     private static NavigateCaretPosition createCaretPosition(IEnumerable<Lyric> lyrics, int lyricIndex)
     {
         var lyric = lyrics.ElementAtOrDefault(lyricIndex);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagCaretPositionAlgorithmTest.cs
@@ -214,12 +214,6 @@ public class TimeTagCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithm
 
     #endregion
 
-    protected override void AssertEqual(TimeTagCaretPosition expected, TimeTagCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-        Assert.AreEqual(expected.TimeTag, actual.TimeTag);
-    }
-
     private static TimeTagCaretPosition createCaretPosition(IEnumerable<Lyric> lyrics, int lyricIndex, int timeTagIndex)
     {
         var lyric = lyrics.ElementAtOrDefault(lyricIndex);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TimeTagIndexCaretPositionTest.cs
@@ -13,10 +13,4 @@ public class TimeTagIndexCaretPositionTest : BaseCharIndexCaretPositionAlgorithm
 {
     protected override TimeTagIndexCaretPosition CreateCaret(Lyric lyric, int index)
         => new(lyric, index);
-
-    protected override void AssertEqual(TimeTagIndexCaretPosition expected, TimeTagIndexCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-        Assert.AreEqual(expected.CharIndex, actual.CharIndex);
-    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/CaretPosition/Algorithms/TypingCaretPositionAlgorithmTest.cs
@@ -169,12 +169,6 @@ public class TypingCaretPositionAlgorithmTest : BaseIndexCaretPositionAlgorithmT
 
     #endregion
 
-    protected override void AssertEqual(TypingCaretPosition expected, TypingCaretPosition actual)
-    {
-        Assert.AreEqual(expected.Lyric, actual.Lyric);
-        Assert.AreEqual(expected.CharGap, actual.CharGap);
-    }
-
     private static TypingCaretPosition createCaretPosition(IEnumerable<Lyric> lyrics, int lyricIndex, int index)
     {
         var lyric = lyrics.ElementAtOrDefault(lyricIndex);


### PR DESCRIPTION
After #2082, it should be possible to use the `EqualityComparer` instead.