### PR TITLE
Add utility to check is latin.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTimeTagTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckLyricTimeTagTest.cs
@@ -102,9 +102,10 @@ public class CheckLyricTimeTagTest : HitObjectCheckTest<Lyric, CheckLyricTimeTag
         AssertNotOk<LyricTimeTagIssue, IssueTemplateLyricTimeTagEmptyTime>(lyric);
     }
 
-    [TestCase("カラオケ", "")] // should not be white-space only.
+    [TestCase("カラオケ", "")] // should not be empty.
     [TestCase("カラオケ", " ")] // should not be white-space only.
-    public void TestCheckRomajiEmptyText(string text, string romajiText)
+    [TestCase("カラオケ", "卡拉OK")] // should be within latin.
+    public void TestCheckTimeTagRomajiInvalidText(string text, string romajiText)
     {
         var lyric = new Lyric
         {
@@ -126,8 +127,7 @@ public class CheckLyricTimeTagTest : HitObjectCheckTest<Lyric, CheckLyricTimeTag
         AssertNotOk<LyricTimeTagIssue, IssueTemplateLyricTimeTagRomajiInvalidText>(lyric);
     }
 
-    [TestCase("カラオケ", "")] // should not be white-space only.
-    [TestCase("カラオケ", " ")] // should not be white-space only.
+    [TestCase("カラオケ", null)] // should not be white-space only.
     public void TestCheckRomajiEmptyTextIfFirst(string text, string romajiText)
     {
         var lyric = new Lyric

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/CharUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/CharUtilsTest.cs
@@ -76,4 +76,19 @@ public class CharUtilsTest
         bool actual = CharUtils.IsChinese(c);
         Assert.AreEqual(expected, actual);
     }
+
+    [TestCase('A', true)]
+    [TestCase('A', true)]
+    [TestCase('Ḁ', true)]
+    [TestCase('ỿ', true)]
+    [TestCase('Ｚ', false)]
+    [TestCase('ｚ', false)]
+    [TestCase('は', false)]
+    [TestCase('^', false)]
+    [TestCase(' ', false)]
+    public void TestIsLatin(char c, bool expected)
+    {
+        bool actual = CharUtils.IsLatin(c);
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Utils/CharUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Utils/CharUtilsTest.cs
@@ -40,9 +40,9 @@ public class CharUtilsTest
     [TestCase('ｚ', true)]
     [TestCase('1', false)]
     [TestCase('文', false)]
-    public void TestIsLatin(char c, bool expected)
+    public void TestIsEnglish(char c, bool expected)
     {
-        bool actual = CharUtils.IsLatin(c);
+        bool actual = CharUtils.IsEnglish(c);
         Assert.AreEqual(expected, actual);
     }
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Lyrics/TimeTags/Ja/JaTimeTagGenerator.cs
@@ -56,7 +56,7 @@ public class JaTimeTagGenerator : TimeTagGenerator<JaTimeTagGeneratorConfig>
                     ? new TimeTag(new TextIndex(i - 1, TextIndex.IndexState.End))
                     : new TimeTag(new TextIndex(i));
 
-                if (CharUtils.IsLatin(pc))
+                if (CharUtils.IsEnglish(pc))
                 {
                     if (Config.CheckWhiteSpaceAlphabet.Value)
                         yield return timeTag;
@@ -76,9 +76,9 @@ public class JaTimeTagGenerator : TimeTagGenerator<JaTimeTagGeneratorConfig>
                     yield return timeTag;
                 }
             }
-            else if (CharUtils.IsLatin(c) || char.IsNumber(c) || CharUtils.IsAsciiSymbol(c))
+            else if (CharUtils.IsEnglish(c) || char.IsNumber(c) || CharUtils.IsAsciiSymbol(c))
             {
-                if (CharUtils.IsSpacing(pc) || (!CharUtils.IsLatin(pc) && !char.IsNumber(pc) && !CharUtils.IsAsciiSymbol(pc)))
+                if (CharUtils.IsSpacing(pc) || (!CharUtils.IsEnglish(pc) && !char.IsNumber(pc) && !CharUtils.IsAsciiSymbol(pc)))
                 {
                     yield return new TimeTag(new TextIndex(i));
                 }

--- a/osu.Game.Rulesets.Karaoke/Utils/CharUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/CharUtils.cs
@@ -46,13 +46,13 @@ public static class CharUtils
     /// <summary>
     /// Check this char is chinese character
     /// </summary>
-    /// <param name="character"></param>
+    /// <param name="c"></param>
     /// <returns></returns>
-    public static bool IsChinese(char character)
+    public static bool IsChinese(char c)
     {
         // From : https://stackoverflow.com/a/61738863/4105113
         int minValue = UnicodeRanges.CjkUnifiedIdeographs.FirstCodePoint;
         int maxValue = minValue + UnicodeRanges.CjkUnifiedIdeographs.Length;
-        return character >= minValue && character < maxValue;
+        return c >= minValue && c < maxValue;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Utils/CharUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Utils/CharUtils.cs
@@ -22,11 +22,11 @@ public static class CharUtils
         (c >= '\uFF65' && c <= '\uFF9F');
 
     /// <summary>
-    /// Check this character is english
+    /// Check this character is English latter or not.
     /// </summary>
     /// <param name="c"></param>
     /// <returns></returns>
-    public static bool IsLatin(char c) =>
+    public static bool IsEnglish(char c) =>
         (c >= 'A' && c <= 'Z') ||
         (c >= 'a' && c <= 'z') ||
         (c >= 'Ａ' && c <= 'Ｚ') ||
@@ -54,5 +54,27 @@ public static class CharUtils
         int minValue = UnicodeRanges.CjkUnifiedIdeographs.FirstCodePoint;
         int maxValue = minValue + UnicodeRanges.CjkUnifiedIdeographs.Length;
         return c >= minValue && c < maxValue;
+    }
+
+    /// <summary>
+    /// Check this char is latin alphabet or not.
+    /// Usually, this is used to check the romanization result.
+    /// </summary>
+    /// <param name="c"></param>
+    /// <returns></returns>
+    public static bool IsLatin(char c)
+    {
+        if (c >= 'A' && c <= 'Z')
+            return true;
+
+        if (c >= 'a' && c <= 'z')
+            return true;
+
+        // another romanized characters
+        // see: https://www.unicode.org/charts/PDF/U1E00.pdf
+        if (c >= '\u1E00' && c <= '\u1EFF')
+            return true;
+
+        return false;
     }
 }


### PR DESCRIPTION
Missing part of #2140.
Char in the romaji field should be white-space or latin only.