### PR TITLE
Fix invalid culture code cause cannot load the ruleset.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Bindables/BindableCultureInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Bindables/BindableCultureInfoTest.cs
@@ -47,4 +47,11 @@ public class BindableCultureInfoTest
         var actual = bindable.Value;
         Assert.AreEqual(expected, actual);
     }
+
+    [TestCase("中文（简体）")]
+    public void TestParsingNotSupportedCultureInfo(string value)
+    {
+        var bindable = new BindableCultureInfo();
+        Assert.DoesNotThrow(() => bindable.Parse(value));
+    }
 }

--- a/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Bindables/BindableCultureInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using osu.Framework.Bindables;
+using osu.Framework.Logging;
 using osu.Game.Rulesets.Karaoke.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Bindables;
@@ -23,23 +24,34 @@ public class BindableCultureInfo : Bindable<CultureInfo?>
             return;
         }
 
-        switch (input)
+        try
         {
-            case string str:
-                Value = CultureInfoUtils.CreateLoadCultureInfoByCode(str);
-                break;
+            switch (input)
+            {
+                case string str:
+                    Value = CultureInfoUtils.CreateLoadCultureInfoByCode(str);
+                    break;
 
-            case int lcid:
-                Value = CultureInfoUtils.CreateLoadCultureInfoById(lcid);
-                break;
+                case int lcid:
+                    Value = CultureInfoUtils.CreateLoadCultureInfoById(lcid);
+                    break;
 
-            case CultureInfo cultureInfo:
-                Value = cultureInfo;
-                break;
+                case CultureInfo cultureInfo:
+                    Value = cultureInfo;
+                    break;
 
-            default:
-                base.Parse(input);
-                break;
+                default:
+                    base.Parse(input);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Value = null;
+
+            // It might have issue that the culture info is not available in the system.
+            // Log it instead of throw exception.
+            Logger.Error(ex, $"Failed to parse {input} into {typeof(CultureInfo)}");
         }
     }
 


### PR DESCRIPTION
Fix issue #2141.
Instead of throw the exception if the culture code is not valid, should reset it and log it instead.

todo:
- [x] Check issue fixed.