### PR TITLE
Update six labor font package to the latest.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="ppy.osu.Game" Version="2023.908.1" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta18" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.0" />
     <!--install because it might cause "Could not load file or assembly" error, might be removed eventually-->
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageReference Include="WanaKanaSharp" Version="0.2.0" />


### PR DESCRIPTION
Have "Method" not found issue.
Guess because six labor package in the osu-framrework is old version.

Here's the nuget package:
https://www.nuget.org/packages/SixLabors.Fonts#dependencies-body-tab
And IDK why this package did not need image sharp package anymore 🤔 

Here's the repo:
https://github.com/SixLabors/Fonts

Here's the sample(not using the latest package)
https://github.com/SixLabors/Fonts/tree/main/samples/DrawWithImageSharp

todo:
- [x] wait sample update -> drawing package should update also.