### PR TITLE
Refactor the import screen stack.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Import/TestSceneLyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Import/TestSceneLyricImporter.cs
@@ -73,16 +73,7 @@ public partial class TestSceneLyricImporter : ScreenTestScene<TestSceneLyricImpo
 
         public void GoToStep(LyricImporterStep step)
         {
-            if (ScreenStack.CurrentScreen is not ILyricImporterStepScreen lyricSubScreen)
-                return;
-
-            if (step == lyricSubScreen.Step)
-                return;
-
-            if (step <= lyricSubScreen.Step)
-                return;
-
-            var totalSteps = Enum.GetValues<LyricImporterStep>().Where(x => x > lyricSubScreen.Step && x <= step);
+            var totalSteps = Enum.GetValues<LyricImporterStep>().Where(x => x > ScreenStack.CurrentStep && x <= step);
 
             foreach (var gotoStep in totalSteps)
             {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/AssignLanguage/AssignLanguageStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/AssignLanguage/AssignLanguageStepScreen.cs
@@ -13,8 +13,6 @@ public partial class AssignLanguageStepScreen : LyricImporterStepScreenWithLyric
 {
     public override string Title => "Language";
 
-    public override LyricImporterStep Step => LyricImporterStep.AssignLanguage;
-
     public override IconUsage Icon => FontAwesome.Solid.Globe;
 
     [Cached(typeof(ILyricPropertyAutoGenerateChangeHandler))]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/AssignLanguage/AssignLanguageStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/AssignLanguage/AssignLanguageStepScreen.cs
@@ -13,8 +13,6 @@ public partial class AssignLanguageStepScreen : LyricImporterStepScreenWithLyric
 {
     public override string Title => "Language";
 
-    public override string ShortTitle => "Language";
-
     public override LyricImporterStep Step => LyricImporterStep.AssignLanguage;
 
     public override IconUsage Icon => FontAwesome.Solid.Globe;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/DragFileStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/DragFileStepScreen.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Import.Lyrics.DragFile;
 public partial class DragFileStepScreen : LyricImporterStepScreen, ICanAcceptFiles
 {
     public override string Title => "Import";
-    public override string ShortTitle => "Import";
     public override LyricImporterStep Step => LyricImporterStep.ImportLyric;
     public override IconUsage Icon => FontAwesome.Solid.Upload;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/DragFileStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/DragFile/DragFileStepScreen.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Import.Lyrics.DragFile;
 public partial class DragFileStepScreen : LyricImporterStepScreen, ICanAcceptFiles
 {
     public override string Title => "Import";
-    public override LyricImporterStep Step => LyricImporterStep.ImportLyric;
     public override IconUsage Icon => FontAwesome.Solid.Upload;
 
     public IEnumerable<string> HandledExtensions => ImportLyricManager.LyricFormatExtensions;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/EditLyric/EditLyricStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/EditLyric/EditLyricStepScreen.cs
@@ -13,8 +13,6 @@ public partial class EditLyricStepScreen : LyricImporterStepScreenWithLyricEdito
 {
     public override string Title => "Edit lyric";
 
-    public override LyricImporterStep Step => LyricImporterStep.EditLyric;
-
     public override IconUsage Icon => FontAwesome.Solid.Globe;
 
     [Cached(typeof(ILyricsChangeHandler))]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/EditLyric/EditLyricStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/EditLyric/EditLyricStepScreen.cs
@@ -13,8 +13,6 @@ public partial class EditLyricStepScreen : LyricImporterStepScreenWithLyricEdito
 {
     public override string Title => "Edit lyric";
 
-    public override string ShortTitle => "Edit";
-
     public override LyricImporterStep Step => LyricImporterStep.EditLyric;
 
     public override IconUsage Icon => FontAwesome.Solid.Globe;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateRuby/GenerateRubyStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateRuby/GenerateRubyStepScreen.cs
@@ -13,8 +13,6 @@ public partial class GenerateRubyStepScreen : LyricImporterStepScreenWithLyricEd
 {
     public override string Title => "Generate ruby";
 
-    public override string ShortTitle => "Generate ruby";
-
     public override LyricImporterStep Step => LyricImporterStep.GenerateRuby;
 
     public override IconUsage Icon => FontAwesome.Solid.Gem;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateRuby/GenerateRubyStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateRuby/GenerateRubyStepScreen.cs
@@ -13,8 +13,6 @@ public partial class GenerateRubyStepScreen : LyricImporterStepScreenWithLyricEd
 {
     public override string Title => "Generate ruby";
 
-    public override LyricImporterStep Step => LyricImporterStep.GenerateRuby;
-
     public override IconUsage Icon => FontAwesome.Solid.Gem;
 
     [Cached(typeof(ILyricPropertyAutoGenerateChangeHandler))]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateTimeTag/GenerateTimeTagStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateTimeTag/GenerateTimeTagStepScreen.cs
@@ -16,8 +16,6 @@ public partial class GenerateTimeTagStepScreen : LyricImporterStepScreenWithLyri
 {
     public override string Title => "Generate time tag";
 
-    public override LyricImporterStep Step => LyricImporterStep.GenerateTimeTag;
-
     public override IconUsage Icon => FontAwesome.Solid.Tag;
 
     [Cached(typeof(ILyricPropertyAutoGenerateChangeHandler))]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateTimeTag/GenerateTimeTagStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/GenerateTimeTag/GenerateTimeTagStepScreen.cs
@@ -16,8 +16,6 @@ public partial class GenerateTimeTagStepScreen : LyricImporterStepScreenWithLyri
 {
     public override string Title => "Generate time tag";
 
-    public override string ShortTitle => "Generate time tag";
-
     public override LyricImporterStep Step => LyricImporterStep.GenerateTimeTag;
 
     public override IconUsage Icon => FontAwesome.Solid.Tag;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
@@ -61,13 +61,14 @@ public partial class Header : Container
             },
         };
 
+        breadcrumbs.Current.TriggerChange();
         breadcrumbs.Current.ValueChanged += screen =>
         {
-            if (screen.NewValue is ILyricImporterStepScreen multiScreen)
-                title.Screen = multiScreen;
-        };
+            if (screen.NewValue is not ILyricImporterStepScreen importerStepScreen)
+                throw new NotImportStepScreenException();
 
-        breadcrumbs.Current.TriggerChange();
+            title.Screen = importerStepScreen;
+        };
     }
 
     [BackgroundDependencyLoader]
@@ -154,10 +155,10 @@ public partial class Header : Container
                 return;
 
             if (Current.Value is not ILyricImporterStepScreen currentScreen)
-                return;
+                throw new NotImportStepScreenException();
 
             if (tab.Value is not ILyricImporterStepScreen targetScreen)
-                return;
+                throw new NotImportStepScreenException();
 
             if (targetScreen.Step > currentScreen.Step)
                 throw new InvalidOperationException("Cannot roll back to next step. How did you did that?");

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -159,9 +158,6 @@ public partial class Header : Container
 
             if (tab.Value is not ILyricImporterStepScreen targetScreen)
                 throw new NotImportStepScreenException();
-
-            if (targetScreen.Step > currentScreen.Step)
-                throw new InvalidOperationException("Cannot roll back to next step. How did you did that?");
 
             // Should make sure that
             targetScreen.ConfirmRollBackFromStep(currentScreen, enabled =>

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Header.cs
@@ -86,7 +86,7 @@ public partial class Header : Container
 
         public ILyricImporterStepScreen Screen
         {
-            set => pageTitle.Text = value.ShortTitle;
+            set => pageTitle.Text = value.Title;
         }
 
         public LyricImporterHeaderTitle()

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/ILyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/ILyricImporterStepScreen.cs
@@ -9,8 +9,6 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Import.Lyrics;
 
 public interface ILyricImporterStepScreen : IScreen
 {
-    LyricImporterStep Step { get; }
-
     string Title { get; }
 
     IconUsage Icon { get; }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/ILyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/ILyricImporterStepScreen.cs
@@ -13,8 +13,6 @@ public interface ILyricImporterStepScreen : IScreen
 
     string Title { get; }
 
-    string ShortTitle { get; }
-
     IconUsage Icon { get; }
 
     void ConfirmRollBackFromStep(ILyricImporterStepScreen fromScreen, Action<bool> callBack);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
@@ -130,11 +130,6 @@ public partial class LyricImporter : ScreenWithBeatmapBackground, IImportStateRe
         switch (e.Action)
         {
             case GlobalAction.Back:
-                // as we don't want to display the back button, manual handling of exit action is required.
-                // follow how editor.cs does.
-                if (ScreenStack.CurrentScreen is not ILyricImporterStepScreen screen)
-                    throw new NotImportStepScreenException();
-
                 if (ScreenStack.IsFirstStep())
                 {
                     // the better UX behavior should be move to the previous step.

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
@@ -133,7 +133,7 @@ public partial class LyricImporter : ScreenWithBeatmapBackground, IImportStateRe
                 // as we don't want to display the back button, manual handling of exit action is required.
                 // follow how editor.cs does.
                 if (ScreenStack.CurrentScreen is not ILyricImporterStepScreen screen)
-                    throw new InvalidOperationException("Screen stack should only contains step screen");
+                    throw new NotImportStepScreenException();
 
                 if (screen.Step != LyricImporterStep.ImportLyric)
                 {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporter.cs
@@ -135,7 +135,7 @@ public partial class LyricImporter : ScreenWithBeatmapBackground, IImportStateRe
                 if (ScreenStack.CurrentScreen is not ILyricImporterStepScreen screen)
                     throw new NotImportStepScreenException();
 
-                if (screen.Step != LyricImporterStep.ImportLyric)
+                if (ScreenStack.IsFirstStep())
                 {
                     // the better UX behavior should be move to the previous step.
                     // But it will not asking.

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterStepScreen.cs
@@ -26,8 +26,6 @@ public abstract partial class LyricImporterStepScreen : OsuScreen, ILyricImporte
     [Resolved]
     protected IDialogOverlay DialogOverlay { get; private set; } = null!;
 
-    public abstract LyricImporterStep Step { get; }
-
     public abstract IconUsage Icon { get; }
 
     protected LyricImporterStepScreen()

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterStepScreen.cs
@@ -26,8 +26,6 @@ public abstract partial class LyricImporterStepScreen : OsuScreen, ILyricImporte
     [Resolved]
     protected IDialogOverlay DialogOverlay { get; private set; } = null!;
 
-    public abstract string ShortTitle { get; }
-
     public abstract LyricImporterStep Step { get; }
 
     public abstract IconUsage Icon { get; }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
@@ -20,8 +20,11 @@ public partial class LyricImporterSubScreenStack : OsuScreenStack
 
     public void Push(LyricImporterStep step)
     {
-        if (CurrentScreen is ILyricImporterStepScreen lyricSubScreen)
+        if (CurrentScreen != null)
         {
+            if (CurrentScreen is not ILyricImporterStepScreen lyricSubScreen)
+                throw new NotImportStepScreenException();
+
             if (step == lyricSubScreen.Step)
                 throw new ScreenNotCurrentException("Cannot push same screen.");
 
@@ -32,41 +35,29 @@ public partial class LyricImporterSubScreenStack : OsuScreenStack
                 throw new ScreenNotCurrentException("Only generate ruby step can be skipped.");
         }
 
-        switch (step)
-        {
-            case LyricImporterStep.ImportLyric:
-                Push(new DragFileStepScreen());
-                return;
+        Push(getScreenByStep(step));
+        return;
 
-            case LyricImporterStep.EditLyric:
-                Push(new EditLyricStepScreen());
-                return;
-
-            case LyricImporterStep.AssignLanguage:
-                Push(new AssignLanguageStepScreen());
-                return;
-
-            case LyricImporterStep.GenerateRuby:
-                Push(new GenerateRubyStepScreen());
-                return;
-
-            case LyricImporterStep.GenerateTimeTag:
-                Push(new GenerateTimeTagStepScreen());
-                return;
-
-            case LyricImporterStep.Success:
-                Push(new SuccessStepScreen());
-                return;
-
-            default:
-                throw new ScreenNotCurrentException("Screen is not in the lyric import step.");
-        }
+        static ILyricImporterStepScreen getScreenByStep(LyricImporterStep step) =>
+            step switch
+            {
+                LyricImporterStep.ImportLyric => new DragFileStepScreen(),
+                LyricImporterStep.EditLyric => new EditLyricStepScreen(),
+                LyricImporterStep.AssignLanguage => new AssignLanguageStepScreen(),
+                LyricImporterStep.GenerateRuby => new GenerateRubyStepScreen(),
+                LyricImporterStep.GenerateTimeTag => new GenerateTimeTagStepScreen(),
+                LyricImporterStep.Success => new SuccessStepScreen(),
+                _ => throw new ScreenNotCurrentException("Screen is not in the lyric import step.")
+            };
     }
 
-    public void Push(ILyricImporterStepScreen screen)
+    public new void Push(IScreen screen)
     {
-        stack.Push(screen);
-        Push(screen as IScreen);
+        if (screen is not ILyricImporterStepScreen lyricSubScreen)
+            throw new NotImportStepScreenException();
+
+        stack.Push(lyricSubScreen);
+        base.Push(screen);
     }
 
     public void Pop(LyricImporterStep step)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
@@ -72,7 +72,7 @@ public partial class LyricImporterSubScreenStack : OsuScreenStack
 
     public bool IsFirstStep()
     {
-        return stack.Count == 1;
+        return CurrentStep == LyricImporterStep.ImportLyric;
     }
 
     private static ILyricImporterStepScreen getScreenByStep(LyricImporterStep step) =>

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/LyricImporterSubScreenStack.cs
@@ -20,21 +20,6 @@ public partial class LyricImporterSubScreenStack : OsuScreenStack
 
     public void Push(LyricImporterStep step)
     {
-        if (CurrentScreen != null)
-        {
-            if (CurrentScreen is not ILyricImporterStepScreen lyricSubScreen)
-                throw new NotImportStepScreenException();
-
-            if (step == lyricSubScreen.Step)
-                throw new ScreenNotCurrentException("Cannot push same screen.");
-
-            if (step <= lyricSubScreen.Step)
-                throw new ScreenNotCurrentException("Cannot push previous then current screen.");
-
-            if (lyricSubScreen.Step == LyricImporterStep.AssignLanguage && step > LyricImporterStep.GenerateTimeTag)
-                throw new ScreenNotCurrentException("Only generate ruby step can be skipped.");
-        }
-
         Push(getScreenByStep(step));
         return;
 
@@ -56,8 +41,24 @@ public partial class LyricImporterSubScreenStack : OsuScreenStack
         if (screen is not ILyricImporterStepScreen lyricSubScreen)
             throw new NotImportStepScreenException();
 
+        if (CurrentScreen is ILyricImporterStepScreen currentScreen)
+            checkStep(currentScreen.Step, lyricSubScreen.Step);
+
         stack.Push(lyricSubScreen);
         base.Push(screen);
+        return;
+
+        static void checkStep(LyricImporterStep currentStep, LyricImporterStep newStep)
+        {
+            if (newStep == currentStep)
+                throw new ScreenNotCurrentException("Cannot push same screen.");
+
+            if (newStep <= currentStep)
+                throw new ScreenNotCurrentException("Cannot push previous then current screen.");
+
+            if (currentStep == LyricImporterStep.AssignLanguage && newStep > LyricImporterStep.GenerateTimeTag)
+                throw new ScreenNotCurrentException("Only generate ruby step can be skipped.");
+        }
     }
 
     public void Pop(LyricImporterStep step)

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/NotImportStepScreenException.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/NotImportStepScreenException.cs
@@ -1,0 +1,14 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Import.Lyrics;
+
+public class NotImportStepScreenException : InvalidOperationException
+{
+    public NotImportStepScreenException()
+        : base("Screen stack should only contains step screen")
+    {
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/RollBackPopupDialog.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/RollBackPopupDialog.cs
@@ -11,7 +11,7 @@ public partial class RollBackPopupDialog : PopupDialog
     public RollBackPopupDialog(ILyricImporterStepScreen screen, Action<bool> okAction)
     {
         Icon = screen.Icon;
-        HeaderText = screen.ShortTitle;
+        HeaderText = "Rollback?";
         BodyText = $"Will roll-back to step '{screen.Title}'";
         Buttons = new PopupDialogButton[]
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Success/SuccessStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Success/SuccessStepScreen.cs
@@ -10,8 +10,6 @@ public partial class SuccessStepScreen : LyricImporterStepScreen
 {
     public override string Title => "Success";
 
-    public override LyricImporterStep Step => LyricImporterStep.GenerateTimeTag;
-
     public override IconUsage Icon => FontAwesome.Regular.CheckCircle;
 
     [Resolved]

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Success/SuccessStepScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Import/Lyrics/Success/SuccessStepScreen.cs
@@ -10,8 +10,6 @@ public partial class SuccessStepScreen : LyricImporterStepScreen
 {
     public override string Title => "Success";
 
-    public override string ShortTitle => "Success";
-
     public override LyricImporterStep Step => LyricImporterStep.GenerateTimeTag;
 
     public override IconUsage Icon => FontAwesome.Regular.CheckCircle;


### PR DESCRIPTION
Preparation of #2214.

What's done in this PR:
1. Refactor the `LyricImporterSubScreenStack` to make it more easy to understand.
2. Remove some un-need property in the `ILyricImporterStepScreen`.