### PR TITLE
Wrap changelog query into class like `GetChangelogBuildRequest`.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Overlays/TestSceneKaraokeChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Overlays/TestSceneKaraokeChangeLogMarkdownContainer.cs
@@ -24,9 +24,9 @@ public partial class TestSceneKaraokeChangeLogMarkdownContainer : OsuTestScene
     [SetUp]
     public void SetUp() => Schedule(() =>
     {
-        var build = new APIChangelogBuild("karaoke-dev", "karaoke-dev.github.io")
+        var build = new APIChangelogBuild
         {
-            Path = "content/changelog/2020.0620",
+            DocumentUrl = "https://raw.githubusercontent.com/karaoke-dev/karaoke-dev.github.io/master/content/changelog/2020.0620",
             RootUrl = "https://github.com/karaoke-dev/karaoke-dev.github.io/tree/master/content/changelog/2020.0620",
             Content = "---\ntitle: \"2020.0620\"\ndate: 2020-06-20\n---\n\n## Achievement\n\n- Might support convert `UTAU`/`SynthV` project into karaoke beatmap in future. [karaoke](#100#101@andy840119)",
         };

--- a/osu.Game.Rulesets.Karaoke.Tests/Overlays/TestSceneKaraokeChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Overlays/TestSceneKaraokeChangeLogMarkdownContainer.cs
@@ -28,6 +28,7 @@ public partial class TestSceneKaraokeChangeLogMarkdownContainer : OsuTestScene
         {
             Path = "content/changelog/2020.0620",
             RootUrl = "https://github.com/karaoke-dev/karaoke-dev.github.io/tree/master/content/changelog/2020.0620",
+            Content = "---\ntitle: \"2020.0620\"\ndate: 2020-06-20\n---\n\n## Achievement\n\n- Might support convert `UTAU`/`SynthV` project into karaoke beatmap in future. [karaoke](#100#101@andy840119)",
         };
 
         Children = new Drawable[]

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogBuildRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogBuildRequest.cs
@@ -1,0 +1,24 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Octokit;
+using osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
+
+namespace osu.Game.Rulesets.Karaoke.Online.API.Requests;
+
+public class GetChangelogBuildRequest : GithubChangeLogAPIRequest<APIChangelogBuild>
+{
+    private readonly APIChangelogBuild originBuild;
+
+    public GetChangelogBuildRequest(APIChangelogBuild originBuild)
+    {
+        this.originBuild = originBuild;
+    }
+
+    protected override async Task<APIChangelogBuild> Perform(IGitHubClient client)
+    {
+        string contentString = await GetChangelogContent(client, originBuild.Version).ConfigureAwait(false);
+        return CreateBuildWithContent(originBuild, contentString);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
@@ -57,7 +57,7 @@ public class GetChangelogRequest : GithubChangeLogAPIRequest<APIChangelogIndex>
         {
             RootUrl = content.HtmlUrl,
             Path = content.Path,
-            DisplayVersion = content.Name,
+            Version = content.Name,
             PublishedAt = getPublishDateFromName(content.Name),
         };
 

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Octokit;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Rulesets.Karaoke.Extensions;
+using osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
+
+namespace osu.Game.Rulesets.Karaoke.Online.API.Requests;
+
+public class GetChangelogRequest : GithubChangeLogAPIRequest<APIChangelogIndex>
+{
+    protected override async Task<APIChangelogIndex> Perform(IGitHubClient client)
+    {
+        var builds = await getAllBuilds(client).ConfigureAwait(false);
+        int[] years = generateYears(builds);
+
+        return new APIChangelogIndex
+        {
+            Years = years,
+            Builds = builds,
+        };
+    }
+
+    private static async Task<List<APIChangelogBuild>> getAllBuilds(IGitHubClient client)
+    {
+        var reposAscending = await client
+                                   .Repository
+                                   .Content
+                                   .GetAllContents(ORGANIZATION_NAME, PROJECT_NAME, CHANGELOG_PATH)
+                                   .ConfigureAwait(false);
+
+        var builds = reposAscending
+                     .Reverse()
+                     .Where(x => x.Type == ContentType.Dir)
+                     .Select(createBuild)
+                     .ToList();
+
+        // adjust the mapping of previous/next versions by hand.
+        foreach (var build in builds)
+        {
+            build.Versions.Previous = builds.GetPrevious(build);
+            build.Versions.Next = builds.GetNext(build);
+        }
+
+        return builds;
+    }
+
+    private static APIChangelogBuild createBuild(RepositoryContent content)
+    {
+        return new APIChangelogBuild(ORGANIZATION_NAME, PROJECT_NAME)
+        {
+            RootUrl = content.HtmlUrl,
+            Path = content.Path,
+            DisplayVersion = content.Name,
+            PublishedAt = getPublishDateFromName(content.Name),
+        };
+
+        static DateTimeOffset getPublishDateFromName(string name)
+        {
+            var regex = new Regex("(?<year>[-0-9]+).(?<month>[-0-9]{2})(?<day>[-0-9]{2})");
+            var result = regex.Match(name);
+            if (!result.Success)
+                return DateTimeOffset.MaxValue;
+
+            int year = result.GetGroupValue<int>("year");
+            int month = result.GetGroupValue<int>("month");
+            int day = result.GetGroupValue<int>("day");
+
+            return new DateTimeOffset(new DateTime(year, month, day));
+        }
+    }
+
+    private static int[] generateYears(IEnumerable<APIChangelogBuild> builds)
+        => builds.Select(x => x.PublishedAt.Year).Distinct().ToArray();
+}

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GetChangelogRequest.cs
@@ -55,10 +55,10 @@ public class GetChangelogRequest : GithubChangeLogAPIRequest<APIChangelogIndex>
 
     private static APIChangelogBuild createBuild(RepositoryContent content)
     {
-        return new APIChangelogBuild(ORGANIZATION_NAME, PROJECT_NAME)
+        return new APIChangelogBuild
         {
+            DocumentUrl = getDocumentUrl(content.Path),
             RootUrl = content.HtmlUrl,
-            Path = content.Path,
             Version = content.Name,
             PublishedAt = getPublishDateFromName(content.Name),
         };
@@ -76,6 +76,9 @@ public class GetChangelogRequest : GithubChangeLogAPIRequest<APIChangelogIndex>
 
             return new DateTimeOffset(new DateTime(year, month, day));
         }
+
+        string getDocumentUrl(string path)
+            => $"https://raw.githubusercontent.com/{ORGANIZATION_NAME}/{PROJECT_NAME}/{BRANCH_NAME}/{path}/";
     }
 
     private static async Task<APIChangelogBuild> createPreviewBuild(IGitHubClient client, APIChangelogBuild originBuild)

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubAPIRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubAPIRequest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using Octokit;
+using osu.Game.Online.API;
+
+namespace osu.Game.Rulesets.Karaoke.Online.API.Requests;
+
+public abstract class GithubAPIRequest<T> where T : class
+{
+    protected virtual GitHubClient CreateGitHubClient() => new(new ProductHeaderValue(organizationName));
+
+    /// <summary>
+    /// Invoked on successful completion of an API request.
+    /// This will be scheduled to the API's internal scheduler (run on update thread automatically).
+    /// </summary>
+    public event APISuccessHandler<T>? Success;
+
+    /// <summary>
+    /// Invoked on failure to complete an API request.
+    /// This will be scheduled to the API's internal scheduler (run on update thread automatically).
+    /// </summary>
+    public event APIFailureHandler? Failure;
+
+    private readonly object completionStateLock = new();
+
+    /// <summary>
+    /// The state of this request, from an outside perspective.
+    /// This is used to ensure correct notification events are fired.
+    /// </summary>
+    public APIRequestCompletionState CompletionState { get; private set; }
+
+    private readonly string organizationName;
+
+    protected GithubAPIRequest(string organizationName)
+    {
+        this.organizationName = organizationName;
+    }
+
+    public async Task Perform()
+    {
+        var client = CreateGitHubClient();
+
+        try
+        {
+            var response = await Perform(client).ConfigureAwait(false);
+            triggerSuccess(response);
+        }
+        catch (Exception e)
+        {
+            triggerFailure(e);
+        }
+    }
+
+    protected abstract Task<T> Perform(IGitHubClient client);
+
+    private void triggerSuccess(T response)
+    {
+        lock (completionStateLock)
+        {
+            if (CompletionState != APIRequestCompletionState.Waiting)
+                return;
+
+            CompletionState = APIRequestCompletionState.Completed;
+        }
+
+        Success?.Invoke(response);
+    }
+
+    private void triggerFailure(Exception e)
+    {
+        lock (completionStateLock)
+        {
+            if (CompletionState != APIRequestCompletionState.Waiting)
+                return;
+
+            CompletionState = APIRequestCompletionState.Failed;
+        }
+
+        Failure?.Invoke(e);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubChangeLogAPIRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubChangeLogAPIRequest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using Octokit;
+using osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
+
+namespace osu.Game.Rulesets.Karaoke.Online.API.Requests;
+
+public abstract class GithubChangeLogAPIRequest<T> : GithubAPIRequest<T> where T : class
+{
+    protected const string ORGANIZATION_NAME = "karaoke-dev";
+    protected const string PROJECT_NAME = $"{ORGANIZATION_NAME}.github.io";
+    protected const string CHANGELOG_PATH = "content/changelog";
+
+    protected GithubChangeLogAPIRequest()
+        : base(ORGANIZATION_NAME)
+    {
+    }
+
+    protected static async Task<string> GetChangelogContent(IGitHubClient client, string version)
+    {
+        string changeLogPath = $"{CHANGELOG_PATH}/{version}/index.md";
+        byte[]? content = await client
+                                .Repository
+                                .Content
+                                .GetRawContent(ORGANIZATION_NAME, PROJECT_NAME, changeLogPath)
+                                .ConfigureAwait(false);
+
+        // convert the content to a string
+        return System.Text.Encoding.UTF8.GetString(content);
+    }
+
+    protected static APIChangelogBuild CreateBuildWithContent(APIChangelogBuild originBuild, string content)
+    {
+        return new APIChangelogBuild(originBuild.OrganizationName, originBuild.ProjectName)
+        {
+            RootUrl = originBuild.RootUrl,
+            Path = originBuild.Path,
+            Version = originBuild.Version,
+            Content = content,
+            Versions =
+            {
+                Previous = originBuild.Versions.Previous,
+                Next = originBuild.Versions.Next,
+            },
+            PublishedAt = originBuild.PublishedAt,
+        };
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubChangeLogAPIRequest.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/GithubChangeLogAPIRequest.cs
@@ -11,6 +11,7 @@ public abstract class GithubChangeLogAPIRequest<T> : GithubAPIRequest<T> where T
 {
     protected const string ORGANIZATION_NAME = "karaoke-dev";
     protected const string PROJECT_NAME = $"{ORGANIZATION_NAME}.github.io";
+    protected const string BRANCH_NAME = "master";
     protected const string CHANGELOG_PATH = "content/changelog";
 
     protected GithubChangeLogAPIRequest()
@@ -33,10 +34,10 @@ public abstract class GithubChangeLogAPIRequest<T> : GithubAPIRequest<T> where T
 
     protected static APIChangelogBuild CreateBuildWithContent(APIChangelogBuild originBuild, string content)
     {
-        return new APIChangelogBuild(originBuild.OrganizationName, originBuild.ProjectName)
+        return new APIChangelogBuild
         {
+            DocumentUrl = originBuild.DocumentUrl,
             RootUrl = originBuild.RootUrl,
-            Path = originBuild.Path,
             Version = originBuild.Version,
             Content = content,
             Versions =

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
@@ -83,4 +83,6 @@ public class APIChangelogBuild
         /// </summary>
         public APIChangelogBuild? Previous { get; set; }
     }
+
+    public override string ToString() => $"Karaoke! {DisplayVersion}";
 }

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
@@ -8,53 +8,14 @@ namespace osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
 public class APIChangelogBuild
 {
     /// <summary>
-    ///
-    /// </summary>
-    /// <param name="organization">Account or organization name</param>
-    /// <param name="project">Project name</param>
-    /// <param name="branch">Branch name</param>
-    public APIChangelogBuild(string organization, string project, string branch = "master")
-    {
-        OrganizationName = organization;
-        ProjectName = project;
-        Branch = branch;
-        Versions = new VersionNavigation();
-    }
-
-    /// <summary>
-    /// Organization name
-    /// </summary>
-    public string OrganizationName { get; }
-
-    /// <summary>
-    /// Project name
-    /// </summary>
-    public string ProjectName { get; }
-
-    /// <summary>
-    /// Branch name
-    /// </summary>
-    public string Branch { get; }
-
-    /// <summary>
     /// The URL of the loaded document.
     /// </summary>
-    public string DocumentUrl => $"https://raw.githubusercontent.com/{OrganizationName}/{ProjectName}/{Branch}/{Path}/";
+    public string DocumentUrl { get; set; } = null!;
 
     /// <summary>
     /// The base URL for all root-relative links.
     /// </summary>
     public string RootUrl { get; set; } = null!;
-
-    /// <summary>
-    /// Path of the project
-    /// </summary>
-    public string Path { get; set; } = null!;
-
-    /// <summary>
-    /// Path to download readme url
-    /// </summary>
-    public string ReadmeDownloadUrl => $"{DocumentUrl}index.md";
 
     /// <summary>
     /// Version number
@@ -70,13 +31,14 @@ public class APIChangelogBuild
 
     /// <summary>
     /// Might be preview or detail markdown content.
+    /// And the content is markdown format.
     /// </summary>
-    public string Content { get; set; } = null!;
+    public string? Content { get; set; }
 
     /// <summary>
     /// Version
     /// </summary>
-    public VersionNavigation Versions { get; }
+    public VersionNavigation Versions { get; } = new();
 
     /// <summary>
     /// Created date.

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogBuild.cs
@@ -57,9 +57,21 @@ public class APIChangelogBuild
     public string ReadmeDownloadUrl => $"{DocumentUrl}index.md";
 
     /// <summary>
+    /// Version number
+    /// </summary>
+    /// <example>2023.0123</example>
+    /// <example>2023.1111</example>
+    public string Version { get; set; } = null!;
+
+    /// <summary>
     /// Display version
     /// </summary>
-    public string DisplayVersion { get; set; } = null!;
+    public string DisplayVersion => Version;
+
+    /// <summary>
+    /// Might be preview or detail markdown content.
+    /// </summary>
+    public string Content { get; set; } = null!;
 
     /// <summary>
     /// Version

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogIndex.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogIndex.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 
 namespace osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
 
-public class APIChangelogSidebar
+public class APIChangelogIndex
 {
-    public IEnumerable<APIChangelogBuild> Changelogs { get; set; } = Array.Empty<APIChangelogBuild>();
+    public List<APIChangelogBuild> Builds { get; set; } = new();
 
     public int[] Years { get; set; } = Array.Empty<int>();
 }

--- a/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogIndex.cs
+++ b/osu.Game.Rulesets.Karaoke/Online/API/Requests/Responses/APIChangelogIndex.cs
@@ -10,5 +10,7 @@ public class APIChangelogIndex
 {
     public List<APIChangelogBuild> Builds { get; set; } = new();
 
+    public List<APIChangelogBuild> PreviewBuilds { get; set; } = new();
+
     public int[] Years { get; set; } = Array.Empty<int>();
 }

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangeLogMarkdownContainer.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text.RegularExpressions;
 using Markdig.Syntax.Inlines;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Layout;
@@ -25,17 +23,7 @@ public partial class ChangeLogMarkdownContainer : OsuMarkdownContainer
     {
         DocumentUrl = build.DocumentUrl;
         RootUrl = build.RootUrl;
-
-        using var httpClient = new HttpClient();
-
-        try
-        {
-            Text = httpClient.GetStringAsync(build.ReadmeDownloadUrl).GetResultSafely();
-        }
-        catch (Exception)
-        {
-            Text = "Oops, seems there's something wrong with network.";
-        }
+        Text = build.Content;
     }
 
     public override OsuMarkdownTextFlowContainer CreateTextFlow() => new ChangeLogMarkdownTextFlowContainer();

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangelogListing.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/ChangelogListing.cs
@@ -20,9 +20,9 @@ public partial class ChangelogListing : ChangelogContent
 {
     private readonly IReadOnlyList<APIChangelogBuild> entries;
 
-    public ChangelogListing(IEnumerable<APIChangelogBuild> entries)
+    public ChangelogListing(List<APIChangelogBuild> entries)
     {
-        this.entries = entries.Take(4).ToList();
+        this.entries = entries;
     }
 
     [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/ChangelogSidebar.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/ChangelogSidebar.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog.Sidebar;
 public partial class ChangelogSidebar : CompositeDrawable
 {
     [Cached]
-    public readonly Bindable<APIChangelogSidebar> Metadata = new();
+    public readonly Bindable<APIChangelogIndex> Metadata = new();
 
     [Cached]
     public readonly Bindable<int> Year = new();
@@ -109,19 +109,19 @@ public partial class ChangelogSidebar : CompositeDrawable
         Year.BindValueChanged(e => onMetadataChanged(Metadata.Value, e.NewValue), true);
     }
 
-    private void onMetadataChanged(APIChangelogSidebar? metadata, int targetYear)
+    private void onMetadataChanged(APIChangelogIndex? metadata, int targetYear)
     {
         changelogsFlow.Clear();
 
         if (metadata == null)
             return;
 
-        var allPosts = metadata.Changelogs;
+        var builds = metadata.Builds;
 
-        if (allPosts.Any() != true)
+        if (builds.Any() != true)
             return;
 
-        var lookup = metadata.Changelogs.ToLookup(post => post.PublishedAt.Year);
+        var lookup = builds.ToLookup(post => post.PublishedAt.Year);
         var posts = lookup[targetYear].ToList();
         changelogsFlow.Add(new ChangelogSection(targetYear, posts));
     }

--- a/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/YearsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/Changelog/Sidebar/YearsPanel.cs
@@ -18,12 +18,12 @@ namespace osu.Game.Rulesets.Karaoke.Overlays.Changelog.Sidebar;
 
 public partial class YearsPanel : CompositeDrawable
 {
-    private readonly Bindable<APIChangelogSidebar> metadata = new();
+    private readonly Bindable<APIChangelogIndex> metadata = new();
 
     private FillFlowContainer yearsFlow = null!;
 
     [BackgroundDependencyLoader]
-    private void load(OverlayColourProvider overlayColours, Bindable<APIChangelogSidebar> metadata)
+    private void load(OverlayColourProvider overlayColours, Bindable<APIChangelogIndex> metadata)
     {
         this.metadata.BindTo(metadata);
 

--- a/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
@@ -169,9 +169,9 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
 
                 int[] years = builds.Select(x => x.PublishedAt.Year).Distinct().ToArray();
                 sidebar.Year.Value = years.Max();
-                sidebar.Metadata.Value = new APIChangelogSidebar
+                sidebar.Metadata.Value = new APIChangelogIndex
                 {
-                    Changelogs = builds,
+                    Builds = builds,
                     Years = years,
                 };
             });

--- a/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
@@ -95,7 +95,7 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
             }
             else if (index != null)
             {
-                loadContent(new ChangelogListing(index.Builds));
+                loadContent(new ChangelogListing(index.PreviewBuilds));
             }
             else
             {

--- a/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
+++ b/osu.Game.Rulesets.Karaoke/Overlays/KaraokeChangelogOverlay.cs
@@ -2,23 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Octokit;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
-using osu.Game.Rulesets.Karaoke.Extensions;
+using osu.Game.Rulesets.Karaoke.Online.API.Requests;
 using osu.Game.Rulesets.Karaoke.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Karaoke.Overlays.Changelog;
 using osu.Game.Rulesets.Karaoke.Overlays.Changelog.Sidebar;
@@ -39,7 +35,7 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
 
     private Sample? sampleBack;
 
-    private readonly List<APIChangelogBuild> builds = new();
+    private APIChangelogIndex? index;
 
     private readonly string organizationName;
     private readonly string branchName;
@@ -94,10 +90,16 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
         Current.BindValueChanged(e =>
         {
             if (e.NewValue != null)
+            {
                 loadContent(new ChangelogSingleBuild(e.NewValue));
+            }
+            else if (index != null)
+            {
+                loadContent(new ChangelogListing(index.Builds));
+            }
             else
             {
-                loadContent(new ChangelogListing(builds));
+                // todo: should show oops content.
             }
         });
     }
@@ -167,13 +169,11 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
             {
                 Current.TriggerChange();
 
-                int[] years = builds.Select(x => x.PublishedAt.Year).Distinct().ToArray();
-                sidebar.Year.Value = years.Max();
-                sidebar.Metadata.Value = new APIChangelogIndex
-                {
-                    Builds = builds,
-                    Years = years,
-                };
+                if (index == null)
+                    return;
+
+                sidebar.Year.Value = index.Years.Max();
+                sidebar.Metadata.Value = index;
             });
         }
     }
@@ -192,61 +192,24 @@ public partial class KaraokeChangelogOverlay : OnlineOverlay<ChangelogHeader>
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            var client = new GitHubClient(new ProductHeaderValue(organizationName));
+            var req = new GetChangelogRequest();
 
-            try
+            req.Success += res => Schedule(() =>
             {
-                var reposAscending = await client.Repository.Content.GetAllContentsByRef(organizationName, projectName, "content/changelog", branchName).ConfigureAwait(false);
+                index = res;
+                tcs.SetResult(true);
+            });
 
-                if (reposAscending.Any())
-                {
-                    builds.Clear();
-                    builds.AddRange(reposAscending.Reverse().Where(x => x.Type == ContentType.Dir).Select(x => new APIChangelogBuild(organizationName, projectName, branchName)
-                    {
-                        RootUrl = x.HtmlUrl,
-                        Path = x.Path,
-                        DisplayVersion = x.Name,
-                        PublishedAt = getPublishDateFromName(x.Name),
-                    }));
-
-                    foreach (var build in builds)
-                    {
-                        build.Versions.Previous = builds.GetPrevious(build);
-                        build.Versions.Next = builds.GetNext(build);
-                    }
-
-                    tcs.SetResult(true);
-                }
-                else
-                {
-                    tcs.SetResult(false);
-                }
-            }
-            catch (RateLimitExceededException)
+            req.Failure += e =>
             {
-                // todo: maybe show something?
-            }
-            catch (Exception)
-            {
-                // todo: maybe show something?
-            }
+                initialFetchTask = null;
+                tcs.SetException(e);
+            };
 
-            await tcs.Task.ConfigureAwait(false);
-        });
+            await req.Perform().ConfigureAwait(false);
 
-        static DateTimeOffset getPublishDateFromName(string name)
-        {
-            var regex = new Regex("(?<year>[-0-9]+).(?<month>[-0-9]{2})(?<day>[-0-9]{2})");
-            var result = regex.Match(name);
-            if (!result.Success)
-                return DateTimeOffset.MaxValue;
-
-            int year = result.GetGroupValue<int>("year");
-            int month = result.GetGroupValue<int>("month");
-            int day = result.GetGroupValue<int>("day");
-
-            return new DateTimeOffset(new DateTime(year, month, day));
-        }
+            return tcs.Task;
+        }).Unwrap();
     }
 
     private CancellationTokenSource? loadContentCancellation;


### PR DESCRIPTION
Closes issue #2157.
Every request should be wrapped with customized request type.