### PR TITLE
Improvement UX part of create ruby text popover.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCreateRubyTagCaret.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Components/Lyrics/Carets/DrawableCreateRubyTagCaret.cs
@@ -141,10 +141,16 @@ public partial class DrawableCreateRubyTagCaret : DrawableRangeCaret<CreateRubyT
         [Resolved]
         private ILyricRubyTagsChangeHandler lyricRubyTagsChangeHandler { get; set; } = null!;
 
+        private readonly int startCharIndex;
+        private readonly int endCharIndex;
+
         private readonly LabelledTextBox labelledRubyTextBox;
 
         public CreateRubyPopover(int startCharIndex, int endCharIndex)
         {
+            this.startCharIndex = startCharIndex;
+            this.endCharIndex = endCharIndex;
+
             Child = new FillFlowContainer
             {
                 Width = 200,
@@ -156,10 +162,7 @@ public partial class DrawableCreateRubyTagCaret : DrawableRangeCaret<CreateRubyT
                     labelledRubyTextBox = new CreateRubyLabelledTextBox
                     {
                         Label = "Ruby",
-                        Current =
-                        {
-                            Value = "Ruby",
-                        },
+                        PlaceholderText = "Ruby text",
                     },
                     new CreateRubyButton
                     {
@@ -173,19 +176,27 @@ public partial class DrawableCreateRubyTagCaret : DrawableRangeCaret<CreateRubyT
             {
                 addRubyText();
             };
-            return;
+        }
 
-            void addRubyText()
+        private void addRubyText()
+        {
+            string? rubyText = labelledRubyTextBox.Text;
+
+            if (string.IsNullOrEmpty(rubyText))
             {
-                lyricRubyTagsChangeHandler.Add(new RubyTag
-                {
-                    StartIndex = startCharIndex,
-                    EndIndex = endCharIndex,
-                    Text = labelledRubyTextBox.Text,
-                });
-
-                this.HidePopover();
+                labelledRubyTextBox.Description = "Please enter the ruby text";
+                GetContainingInputManager().ChangeFocus(labelledRubyTextBox);
+                return;
             }
+
+            lyricRubyTagsChangeHandler.Add(new RubyTag
+            {
+                StartIndex = startCharIndex,
+                EndIndex = endCharIndex,
+                Text = labelledRubyTextBox.Text,
+            });
+
+            this.HidePopover();
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Just a little bit of improvement of  #2126
1. Should not have default ruby text text, using placeholder instead.
2. Should not be possible to create the ruby text with empty text.