### PR TITLE
Adjust the caret state behavior.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -27,12 +27,6 @@ public interface ILyricCaretState
 
     ICaretPosition? GetCaretPositionByAction(MovingCaretAction action);
 
-    bool MoveCaretToTargetPosition(Lyric lyric);
-
-    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
-
-    bool MoveDraggingCaretIndex<TIndex>(TIndex index) where TIndex : notnull;
-
     bool MoveHoverCaretToTargetPosition(Lyric lyric);
 
     bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
@@ -40,6 +34,12 @@ public interface ILyricCaretState
     bool ConfirmHoverCaretPosition();
 
     bool ClearHoverCaretPosition();
+
+    bool MoveCaretToTargetPosition(Lyric lyric);
+
+    bool MoveCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index) where TIndex : notnull;
+
+    bool MoveDraggingCaretIndex<TIndex>(TIndex index) where TIndex : notnull;
 
     void SyncSelectedHitObjectWithCaret();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -363,9 +363,24 @@ public partial class LyricCaretState : Component, ILyricCaretState
     {
         selectedHitObjects.Clear();
 
-        var lyric = bindableCaretPosition.Value?.Lyric;
-        if (lyric != null)
-            selectedHitObjects.Add(lyric);
+        if (bindableRangeCaretPosition.Value is RangeCaretPosition rangeCaretPosition)
+        {
+            addLyricToSelectedHitObjectList(rangeCaretPosition.Start.Lyric);
+            addLyricToSelectedHitObjectList(rangeCaretPosition.End.Lyric);
+        }
+
+        if (bindableCaretPosition.Value?.Lyric != null)
+        {
+            addLyricToSelectedHitObjectList(bindableCaretPosition.Value.Lyric);
+        }
+
+        void addLyricToSelectedHitObjectList(Lyric newLyric)
+        {
+            if (selectedHitObjects.Contains(newLyric))
+                return;
+
+            selectedHitObjects.Add(newLyric);
+        }
     }
 
     public bool CaretEnabled => algorithm != null;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -261,6 +261,46 @@ public partial class LyricCaretState : Component, ILyricCaretState
         }
     }
 
+    public bool MoveHoverCaretToTargetPosition(Lyric lyric)
+    {
+        var caretPosition = algorithm?.MoveToTargetLyric(lyric);
+        return moveHoverCaretToTargetPosition(caretPosition);
+    }
+
+    public bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index)
+        where TIndex : notnull
+    {
+        if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
+            return false;
+
+        var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);
+        return moveHoverCaretToTargetPosition(caretPosition);
+    }
+
+    private bool moveHoverCaretToTargetPosition(ICaretPosition? position)
+    {
+        if (position == null)
+            return false;
+
+        bindableHoverCaretPosition.Value = position;
+
+        return true;
+    }
+
+    public bool ConfirmHoverCaretPosition()
+    {
+        // place hover caret to target position.
+        var position = BindableHoverCaretPosition.Value;
+        return moveCaretToTargetPosition(position);
+    }
+
+    public bool ClearHoverCaretPosition()
+    {
+        bindableHoverCaretPosition.Value = null;
+
+        return true;
+    }
+
     public bool MoveCaretToTargetPosition(Lyric lyric)
     {
         var caretPosition = algorithm?.MoveToTargetLyric(lyric);
@@ -315,46 +355,6 @@ public partial class LyricCaretState : Component, ILyricCaretState
 
         bindableHoverCaretPosition.Value = null;
         bindableRangeCaretPosition.Value = new RangeCaretPosition(startCaretPosition, endCaretPosition);
-
-        return true;
-    }
-
-    public bool MoveHoverCaretToTargetPosition(Lyric lyric)
-    {
-        var caretPosition = algorithm?.MoveToTargetLyric(lyric);
-        return moveHoverCaretToTargetPosition(caretPosition);
-    }
-
-    public bool MoveHoverCaretToTargetPosition<TIndex>(Lyric lyric, TIndex index)
-        where TIndex : notnull
-    {
-        if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
-            return false;
-
-        var caretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(lyric, index);
-        return moveHoverCaretToTargetPosition(caretPosition);
-    }
-
-    private bool moveHoverCaretToTargetPosition(ICaretPosition? position)
-    {
-        if (position == null)
-            return false;
-
-        bindableHoverCaretPosition.Value = position;
-
-        return true;
-    }
-
-    public bool ConfirmHoverCaretPosition()
-    {
-        // place hover caret to target position.
-        var position = BindableHoverCaretPosition.Value;
-        return moveCaretToTargetPosition(position);
-    }
-
-    public bool ClearHoverCaretPosition()
-    {
-        bindableHoverCaretPosition.Value = null;
 
         return true;
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -331,7 +331,7 @@ public partial class LyricCaretState : Component, ILyricCaretState
             return false;
 
         var endCaretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(caretPosition.Lyric, index);
-        return moveDraggingCaretToTargetPosition(startCaretPosition, endCaretPosition);
+        return moveRangeCaretToTargetPosition(startCaretPosition, endCaretPosition);
     }
 
     private bool moveCaretToTargetPosition(ICaretPosition? position)
@@ -348,7 +348,7 @@ public partial class LyricCaretState : Component, ILyricCaretState
         return true;
     }
 
-    private bool moveDraggingCaretToTargetPosition(IIndexCaretPosition startCaretPosition, IIndexCaretPosition? endCaretPosition)
+    private bool moveRangeCaretToTargetPosition(IIndexCaretPosition startCaretPosition, IIndexCaretPosition? endCaretPosition)
     {
         if (endCaretPosition == null)
             return false;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/RangeCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/RangeCaretPosition.cs
@@ -6,26 +6,43 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
-public struct RangeCaretPosition
+public class RangeCaretPosition : RangeCaretPosition<IIndexCaretPosition>
 {
     public RangeCaretPosition(IIndexCaretPosition start, IIndexCaretPosition end)
+        : base(start, end)
+    {
+    }
+
+    public RangeCaretPosition<TIndexCaretPosition> GetRangeCaretPositionWithType<TIndexCaretPosition>()
+        where TIndexCaretPosition : struct, IIndexCaretPosition
+    {
+        if (Start is not TIndexCaretPosition start || End is not TIndexCaretPosition end)
+            throw new InvalidCastException();
+
+        return new RangeCaretPosition<TIndexCaretPosition>(start, end);
+    }
+}
+
+public class RangeCaretPosition<TIndexCaretPosition> where TIndexCaretPosition : IIndexCaretPosition
+{
+    public RangeCaretPosition(TIndexCaretPosition start, TIndexCaretPosition end)
     {
         Start = start;
         End = end;
     }
 
-    public IIndexCaretPosition Start { get; set; }
+    public TIndexCaretPosition Start { get; }
 
-    public IIndexCaretPosition End { get; set; }
+    public TIndexCaretPosition End { get; }
 
     /// <summary>
     /// Get the range caret position with ordered.
     /// </summary>
     /// <returns></returns>
-    public Tuple<IIndexCaretPosition, IIndexCaretPosition> GetRangeCaretPosition()
+    public Tuple<TIndexCaretPosition, TIndexCaretPosition> GetRangeCaretPosition()
     {
         return Start < End
-            ? new Tuple<IIndexCaretPosition, IIndexCaretPosition>(Start, End)
-            : new Tuple<IIndexCaretPosition, IIndexCaretPosition>(End, Start);
+            ? new Tuple<TIndexCaretPosition, TIndexCaretPosition>(Start, End)
+            : new Tuple<TIndexCaretPosition, TIndexCaretPosition>(End, Start);
     }
 }


### PR DESCRIPTION
What's done in this PR:
- Adjust some method order in the lyric editor caret state.
- Handle the action (e.g. move to previous index) if has range caret position. Should follow the same behavior as text editor in the windows/osx.