### PR TITLE
Change the drag caret position will not change the caret position.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/BaseLyricCaretStateTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/BaseLyricCaretStateTest.cs
@@ -66,7 +66,7 @@ public abstract partial class BaseLyricCaretStateTest : OsuTestScene
     [SetUp]
     public void Setup()
     {
-        AddStep("Set-up.", () =>
+        AddStep("Set-up", () =>
         {
             state.SwitchMode(LyricEditorMode.View);
         });
@@ -149,7 +149,7 @@ public abstract partial class BaseLyricCaretStateTest : OsuTestScene
 
     public void PrepareRangeCaretPosition(Func<RangeCaretPosition?> getPosition)
     {
-        AddStep("Set caret position", () =>
+        AddStep("Set range caret position", () =>
         {
             if (LyricCaretState.BindableRangeCaretPosition is not Bindable<RangeCaretPosition?> bindable)
                 throw new InvalidOperationException();

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateActionTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateActionTest.cs
@@ -301,7 +301,7 @@ public partial class LyricCaretStateActionTest : BaseLyricCaretStateTest
 
     protected void AssertGetCaretPositionByAction(MovingCaretAction action, Func<ICaretPosition?> getPosition)
     {
-        AddAssert("Assert caret position", () =>
+        AddAssert("Assert caret position by action", () =>
         {
             var expectedCaret = getPosition();
             var actualCaret = LyricCaretState.GetCaretPositionByAction(action);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateMoveCaretTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateMoveCaretTest.cs
@@ -208,12 +208,12 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
     {
         PrepareLyrics(new[] { "Lyric1", "Lyric2" });
         ChangeMode(TestCaretType.CaretDraggable);
-        MoveCaretToTargetPosition(() => GetLyric(1), () => 1);
+        MoveHoverCaretToTargetPosition(() => GetLyric(1), () => 1);
 
         // start dragging.
         StartDragging();
         AssertHoverCaretPosition(() => null);
-        AssertCaretPosition(() => new TypingCaretPosition(GetLyric(1), 1));
+        AssertCaretPosition(() => null);
         AssertDraggableCaretPosition(() =>
         {
             var startPosition = new TypingCaretPosition(GetLyric(1), 1);
@@ -225,7 +225,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
         // move dragging index.
         MoveDraggingCaretIndex(() => 2);
         AssertHoverCaretPosition(() => null);
-        AssertCaretPosition(() => new TypingCaretPosition(GetLyric(1), 1));
+        AssertCaretPosition(() => null);
         AssertDraggableCaretPosition(() =>
         {
             var startPosition = new TypingCaretPosition(GetLyric(1), 1);
@@ -237,7 +237,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
         // end dragging.
         EndDragging();
         AssertHoverCaretPosition(() => null);
-        AssertCaretPosition(() => new TypingCaretPosition(GetLyric(1), 1));
+        AssertCaretPosition(() => null);
         AssertDraggableCaretPosition(() =>
         {
             var startPosition = new TypingCaretPosition(GetLyric(1), 1);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateMoveCaretTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateMoveCaretTest.cs
@@ -253,7 +253,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
 
     protected void MoveHoverCaretToTargetPosition(Func<Lyric> lyric)
     {
-        AddStep("Moving hover caret by action", () =>
+        AddStep("Moving hover caret to target position", () =>
         {
             LyricCaretState.MoveHoverCaretToTargetPosition(lyric());
         });
@@ -262,7 +262,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
     protected void MoveHoverCaretToTargetPosition<TIndex>(Func<Lyric> lyric, Func<TIndex> index)
         where TIndex : notnull
     {
-        AddStep("Moving hover caret by caret position", () =>
+        AddStep("Moving hover caret to target position with index", () =>
         {
             LyricCaretState.MoveHoverCaretToTargetPosition(lyric(), index());
         });
@@ -270,7 +270,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
 
     protected void ConfirmHoverCaretPosition()
     {
-        AddStep("Moving hover caret by action", () =>
+        AddStep("Conform hover caret position", () =>
         {
             LyricCaretState.ConfirmHoverCaretPosition();
         });
@@ -278,7 +278,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
 
     protected void ClearHoverCaretPosition()
     {
-        AddStep("Moving hover caret by action", () =>
+        AddStep("Clear hover caret position", () =>
         {
             LyricCaretState.ClearHoverCaretPosition();
         });
@@ -286,7 +286,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
 
     protected void MoveCaretToTargetPosition(Func<Lyric> lyric)
     {
-        AddStep("Moving caret by action", () =>
+        AddStep("Move caret to target position", () =>
         {
             LyricCaretState.MoveCaretToTargetPosition(lyric());
         });
@@ -295,7 +295,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
     protected void MoveCaretToTargetPosition<TIndex>(Func<Lyric> lyric, Func<TIndex> index)
         where TIndex : notnull
     {
-        AddStep("Moving caret by action", () =>
+        AddStep("Move caret to target position with index", () =>
         {
             LyricCaretState.MoveCaretToTargetPosition(lyric(), index());
         });
@@ -312,7 +312,7 @@ public partial class LyricCaretStateMoveCaretTest : BaseLyricCaretStateTest
     protected void MoveDraggingCaretIndex<TIndex>(Func<TIndex> index)
         where TIndex : notnull
     {
-        AddStep("Moving caret by caret position", () =>
+        AddStep("Moving dragging caret index", () =>
         {
             LyricCaretState.MoveDraggingCaretIndex(index());
         });

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateSwitchModeTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateSwitchModeTest.cs
@@ -141,13 +141,13 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
 
     protected void AssertCaretPositionAlgorithmIsNull()
     {
-        AddAssert("Assert caret position type", () => LyricCaretState.CaretPositionAlgorithm == null);
+        AddAssert("Assert caret position algorithm should be null", () => LyricCaretState.CaretPositionAlgorithm == null);
     }
 
     protected void AssertCaretPositionAlgorithm<TCaretPositionAlgorithm>()
         where TCaretPositionAlgorithm : ICaretPositionAlgorithm
     {
-        AddAssert("Assert caret position type", () => LyricCaretState.CaretPositionAlgorithm?.GetType() == typeof(TCaretPositionAlgorithm));
+        AddAssert("Assert caret position algorithm", () => LyricCaretState.CaretPositionAlgorithm?.GetType() == typeof(TCaretPositionAlgorithm));
     }
 
     #endregion

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateSwitchModeTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Beatmap/Lyrics/States/LyricCaretStateSwitchModeTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Beatmap.Lyrics.States;
@@ -24,6 +25,8 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
 
         AssertCaretEnabled(false);
         AssertCaretDraggable(false);
+
+        AssertCaretPositionAlgorithmIsNull();
     }
 
     [Test]
@@ -38,6 +41,8 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
 
         AssertCaretEnabled(true);
         AssertCaretDraggable(false);
+
+        AssertCaretPositionAlgorithm<NavigateCaretPositionAlgorithm>();
     }
 
     [Test]
@@ -52,6 +57,8 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
 
         AssertCaretEnabled(true);
         AssertCaretDraggable(false);
+
+        AssertCaretPositionAlgorithm<CuttingCaretPositionAlgorithm>();
     }
 
     [Test]
@@ -66,6 +73,8 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
 
         AssertCaretEnabled(true);
         AssertCaretDraggable(true);
+
+        AssertCaretPositionAlgorithm<TypingCaretPositionAlgorithm>();
     }
 
     #endregion
@@ -128,6 +137,17 @@ public partial class LyricCaretStateSwitchModeTest : BaseLyricCaretStateTest
     protected void AssertCaretDraggable(bool caretDraggable)
     {
         AddAssert("Assert caret draggable", () => LyricCaretState.CaretDraggable == caretDraggable);
+    }
+
+    protected void AssertCaretPositionAlgorithmIsNull()
+    {
+        AddAssert("Assert caret position type", () => LyricCaretState.CaretPositionAlgorithm == null);
+    }
+
+    protected void AssertCaretPositionAlgorithm<TCaretPositionAlgorithm>()
+        where TCaretPositionAlgorithm : ICaretPositionAlgorithm
+    {
+        AddAssert("Assert caret position type", () => LyricCaretState.CaretPositionAlgorithm?.GetType() == typeof(TCaretPositionAlgorithm));
     }
 
     #endregion

--- a/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Utils/ValueChangedEventUtils.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Utils;
 
@@ -15,6 +16,15 @@ public static class ValueChangedEventUtils
         var newLyric = e.NewValue?.Lyric;
 
         return oldLyric != newLyric;
+    }
+
+    public static bool LyricChanged(ValueChangedEvent<RangeCaretPosition?> e)
+    {
+        var oldRangeCaret = e.OldValue;
+        var newRangeCaret = e.NewValue;
+
+        return oldRangeCaret?.Start.Lyric != newRangeCaret?.Start.Lyric
+               || oldRangeCaret?.End.Lyric != newRangeCaret?.End.Lyric;
     }
 
     public static bool EditModeChanged(ValueChangedEvent<EditorModeWithEditStep> e)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableTypingCaret.cs
@@ -84,6 +84,7 @@ public partial class DrawableTypingCaret : DrawableRangeCaret<TypingCaretPositio
         int minGap = caret.GetRangeCaretPosition().Item1.CharGap;
         int maxGap = caret.GetRangeCaretPosition().Item2.CharGap;
 
+        typingCaretEventHandler?.ChangeLyric(caret.Start.Lyric);
         typingCaretEventHandler?.ChangeCharGapAndOffset(maxGap, maxGap - minGap);
         typingCaretEventHandler?.FocusInputCaretTextBox();
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
@@ -109,9 +109,6 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
 
     protected override void OnDrag(DragEvent e)
     {
-        if (!lyricCaretState.CaretDraggable)
-            throw new InvalidOperationException();
-
         float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
         object? caretIndex = getCaretIndexByPosition(xPosition);
 
@@ -125,9 +122,6 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
 
     protected override void OnDragEnd(DragEndEvent e)
     {
-        if (!lyricCaretState.CaretDraggable)
-            throw new InvalidOperationException();
-
         lyricCaretState.EndDragging();
 
         base.OnDragEnd(e);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
@@ -103,9 +103,6 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
         if (!lyricCaretState.CaretDraggable)
             return false;
 
-        if (lyricCaretState.HoverCaretPosition != null)
-            lyricCaretState.ConfirmHoverCaretPosition();
-
         // confirm the hover caret position before drag start.
         return lyricCaretState.StartDragging();
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/EditableLyric.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -11,6 +10,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Lyrics;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.Algorithms;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Components.Lyrics;
@@ -57,8 +57,7 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
         if (e.HasAnyButtonPressed)
             return false;
 
-        float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
-        object? caretIndex = getCaretIndexByPosition(xPosition);
+        object? caretIndex = getCaretIndexByPosition(e);
 
         if (caretIndex != null)
         {
@@ -82,6 +81,22 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
 
         // lost hover caret and time-tag caret
         lyricCaretState.ClearHoverCaretPosition();
+    }
+
+    private object? getCaretIndexByPosition(UIEvent mouseEvent)
+    {
+        var algorithm = lyricCaretState.CaretPositionAlgorithm;
+        float xPosition = ToLocalSpace(mouseEvent.ScreenSpaceMousePosition).X;
+        return algorithm switch
+        {
+            CuttingCaretPositionAlgorithm => KaraokeSpriteText.GetCharIndicatorByPosition(xPosition),
+            TypingCaretPositionAlgorithm => KaraokeSpriteText.GetCharIndicatorByPosition(xPosition),
+            NavigateCaretPositionAlgorithm => null,
+            CreateRubyTagCaretPositionAlgorithm => KaraokeSpriteText.GetCharIndexByPosition(xPosition),
+            TimeTagIndexCaretPositionAlgorithm => KaraokeSpriteText.GetCharIndexByPosition(xPosition),
+            TimeTagCaretPositionAlgorithm => KaraokeSpriteText.GetTimeTagByPosition(xPosition),
+            _ => null,
+        };
     }
 
     #endregion
@@ -109,8 +124,7 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
 
     protected override void OnDrag(DragEvent e)
     {
-        float xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X;
-        object? caretIndex = getCaretIndexByPosition(xPosition);
+        object? caretIndex = getCaretIndexByPosition(e);
 
         if (caretIndex != null)
         {
@@ -126,18 +140,6 @@ public partial class EditableLyric : InteractableLyric, IEditableLyricState
 
         base.OnDragEnd(e);
     }
-
-    private object? getCaretIndexByPosition(float position) =>
-        lyricCaretState.CaretPosition switch
-        {
-            CuttingCaretPosition => KaraokeSpriteText.GetCharIndicatorByPosition(position),
-            TypingCaretPosition => KaraokeSpriteText.GetCharIndicatorByPosition(position),
-            NavigateCaretPosition => null,
-            CreateRubyTagCaretPosition => KaraokeSpriteText.GetCharIndexByPosition(position),
-            TimeTagIndexCaretPosition => KaraokeSpriteText.GetCharIndexByPosition(position),
-            TimeTagCaretPosition => KaraokeSpriteText.GetTimeTagByPosition(position),
-            _ => null,
-        };
 
     #endregion
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/ILyricCaretState.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition.Algorithms;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
 
@@ -50,4 +51,8 @@ public interface ILyricCaretState
     bool CaretEnabled { get; }
 
     bool CaretDraggable { get; }
+
+    ICaretPositionAlgorithm? CaretPositionAlgorithm => BindableCaretPositionAlgorithm.Value;
+
+    IBindable<ICaretPositionAlgorithm?> BindableCaretPositionAlgorithm { get; }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -30,7 +30,10 @@ public partial class LyricCaretState : Component, ILyricCaretState
     private readonly Bindable<RangeCaretPosition?> bindableRangeCaretPosition = new();
     private readonly Bindable<Lyric?> bindableFocusedLyric = new();
 
-    private ICaretPositionAlgorithm? algorithm;
+    public IBindable<ICaretPositionAlgorithm?> BindableCaretPositionAlgorithm => bindableCaretPositionAlgorithm;
+
+    private ICaretPositionAlgorithm? algorithm => bindableCaretPositionAlgorithm.Value;
+    private readonly Bindable<ICaretPositionAlgorithm?> bindableCaretPositionAlgorithm = new();
 
     private readonly IBindableList<Lyric> bindableLyrics = new BindableList<Lyric>();
 
@@ -104,7 +107,7 @@ public partial class LyricCaretState : Component, ILyricCaretState
     private void refreshAlgorithmAndCaretPosition()
     {
         // refresh algorithm
-        algorithm = getAlgorithmByMode(bindableModeWithEditStep.Value);
+        bindableCaretPositionAlgorithm.Value = getAlgorithmByMode(bindableModeWithEditStep.Value);
 
         // refresh caret position
         var lyric = bindableCaretPosition.Value?.Lyric;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/LyricCaretState.cs
@@ -375,7 +375,7 @@ public partial class LyricCaretState : Component, ILyricCaretState
         if (!CaretDraggable)
             throw new InvalidOperationException("Should not call this method if the caret is not draggable");
 
-        var caretPosition = bindableCaretPosition.Value;
+        var caretPosition = bindableHoverCaretPosition.Value;
         if (caretPosition is not IIndexCaretPosition indexCaretPosition)
             throw new InvalidOperationException($"Binding caret position should have value and the type should be {typeof(IIndexCaretPosition)}.");
 
@@ -388,14 +388,15 @@ public partial class LyricCaretState : Component, ILyricCaretState
         if (!CaretDraggable)
             throw new InvalidOperationException("Should not call this method if the caret is not draggable");
 
-        var caretPosition = bindableCaretPosition.Value;
-        if (caretPosition is not IIndexCaretPosition startCaretPosition)
-            throw new InvalidOperationException($"Binding caret position should have value and the type should be {typeof(IIndexCaretPosition)}.");
+        var rangeCaretPosition = bindableRangeCaretPosition.Value;
+        if (rangeCaretPosition == null)
+            throw new InvalidOperationException("Binding range caret position should not be null.");
 
         if (algorithm is not IIndexCaretPositionAlgorithm indexCaretPositionAlgorithm)
             throw new InvalidOperationException("Algorithm should be index caret position algorithm.");
 
-        var endCaretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(caretPosition.Lyric, index);
+        var startCaretPosition = rangeCaretPosition.Start;
+        var endCaretPosition = indexCaretPositionAlgorithm.MoveToTargetLyric(startCaretPosition.Lyric, index);
         return moveRangeCaretToTargetPosition(startCaretPosition, endCaretPosition, RangeCaretDraggingState.Dragging);
     }
 
@@ -406,7 +407,7 @@ public partial class LyricCaretState : Component, ILyricCaretState
 
         var rangeCaretPosition = bindableRangeCaretPosition.Value;
         if (rangeCaretPosition == null)
-            return false;
+            throw new InvalidOperationException("Binding range caret position should not be null.");
 
         return moveRangeCaretToTargetPosition(rangeCaretPosition.Start, rangeCaretPosition.End, RangeCaretDraggingState.EndDrag);
     }
@@ -431,7 +432,11 @@ public partial class LyricCaretState : Component, ILyricCaretState
             return false;
 
         bindableHoverCaretPosition.Value = null;
+        bindableCaretPosition.Value = null;
         bindableRangeCaretPosition.Value = new RangeCaretPosition(startCaretPosition, endCaretPosition, draggingState);
+
+        if (draggingState == RangeCaretDraggingState.EndDrag)
+            postProcess();
 
         return true;
     }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/RangeCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/States/RangeCaretPosition.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
@@ -28,6 +29,9 @@ public class RangeCaretPosition<TIndexCaretPosition> : IEquatable<RangeCaretPosi
 {
     public RangeCaretPosition(TIndexCaretPosition start, TIndexCaretPosition end, RangeCaretDraggingState draggingState)
     {
+        if (start.GetType() != end.GetType())
+            throw new InvalidOperationException("Start and end caret index should be the same type.");
+
         Start = start;
         End = end;
         DraggingState = draggingState;
@@ -77,6 +81,19 @@ public class RangeCaretPosition<TIndexCaretPosition> : IEquatable<RangeCaretPosi
     public override int GetHashCode()
     {
         return HashCode.Combine(Start, End);
+    }
+
+    public bool IsInRange(Lyric lyric)
+    {
+        int minOrder = Math.Min(Start.Lyric.Order, End.Lyric.Order);
+        int maxOrder = Math.Max(Start.Lyric.Order, End.Lyric.Order);
+
+        return lyric.Order >= minOrder && lyric.Order <= maxOrder;
+    }
+
+    public Type GetCaretPositionType()
+    {
+        return Start.GetType();
     }
 }
 


### PR DESCRIPTION
As title.

Need to make sure that caret position will have value if click or drag the lyric before.
But should be better to make them as individual behavior.

Means "caret position" and "drag caret position" should not exists at the same time.

Also.
Expose the caret position algorithm for easier to let outside know what is current algorithm is using.
So they can prepare the caret index position or create the drawable caret.