### PR TITLE
Rename the test method/utility.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Asserts/RubyTagAssert.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Asserts/RubyTagAssert.cs
@@ -3,13 +3,13 @@
 
 using System.Collections.Generic;
 using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Objects.Types;
+using osu.Game.Rulesets.Karaoke.Objects;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Asserts;
 
-public class TextTagAssert : Assert
+public class RubyTagAssert : Assert
 {
-    public static void ArePropertyEqual<T>(IList<T> expected, IList<T> actual) where T : ITextTag
+    public static void ArePropertyEqual(IList<RubyTag> expected, IList<RubyTag> actual)
     {
         AreEqual(expected.Count, actual.Count);
 
@@ -20,7 +20,7 @@ public class TextTagAssert : Assert
         }
     }
 
-    public static void ArePropertyEqual<T>(T expected, T actual) where T : ITextTag
+    public static void ArePropertyEqual(RubyTag expected, RubyTag actual)
     {
         AreEqual(expected.Text, actual.Text);
         AreEqual(expected.StartIndex, actual.StartIndex);

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Lyrics/LyricTimeTagsChangeHandlerTest.cs
@@ -467,7 +467,7 @@ public partial class LyricTimeTagsChangeHandlerTest : LyricPropertyChangeHandler
     [TestCase(ShiftingDirection.Left, ShiftingType.Index, 1)]
     [TestCase(ShiftingDirection.Right, ShiftingType.State, 3)]
     [TestCase(ShiftingDirection.Right, ShiftingType.Index, 3)]
-    public void TestShiftingWithSameTextTag(ShiftingDirection direction, ShiftingType type, int expectedIndex)
+    public void TestShiftingWithSameTimeTag(ShiftingDirection direction, ShiftingType type, int expectedIndex)
     {
         PrepareHitObject(() => new Lyric
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romanisation/Ja/JaRomanisationGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/Romanisation/Ja/JaRomanisationGeneratorTest.cs
@@ -91,13 +91,13 @@ public class JaRomanisationGeneratorTest : BaseRomanisationGeneratorTest<JaRoman
 
         static JaRomanisationGenerator.RomanisationGeneratorParameter parseRomanisationGenerateResult(string str)
         {
-            // because format is same as the text-tag testing format, so just use the ruby helper.
-            var textTag = TestCaseTagHelper.ParseRubyTag(str);
+            // because format is same as the ruby-tag testing format, so just use the ruby helper.
+            var tag = TestCaseTagHelper.ParseRubyTag(str);
             return new JaRomanisationGenerator.RomanisationGeneratorParameter
             {
-                StartIndex = textTag.StartIndex,
-                EndIndex = textTag.EndIndex,
-                RomanisedSyllable = textTag.Text,
+                StartIndex = tag.StartIndex,
+                EndIndex = tag.EndIndex,
+                RomanisedSyllable = tag.Text,
             };
         }
     }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/BaseRubyTagGeneratorTest.cs
@@ -26,6 +26,6 @@ public abstract class BaseRubyTagGeneratorTest<TRubyTagGenerator, TConfig> : Bas
 
     protected override void AssertEqual(RubyTag[] expected, RubyTag[] actual)
     {
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/RubyTagGeneratorSelectorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Generator/Lyrics/RubyTags/RubyTagGeneratorSelectorTest.cs
@@ -47,6 +47,6 @@ public class RubyTagGeneratorSelectorTest : BaseLyricGeneratorSelectorTest<RubyT
 
     protected override void AssertEqual(RubyTag[] expected, RubyTag[] actual)
     {
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
@@ -44,7 +44,7 @@ public class LyricConverterTest : BaseSingleConverterTest<LyricConverter>
         TimeTagAssert.ArePropertyEqual(expected.TimeTags, actual.TimeTags);
         Assert.AreEqual(expected.LyricStartTime, actual.LyricStartTime);
         Assert.AreEqual(expected.LyricEndTime, actual.LyricEndTime);
-        TextTagAssert.ArePropertyEqual(expected.RubyTags, actual.RubyTags);
+        RubyTagAssert.ArePropertyEqual(expected.RubyTags, actual.RubyTags);
         Assert.AreEqual(expected.StartTime, actual.StartTime);
         Assert.AreEqual(expected.Duration, actual.Duration);
         Assert.AreEqual(expected.SingerIds, actual.SingerIds);

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagConverterTest.cs
@@ -51,6 +51,6 @@ public class RubyTagConverterTest : BaseSingleConverterTest<RubyTagConverter>
             Text = text,
         };
         var actual = JsonConvert.DeserializeObject<RubyTag>($"\"{json}\"", CreateSettings()) ?? throw new InvalidCastException();
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagsConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/RubyTagsConverterTest.cs
@@ -63,6 +63,6 @@ public class RubyTagsConverterTest : BaseSingleConverterTest<RubyTagsConverter>
             },
         };
         var actual = JsonConvert.DeserializeObject<RubyTag[]>(json, CreateSettings()) ?? throw new InvalidCastException();
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
@@ -61,7 +61,7 @@ public class LyricTest
 
         Assert.AreNotSame(clonedLyric.RubyTagsVersion, lyric.RubyTagsVersion);
         Assert.AreNotSame(clonedLyric.RubyTagsBindable, lyric.RubyTagsBindable);
-        TextTagAssert.ArePropertyEqual(clonedLyric.RubyTags, lyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(clonedLyric.RubyTags, lyric.RubyTags);
 
         Assert.AreNotSame(clonedLyric.StartTimeBindable, lyric.StartTimeBindable);
         Assert.AreEqual(clonedLyric.StartTime, lyric.StartTime);
@@ -121,7 +121,7 @@ public class LyricTest
 
         Assert.AreEqual(referencedLyric.Text, lyric.Text);
         TimeTagAssert.ArePropertyEqual(referencedLyric.TimeTags, lyric.TimeTags);
-        TextTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
         Assert.AreEqual(referencedLyric.SingerIds, lyric.SingerIds);
         Assert.AreEqual(referencedLyric.Translates, lyric.Translates);
         Assert.AreEqual(referencedLyric.Language, lyric.Language);
@@ -151,7 +151,7 @@ public class LyricTest
 
         Assert.AreEqual(referencedLyric.Text, lyric.Text);
         TimeTagAssert.ArePropertyEqual(referencedLyric.TimeTags, lyric.TimeTags);
-        TextTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
         Assert.AreEqual(referencedLyric.SingerIds, lyric.SingerIds);
         Assert.AreEqual(referencedLyric.Translates, lyric.Translates);
         Assert.AreEqual(referencedLyric.Language, lyric.Language);
@@ -187,7 +187,7 @@ public class LyricTest
 
         // property should be the same
         TimeTagAssert.ArePropertyEqual(referencedLyric.TimeTags, lyric.TimeTags);
-        TextTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
 
         // and because there's no change inside the tag, so there's version change.
         Assert.AreEqual(0, lyric.TimeTagsTimingVersion.Value);
@@ -201,7 +201,7 @@ public class LyricTest
 
         // property should be equal.
         TimeTagAssert.ArePropertyEqual(referencedLyric.TimeTags, lyric.TimeTags);
-        TextTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(referencedLyric.RubyTags, lyric.RubyTags);
 
         // and note that because only one property is different, so version should change once.
         Assert.AreEqual(1, lyric.TimeTagsTimingVersion.Value);

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricUtilsTest.cs
@@ -52,7 +52,7 @@ public class LyricUtilsTest
 
         var expected = TestCaseTagHelper.ParseRubyTags(targetRubies);
         var actual = lyric.RubyTags;
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, 2, new[] { "[0,start]:3000", "[1,start]:4000" })]
@@ -101,7 +101,7 @@ public class LyricUtilsTest
 
         var expected = TestCaseTagHelper.ParseRubyTags(targetRubies);
         var actual = lyric.RubyTags;
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000" }, 0, "karaoke", new[] { "[7,start]:1000", "[8,start]:2000", "[9,start]:3000", "[10,start]:4000" })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricUtilsTest.cs
@@ -224,18 +224,18 @@ public class LyricUtilsTest
 
     #endregion
 
-    #region Ruby/romaji tag
+    #region Ruby tag
 
     [TestCase("からおけ", 0, true)]
     [TestCase("からおけ", 4, true)]
     [TestCase("からおけ", -1, false)]
     [TestCase("からおけ", 5, false)]
     [TestCase("", 0, true)]
-    public void TestAbleToInsertTextTagAtIndex(string text, int index, bool expected)
+    public void TestAbleToInsertRubyTagAtIndex(string text, int index, bool expected)
     {
         var lyric = TestCaseTagHelper.ParseLyricWithTimeTag(text);
 
-        bool actual = LyricUtils.AbleToInsertTextTagAtIndex(lyric, index);
+        bool actual = LyricUtils.AbleToInsertRubyTagAtIndex(lyric, index);
         Assert.AreEqual(expected, actual);
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/LyricsUtilsTest.cs
@@ -70,8 +70,8 @@ public class LyricsUtilsTest
 
         var (firstLyric, secondLyric) = LyricsUtils.SplitLyric(lyric, splitIndex);
 
-        TextTagAssert.ArePropertyEqual(TestCaseTagHelper.ParseRubyTags(firstRubyTags), firstLyric.RubyTags);
-        TextTagAssert.ArePropertyEqual(TestCaseTagHelper.ParseRubyTags(secondRubyTags), secondLyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(TestCaseTagHelper.ParseRubyTags(firstRubyTags), firstLyric.RubyTags);
+        RubyTagAssert.ArePropertyEqual(TestCaseTagHelper.ParseRubyTags(secondRubyTags), secondLyric.RubyTags);
     }
 
     [Ignore("Not really sure second lyric is based on lyric time or time-tag time.")]
@@ -200,7 +200,7 @@ public class LyricsUtilsTest
 
         var expected = TestCaseTagHelper.ParseRubyTags(expectedRubyTags);
         var actual = combineLyric.RubyTags;
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new double[] { 1000, 0 }, new double[] { 1000, 0 }, new double[] { 1000, 0 })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/TextTagUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/TextTagUtilsTest.cs
@@ -26,7 +26,7 @@ public class TextTagUtilsTest
 
         var expectedRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
         var actualRubyTag = generateFixedTag(rubyTag, lyric);
-        TextTagAssert.ArePropertyEqual(expectedRubyTag, actualRubyTag);
+        RubyTagAssert.ArePropertyEqual(expectedRubyTag, actualRubyTag);
 
         static T generateFixedTag<T>(T textTag, string lyric) where T : ITextTag, new()
         {
@@ -61,7 +61,7 @@ public class TextTagUtilsTest
         // test ruby tag.
         var expectedRubyTag = TestCaseTagHelper.ParseRubyTag(actualTag);
         var actualRubyTag = generateShiftingTag(rubyTag, lyric, offset);
-        TextTagAssert.ArePropertyEqual(expectedRubyTag, actualRubyTag);
+        RubyTagAssert.ArePropertyEqual(expectedRubyTag, actualRubyTag);
 
         static T generateShiftingTag<T>(T textTag, string lyric, int offset) where T : ITextTag, new()
         {

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/TextTagsUtilsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/Utils/TextTagsUtilsTest.cs
@@ -19,7 +19,7 @@ public class TextTagsUtilsTest
     {
         var expected = TestCaseTagHelper.ParseRubyTags(expectedTextTags);
         var actual = TextTagsUtils.Sort(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0,6]:ka" }, "karaoke", new string[] { })]
@@ -29,7 +29,7 @@ public class TextTagsUtilsTest
     {
         var expected = TestCaseTagHelper.ParseRubyTags(expectedTextTags);
         var actual = TextTagsUtils.FindOutOfRange(TestCaseTagHelper.ParseRubyTags(textTags), lyric);
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0]:ka", "[1]:ra", "[2]:o" }, TextTagsUtils.Sorting.Asc, new string[] { })]
@@ -45,7 +45,7 @@ public class TextTagsUtilsTest
     {
         var expected = TestCaseTagHelper.ParseRubyTags(expectedTextTags);
         var actual = TextTagsUtils.FindOverlapping(TestCaseTagHelper.ParseRubyTags(textTags), sorting);
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0]:ka", "[1]:ra", "[2]:o" }, new string[] { })]
@@ -56,7 +56,7 @@ public class TextTagsUtilsTest
     {
         var expected = TestCaseTagHelper.ParseRubyTags(expectedTextTags);
         var actual = TextTagsUtils.FindEmptyText(TestCaseTagHelper.ParseRubyTags(textTags));
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 
     [TestCase(new[] { "[0]:ka" }, "[0]:ka")]
@@ -67,6 +67,6 @@ public class TextTagsUtilsTest
 
         var expected = TestCaseTagHelper.ParseRubyTag(expectTextTag);
         var actual = TextTagsUtils.Combine(rubyTags);
-        TextTagAssert.ArePropertyEqual(expected, actual);
+        RubyTagAssert.ArePropertyEqual(expected, actual);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Utils/LyricUtils.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Utils/LyricUtils.cs
@@ -192,9 +192,9 @@ public static class LyricUtils
 
     #endregion
 
-    #region Ruby/romaji tag
+    #region Ruby tag
 
-    public static bool AbleToInsertTextTagAtIndex(Lyric lyric, int index)
+    public static bool AbleToInsertRubyTagAtIndex(Lyric lyric, int index)
         => index >= 0 && index <= lyric.Text.Length;
 
     #endregion


### PR DESCRIPTION
What's done in this PR:
- TextTagAsser -> RubyTagAssert
- Rename some related methods.