### PR TITLE
Separate the working property.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -12,6 +12,9 @@ using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Configuration;
 using osu.Game.Rulesets.Karaoke.Edit.Utils;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
+using osu.Game.Rulesets.Karaoke.Stages;
 using osu.Game.Rulesets.Karaoke.Stages.Types;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
@@ -233,11 +236,27 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
 
             return editorBeatmap.HitObjects.OfType<KaraokeHitObject>().All(hitObject => hitObject switch
             {
-                Lyric lyric => lyric.GetAllInvalidWorkingProperties().Length == 0,
-                Note note => note.GetAllInvalidWorkingProperties().Length == 0,
+                Lyric lyric => !hasInvalidWorkingProperty(lyric),
+                Note note => !hasInvalidWorkingProperty(note),
                 _ => throw new NotSupportedException(),
             });
         });
+    }
+
+    private static bool hasInvalidWorkingProperty(Lyric lyric)
+    {
+        if (lyric is not (IHasWorkingProperty<LyricWorkingProperty, KaraokeBeatmap> workingProperty and IHasWorkingProperty<LyricStageWorkingProperty, StageInfo> stageWorkingProperty))
+            throw new NotSupportedException();
+
+        return workingProperty.HasInvalidWorkingProperty() || stageWorkingProperty.HasInvalidWorkingProperty();
+    }
+
+    private static bool hasInvalidWorkingProperty(Note note)
+    {
+        if (note is not (IHasWorkingProperty<NoteWorkingProperty, KaraokeBeatmap> workingProperty and IHasWorkingProperty<NoteStageWorkingProperty, StageInfo> stageWorkingProperty))
+            throw new NotSupportedException();
+
+        return workingProperty.HasInvalidWorkingProperty() || stageWorkingProperty.HasInvalidWorkingProperty();
     }
 
     private partial class MockEditorChangeHandler : TransactionalCommitComponent, IEditorChangeHandler

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/HitObjectWorkingPropertyValidatorTest.cs
@@ -9,9 +9,9 @@ using osu.Game.Rulesets.Karaoke.Objects.Types;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
-public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag>
+public abstract class HitObjectWorkingPropertyValidatorTest<THitObject, TFlag, TFillProperty>
     where TFlag : struct, Enum
-    where THitObject : KaraokeHitObject, IHasWorkingProperty<TFlag>, new()
+    where THitObject : KaraokeHitObject, IHasWorkingProperty<TFlag, TFillProperty>, new()
 {
     [Test]
     public void CheckInitialState([Values] TFlag flag)

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricStageWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricStageWorkingPropertyValidatorTest.cs
@@ -1,0 +1,64 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Stages.Classic;
+using osu.Game.Rulesets.Karaoke.Objects.Workings;
+using osu.Game.Rulesets.Karaoke.Stages;
+using osu.Game.Rulesets.Karaoke.Stages.Classic;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
+
+public class LyricStageWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricStageWorkingProperty, StageInfo>
+{
+    [Test]
+    public void TestStartTime()
+    {
+        var lyric = new Lyric();
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
+        AssetIsValid(lyric, LyricStageWorkingProperty.StartTime, true);
+    }
+
+    [Test]
+    public void TestDuration()
+    {
+        var lyric = new Lyric();
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.Duration = 1000);
+        AssetIsValid(lyric, LyricStageWorkingProperty.Duration, true);
+    }
+
+    [Test]
+    public void TestTiming()
+    {
+        var lyric = new Lyric();
+
+        // state is still invalid because duration is not assign.
+        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
+        AssetIsValid(lyric, LyricStageWorkingProperty.Timing, false);
+
+        // ok, should be valid now.
+        Assert.DoesNotThrow(() => lyric.Duration = 1000);
+        AssetIsValid(lyric, LyricStageWorkingProperty.Timing, true);
+    }
+
+    [Test]
+    public void TestEffectApplier()
+    {
+        var lyric = new Lyric();
+
+        // state is valid because assign the property.
+        Assert.DoesNotThrow(() => lyric.EffectApplier = new LyricClassicStageEffectApplier(Array.Empty<StageElement>(), new ClassicStageDefinition()));
+        AssetIsValid(lyric, LyricStageWorkingProperty.EffectApplier, true);
+    }
+
+    protected override bool IsInitialStateValid(LyricStageWorkingProperty flag)
+    {
+        return new LyricStageWorkingPropertyValidator(new Lyric()).IsValid(flag);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -7,10 +7,7 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Objects.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
-using osu.Game.Rulesets.Karaoke.Stages;
-using osu.Game.Rulesets.Karaoke.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Tests.Extensions;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
@@ -18,40 +15,6 @@ namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
 public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty, KaraokeBeatmap>
 {
-    [Test]
-    public void TestStartTime()
-    {
-        var lyric = new Lyric();
-
-        // state is valid because assign the property.
-        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.StartTime, true);
-    }
-
-    [Test]
-    public void TestDuration()
-    {
-        var lyric = new Lyric();
-
-        // state is valid because assign the property.
-        Assert.DoesNotThrow(() => lyric.Duration = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.Duration, true);
-    }
-
-    [Test]
-    public void TestTiming()
-    {
-        var lyric = new Lyric();
-
-        // state is still invalid because duration is not assign.
-        Assert.DoesNotThrow(() => lyric.StartTime = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, false);
-
-        // ok, should be valid now.
-        Assert.DoesNotThrow(() => lyric.Duration = 1000);
-        AssetIsValid(lyric, LyricWorkingProperty.Timing, true);
-    }
-
     [Test]
     public void TestSingers()
     {
@@ -187,16 +150,6 @@ public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidat
         // should throw the exception if assign the working reference lyric to the unmatched reference lyric id.
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => lyric.ReferenceLyric = new Lyric().ChangeId(3));
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => lyric.ReferenceLyric = null);
-    }
-
-    [Test]
-    public void TestEffectApplier()
-    {
-        var lyric = new Lyric();
-
-        // state is valid because assign the property.
-        Assert.DoesNotThrow(() => lyric.EffectApplier = new LyricClassicStageEffectApplier(Array.Empty<StageElement>(), new ClassicStageDefinition()));
-        AssetIsValid(lyric, LyricWorkingProperty.EffectApplier, true);
     }
 
     protected override bool IsInitialStateValid(LyricWorkingProperty flag)

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/LyricWorkingPropertyValidatorTest.cs
@@ -16,7 +16,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
-public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty>
+public class LyricWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Lyric, LyricWorkingProperty, KaraokeBeatmap>
 {
     [Test]
     public void TestStartTime()

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Objects.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
@@ -13,7 +14,7 @@ using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Objects.Workings;
 
-public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Note, NoteWorkingProperty>
+public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidatorTest<Note, NoteWorkingProperty, KaraokeBeatmap>
 {
     [Test]
     public void TestPage()

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Workings/NoteWorkingPropertyValidatorTest.cs
@@ -1,14 +1,10 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Objects.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
-using osu.Game.Rulesets.Karaoke.Stages;
-using osu.Game.Rulesets.Karaoke.Stages.Classic;
 using osu.Game.Rulesets.Karaoke.Tests.Extensions;
 using osu.Game.Rulesets.Karaoke.Tests.Helper;
 
@@ -74,16 +70,6 @@ public class NoteWorkingPropertyValidatorTest : HitObjectWorkingPropertyValidato
         // should throw the exception if assign the working reference lyric to the unmatched reference lyric id.
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => note.ReferenceLyric = new Lyric().ChangeId(3));
         Assert.Throws<InvalidWorkingPropertyAssignException>(() => note.ReferenceLyric = null);
-    }
-
-    [Test]
-    public void TestEffectApplier()
-    {
-        var note = new Note();
-
-        // page state is valid because assign the property.
-        Assert.DoesNotThrow(() => note.EffectApplier = new NoteClassicStageEffectApplier(Array.Empty<StageElement>(), new ClassicStageDefinition()));
-        AssetIsValid(note, NoteWorkingProperty.EffectApplier, true);
     }
 
     protected override bool IsInitialStateValid(NoteWorkingProperty flag)

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
@@ -41,10 +42,10 @@ public class KaraokeBeatmapProcessor : BeatmapProcessor
             // should invalidate the working property here because the stage info is changed.
             beatmap.HitObjects.OfType<Lyric>().ForEach(x =>
             {
-                x.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
-                x.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier);
+                x.InvalidateWorkingProperty(LyricStageWorkingProperty.Timing);
+                x.InvalidateWorkingProperty(LyricStageWorkingProperty.EffectApplier);
             });
-            beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteWorkingProperty.EffectApplier));
+            beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteStageWorkingProperty.EffectApplier));
         }
 
         if (beatmap.CurrentStageInfo is IHasCalculatedProperty calculatedProperty)
@@ -63,6 +64,15 @@ public class KaraokeBeatmapProcessor : BeatmapProcessor
         foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty<KaraokeBeatmap>>().ToArray())
         {
             hitObject.ValidateWorkingProperty(beatmap);
+        }
+
+        var stageInfo = beatmap.CurrentStageInfo;
+        if (stageInfo == null)
+            throw new InvalidCastException();
+
+        foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty<StageInfo>>().ToArray())
+        {
+            hitObject.ValidateWorkingProperty(stageInfo);
         }
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapProcessor.cs
@@ -60,7 +60,7 @@ public class KaraokeBeatmapProcessor : BeatmapProcessor
     {
         // should convert to array here because validate the working property might change the start-time and the end time.
         // which will cause got the wrong item in the array.
-        foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty>().ToArray())
+        foreach (var hitObject in beatmap.HitObjects.OfType<IHasWorkingProperty<KaraokeBeatmap>>().ToArray())
         {
             hitObject.ValidateWorkingProperty(beatmap);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/BeatmapPropertyChangeHandler.cs
@@ -89,7 +89,7 @@ public partial class BeatmapPropertyChangeHandler : Component
     protected void InvalidateAllHitObjectWorkingProperty<TWorkingProperty>(TWorkingProperty property)
         where TWorkingProperty : struct, Enum
     {
-        foreach (var hitObject in KaraokeBeatmap.HitObjects.OfType<IHasWorkingProperty<TWorkingProperty>>())
+        foreach (var hitObject in KaraokeBeatmap.HitObjects.OfType<IHasWorkingProperty<TWorkingProperty, KaraokeBeatmap>>())
         {
             hitObject.InvalidateWorkingProperty(property);
         }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/ClassicStageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/ClassicStageChangeHandler.cs
@@ -119,7 +119,7 @@ public partial class ClassicStageChangeHandler : BeatmapPropertyChangeHandler, I
         {
             action(stageInfo.LyricTimingInfo);
 
-            InvalidateAllHitObjectWorkingProperty(LyricWorkingProperty.Timing);
+            InvalidateAllHitObjectWorkingProperty(LyricStageWorkingProperty.Timing);
         });
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
@@ -38,10 +38,10 @@ public abstract class ModStage<TStageInfo> : ModStage, IApplicableAfterBeatmapCo
         // has the same logic in the beatmap processor.
         beatmap.HitObjects.OfType<Lyric>().ForEach(x =>
         {
-            x.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
-            x.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier);
+            x.InvalidateWorkingProperty(LyricStageWorkingProperty.Timing);
+            x.InvalidateWorkingProperty(LyricStageWorkingProperty.EffectApplier);
         });
-        beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteWorkingProperty.EffectApplier));
+        beatmap.HitObjects.OfType<Note>().ForEach(x => x.InvalidateWorkingProperty(NoteStageWorkingProperty.EffectApplier));
     }
 
     protected abstract void ApplyToCurrentStageInfo(TStageInfo stageInfo);

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric.cs
@@ -188,6 +188,7 @@ public partial class Lyric : KaraokeHitObject, IHasPage, IHasDuration, IHasSinge
     public Lyric()
     {
         workingPropertyValidator = new LyricWorkingPropertyValidator(this);
+        stageWorkingPropertyValidator = new LyricStageWorkingPropertyValidator(this);
 
         initInternalBindingEvent();
         initReferenceLyricEvent();

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffectApplier
+public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty, KaraokeBeatmap>, IHasEffectApplier
 {
     [JsonIgnore]
     private readonly LyricWorkingPropertyValidator workingPropertyValidator;

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -21,23 +21,35 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty, KaraokeBeatmap>, IHasEffectApplier
+public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty, KaraokeBeatmap>, IHasWorkingProperty<LyricStageWorkingProperty, StageInfo>, IHasEffectApplier
 {
     [JsonIgnore]
     private readonly LyricWorkingPropertyValidator workingPropertyValidator;
 
+    [JsonIgnore]
+    private readonly LyricStageWorkingPropertyValidator stageWorkingPropertyValidator;
+
     public bool InvalidateWorkingProperty(LyricWorkingProperty workingProperty)
         => workingPropertyValidator.Invalidate(workingProperty);
+
+    public bool InvalidateWorkingProperty(LyricStageWorkingProperty workingProperty)
+        => stageWorkingPropertyValidator.Invalidate(workingProperty);
 
     private void updateStateByWorkingProperty(LyricWorkingProperty workingProperty)
         => workingPropertyValidator.UpdateStateByWorkingProperty(workingProperty);
 
-    public LyricWorkingProperty[] GetAllInvalidWorkingProperties()
+    private void updateStateByWorkingProperty(LyricStageWorkingProperty workingProperty)
+        => stageWorkingPropertyValidator.UpdateStateByWorkingProperty(workingProperty);
+
+    LyricWorkingProperty[] IHasWorkingProperty<LyricWorkingProperty, KaraokeBeatmap>.GetAllInvalidWorkingProperties()
         => workingPropertyValidator.GetAllInvalidFlags();
+
+    LyricStageWorkingProperty[] IHasWorkingProperty<LyricStageWorkingProperty, StageInfo>.GetAllInvalidWorkingProperties()
+        => stageWorkingPropertyValidator.GetAllInvalidFlags();
 
     public void ValidateWorkingProperty(KaraokeBeatmap beatmap)
     {
-        foreach (var flag in GetAllInvalidWorkingProperties())
+        foreach (var flag in workingPropertyValidator.GetAllInvalidFlags())
         {
             switch (flag)
             {
@@ -111,6 +123,10 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty, KaraokeBe
 
             return stageInfo.GetStageAppliers(lyric);
         }
+    }
+
+    public void ValidateWorkingProperty(StageInfo stageInfo)
+    {
     }
 
     [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Objects/Note.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note.cs
@@ -127,6 +127,7 @@ public partial class Note : KaraokeHitObject, IHasPage, IHasDuration, IHasText, 
     public Note()
     {
         workingPropertyValidator = new NoteWorkingPropertyValidator(this);
+        stageWorkingPropertyValidator = new NoteStageWorkingPropertyValidator(this);
 
         initInternalBindingEvent();
         initReferenceLyricEvent();

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -61,10 +61,6 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeat
                     ReferenceLyric = findLyricById(beatmap, ReferenceLyricId);
                     break;
 
-                case NoteWorkingProperty.EffectApplier:
-                    EffectApplier = getStageEffectApplier(beatmap, this);
-                    break;
-
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -75,19 +71,22 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeat
 
         static Lyric? findLyricById(IBeatmap beatmap, ElementId? id) =>
             id == null ? null : beatmap.HitObjects.OfType<Lyric>().Single(x => x.ID == id);
-
-        static IStageEffectApplier getStageEffectApplier(KaraokeBeatmap beatmap, Note note)
-        {
-            var stageInfo = beatmap.CurrentStageInfo;
-            if (stageInfo == null)
-                throw new InvalidCastException();
-
-            return stageInfo.GetStageAppliers(note);
-        }
     }
 
     public void ValidateWorkingProperty(StageInfo stageInfo)
     {
+        foreach (var flag in stageWorkingPropertyValidator.GetAllInvalidFlags())
+        {
+            switch (flag)
+            {
+                case NoteStageWorkingProperty.EffectApplier:
+                    EffectApplier = stageInfo.GetStageAppliers(this);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 
     [JsonIgnore]
@@ -190,7 +189,7 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeat
         {
             EffectApplierBindable.Value = value;
 
-            updateStateByWorkingProperty(NoteWorkingProperty.EffectApplier);
+            updateStateByWorkingProperty(NoteStageWorkingProperty.EffectApplier);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Karaoke.Beatmaps.Metadatas;
 using osu.Game.Rulesets.Karaoke.Objects.Stages;
 using osu.Game.Rulesets.Karaoke.Objects.Types;
 using osu.Game.Rulesets.Karaoke.Objects.Workings;
+using osu.Game.Rulesets.Karaoke.Stages;
 
 namespace osu.Game.Rulesets.Karaoke.Objects;
 
@@ -20,23 +21,35 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeatmap>, IHasEffectApplier
+public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeatmap>, IHasWorkingProperty<NoteStageWorkingProperty, StageInfo>, IHasEffectApplier
 {
     [JsonIgnore]
     private readonly NoteWorkingPropertyValidator workingPropertyValidator;
 
+    [JsonIgnore]
+    private readonly NoteStageWorkingPropertyValidator stageWorkingPropertyValidator;
+
     public bool InvalidateWorkingProperty(NoteWorkingProperty workingProperty)
         => workingPropertyValidator.Invalidate(workingProperty);
+
+    public bool InvalidateWorkingProperty(NoteStageWorkingProperty workingProperty)
+        => stageWorkingPropertyValidator.Invalidate(workingProperty);
 
     private void updateStateByWorkingProperty(NoteWorkingProperty workingProperty)
         => workingPropertyValidator.UpdateStateByWorkingProperty(workingProperty);
 
-    public NoteWorkingProperty[] GetAllInvalidWorkingProperties()
+    private void updateStateByWorkingProperty(NoteStageWorkingProperty workingProperty)
+        => stageWorkingPropertyValidator.UpdateStateByWorkingProperty(workingProperty);
+
+    NoteWorkingProperty[] IHasWorkingProperty<NoteWorkingProperty, KaraokeBeatmap>.GetAllInvalidWorkingProperties()
         => workingPropertyValidator.GetAllInvalidFlags();
+
+    NoteStageWorkingProperty[] IHasWorkingProperty<NoteStageWorkingProperty, StageInfo>.GetAllInvalidWorkingProperties()
+        => stageWorkingPropertyValidator.GetAllInvalidFlags();
 
     public void ValidateWorkingProperty(KaraokeBeatmap beatmap)
     {
-        foreach (var flag in GetAllInvalidWorkingProperties())
+        foreach (var flag in workingPropertyValidator.GetAllInvalidFlags())
         {
             switch (flag)
             {
@@ -71,6 +84,10 @@ public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeat
 
             return stageInfo.GetStageAppliers(note);
         }
+    }
+
+    public void ValidateWorkingProperty(StageInfo stageInfo)
+    {
     }
 
     [JsonIgnore]

--- a/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Note_Working.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Objects;
 /// Placing the properties that set by <see cref="KaraokeBeatmapProcessor"/> or being calculated.
 /// Those properties will not be saved into the beatmap.
 /// </summary>
-public partial class Note : IHasWorkingProperty<NoteWorkingProperty>, IHasEffectApplier
+public partial class Note : IHasWorkingProperty<NoteWorkingProperty, KaraokeBeatmap>, IHasEffectApplier
 {
     [JsonIgnore]
     private readonly NoteWorkingPropertyValidator workingPropertyValidator;

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
@@ -2,11 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 
 namespace osu.Game.Rulesets.Karaoke.Objects.Types;
 
-public interface IHasWorkingProperty<TWorkingProperty> : IHasWorkingProperty
+public interface IHasWorkingProperty<TWorkingProperty, TFillProperty> : IHasWorkingProperty<TFillProperty>
     where TWorkingProperty : struct, Enum
 {
     bool InvalidateWorkingProperty(TWorkingProperty workingProperty);
@@ -14,7 +13,7 @@ public interface IHasWorkingProperty<TWorkingProperty> : IHasWorkingProperty
     TWorkingProperty[] GetAllInvalidWorkingProperties();
 }
 
-public interface IHasWorkingProperty
+public interface IHasWorkingProperty<in TFillProperty>
 {
-    void ValidateWorkingProperty(KaraokeBeatmap beatmap);
+    void ValidateWorkingProperty(TFillProperty fillProperty);
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Types/IHasWorkingProperty.cs
@@ -11,6 +11,8 @@ public interface IHasWorkingProperty<TWorkingProperty, TFillProperty> : IHasWork
     bool InvalidateWorkingProperty(TWorkingProperty workingProperty);
 
     TWorkingProperty[] GetAllInvalidWorkingProperties();
+
+    bool HasInvalidWorkingProperty() => GetAllInvalidWorkingProperties().Length > 0;
 }
 
 public interface IHasWorkingProperty<in TFillProperty>

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricStageWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricStageWorkingProperty.cs
@@ -1,0 +1,33 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
+
+/// <summary>
+/// Specifies which properties in the <see cref="Lyric"/> are being invalidated.
+/// </summary>
+[Flags]
+public enum LyricStageWorkingProperty
+{
+    /// <summary>
+    /// <see cref="Lyric.StartTime"/> is being invalidated.
+    /// </summary>
+    StartTime = 1,
+
+    /// <summary>
+    /// <see cref="Lyric.Duration"/> is being invalidated.
+    /// </summary>
+    Duration = 1 << 1,
+
+    /// <summary>
+    /// <see cref="Lyric.StartTime"/> and <see cref="Lyric.Duration"/> is being invalidated.
+    /// </summary>
+    Timing = StartTime | Duration,
+
+    /// <summary>
+    /// <see cref="Lyric.EffectApplier"/> is being invalidated.
+    /// </summary>
+    EffectApplier = 1 << 2,
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricStageWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricStageWorkingPropertyValidator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
+
+public class LyricStageWorkingPropertyValidator : HitObjectWorkingPropertyValidator<Lyric, LyricStageWorkingProperty>
+{
+    public LyricStageWorkingPropertyValidator(Lyric hitObject)
+        : base(hitObject)
+    {
+    }
+
+    protected override bool HasDataProperty(LyricStageWorkingProperty flags) => false;
+
+    protected override bool IsWorkingPropertySynced(Lyric hitObject, LyricStageWorkingProperty flags) => true;
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingProperty.cs
@@ -12,37 +12,17 @@ namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
 public enum LyricWorkingProperty
 {
     /// <summary>
-    /// <see cref="Lyric.StartTime"/> is being invalidated.
-    /// </summary>
-    StartTime = 1,
-
-    /// <summary>
-    /// <see cref="Lyric.Duration"/> is being invalidated.
-    /// </summary>
-    Duration = 1 << 1,
-
-    /// <summary>
-    /// <see cref="Lyric.StartTime"/> and <see cref="Lyric.Duration"/> is being invalidated.
-    /// </summary>
-    Timing = StartTime | Duration,
-
-    /// <summary>
     /// <see cref="Lyric.Singers"/> is being invalidated.
     /// </summary>
-    Singers = 1 << 2,
+    Singers = 1,
 
     /// <summary>
     /// <see cref="Lyric.PageIndex"/> is being invalidated.
     /// </summary>
-    Page = 1 << 3,
+    Page = 1 << 1,
 
     /// <summary>
     /// <see cref="Lyric.ReferenceLyric"/> is being invalidated.
     /// </summary>
-    ReferenceLyric = 1 << 4,
-
-    /// <summary>
-    /// <see cref="Lyric.EffectApplier"/> is being invalidated.
-    /// </summary>
-    EffectApplier = 1 << 5,
+    ReferenceLyric = 1 << 2,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/LyricWorkingPropertyValidator.cs
@@ -18,26 +18,18 @@ public class LyricWorkingPropertyValidator : HitObjectWorkingPropertyValidator<L
     protected override bool HasDataProperty(LyricWorkingProperty flags) =>
         flags switch
         {
-            LyricWorkingProperty.StartTime => false,
-            LyricWorkingProperty.Duration => false,
-            LyricWorkingProperty.Timing => false,
             LyricWorkingProperty.Singers => true,
             LyricWorkingProperty.Page => false,
             LyricWorkingProperty.ReferenceLyric => true,
-            LyricWorkingProperty.EffectApplier => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null),
         };
 
     protected override bool IsWorkingPropertySynced(Lyric hitObject, LyricWorkingProperty flags) =>
         flags switch
         {
-            LyricWorkingProperty.StartTime => true,
-            LyricWorkingProperty.Duration => true,
-            LyricWorkingProperty.Timing => true,
             LyricWorkingProperty.Singers => isWorkingSingerSynced(hitObject),
             LyricWorkingProperty.Page => true,
             LyricWorkingProperty.ReferenceLyric => isReferenceLyricSynced(hitObject),
-            LyricWorkingProperty.EffectApplier => true,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null),
         };
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteStageWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteStageWorkingProperty.cs
@@ -1,0 +1,18 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
+
+/// <summary>
+/// Specifies which properties in the <see cref="Note"/> are being invalidated.
+/// </summary>
+[Flags]
+public enum NoteStageWorkingProperty
+{
+    /// <summary>
+    /// <see cref="Note.EffectApplier"/> is being invalidated.
+    /// </summary>
+    EffectApplier = 1,
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteStageWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteStageWorkingPropertyValidator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Karaoke.Objects.Workings;
+
+public class NoteStageWorkingPropertyValidator : HitObjectWorkingPropertyValidator<Note, NoteStageWorkingProperty>
+{
+    public NoteStageWorkingPropertyValidator(Note hitObject)
+        : base(hitObject)
+    {
+    }
+
+    protected override bool HasDataProperty(NoteStageWorkingProperty flags) => false;
+
+    protected override bool IsWorkingPropertySynced(Note hitObject, NoteStageWorkingProperty flags) => true;
+}

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingProperty.cs
@@ -20,9 +20,4 @@ public enum NoteWorkingProperty
     /// <see cref="Note.ReferenceLyric"/> is being invalidated.
     /// </summary>
     ReferenceLyric = 1 << 1,
-
-    /// <summary>
-    /// <see cref="Note.EffectApplier"/> is being invalidated.
-    /// </summary>
-    EffectApplier = 1 << 2,
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Workings/NoteWorkingPropertyValidator.cs
@@ -17,7 +17,6 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
         {
             NoteWorkingProperty.Page => false,
             NoteWorkingProperty.ReferenceLyric => true,
-            NoteWorkingProperty.EffectApplier => false,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null),
         };
 
@@ -26,7 +25,6 @@ public class NoteWorkingPropertyValidator : HitObjectWorkingPropertyValidator<No
         {
             NoteWorkingProperty.Page => true,
             NoteWorkingProperty.ReferenceLyric => hitObject.ReferenceLyric?.ID == hitObject.ReferenceLyricId,
-            NoteWorkingProperty.EffectApplier => true,
             _ => throw new ArgumentOutOfRangeException(nameof(flags), flags, null),
         };
 }

--- a/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
@@ -86,8 +86,8 @@ public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
             layoutCategory.AddToMapping(element, lyric);
 
             // Need to invalidate the working property in the lyric to let the property re-fill in the beatmap processor.
-            lyric.InvalidateWorkingProperty(LyricWorkingProperty.Timing);
-            lyric.InvalidateWorkingProperty(LyricWorkingProperty.EffectApplier);
+            lyric.InvalidateWorkingProperty(LyricStageWorkingProperty.Timing);
+            lyric.InvalidateWorkingProperty(LyricStageWorkingProperty.EffectApplier);
         }
 
         calculatedPropertyIsUpdated = true;


### PR DESCRIPTION
Mark as part of #2090.

目前希望 stageInfo 也能有自己的 processor.

第一個目標是把 ValidateWorkingProperty 分開
讓 beatmap processor / stage info processor 能夠分別丟入 karaoke beatmap / stage info 來把 lyric/note 的 working property 補上值

以 lyric 舉例
目前所有的 working property type 都是放在同一個 enum 中

但會有一個缺點，需要呼叫ValidateWorkingProperty(beatmap) + ValidateWorkingProperty(stage) 才能把所有的 working property 都補上值

有一個想法，是不同種類的 working property (beatmap / stage) 應該都要有自己的 enum，有一些好處:
- 可以確認 ValidateWorkingProperty(beatmap) 跑完後，所有和 beatmap 相關的 working property 都是有值的

Notion:
https://karaoke-dev.notion.site/HitObject-working-property-f269d04837a14000a2a21e03c1a8c8d0?pvs=4
先記錄在這邊，想好後再開始處理這隻 PR
