### PR TITLE
Moving index caret position should be only in the editable lyric.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/ViewOnlyLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/ViewOnlyLyric.cs
@@ -2,12 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics;
 
 public partial class ViewOnlyLyric : InteractableLyric
 {
+    [Resolved]
+    private ILyricCaretState lyricCaretState { get; set; } = null!;
+
     public ViewOnlyLyric(Lyric lyric)
         : base(lyric)
     {
@@ -19,5 +25,31 @@ public partial class ViewOnlyLyric : InteractableLyric
         {
             new TimeTagLayer(lyric),
         };
+    }
+
+    protected override bool OnMouseMove(MouseMoveEvent e)
+    {
+        if (!lyricCaretState.CaretEnabled)
+            return false;
+
+        if (IsDragged)
+            return false;
+
+        lyricCaretState.MoveHoverCaretToTargetPosition(Lyric);
+
+        return base.OnMouseMove(e);
+    }
+
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        base.OnHoverLost(e);
+
+        // lost hover caret and time-tag caret
+        lyricCaretState.ClearHoverCaretPosition();
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        return lyricCaretState.MoveCaretToTargetPosition(Lyric);
     }
 }


### PR DESCRIPTION
![image](https://github.com/karaoke-dev/karaoke/assets/9100368/7a303c9f-175f-4bc8-b7e2-c92cb6b69ccd)
Should not change the caret position index in here, the UX feels weird.

Found while implementing the #2112