### PR TITLE
Lyric start/end time should be nullable.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcDecoderTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Beatmaps/Formats/LrcDecoderTest.cs
@@ -26,8 +26,8 @@ public class LrcDecoderTest
         var actual = beatmap.HitObjects.OfType<Lyric>().FirstOrDefault()!;
         Assert.IsNotNull(actual);
         Assert.AreEqual(expectedText, actual.Text);
-        Assert.AreEqual(expectedStartTime, actual.LyricStartTime);
-        Assert.AreEqual(expectedEndTime, actual.LyricEndTime);
+        Assert.AreEqual(expectedStartTime, actual.LyricTimingInfo?.StartTime);
+        Assert.AreEqual(expectedEndTime, actual.LyricTimingInfo?.EndTime);
     }
 
     [TestCase("[00:01.00]か[00:02.00]ら[00:03.00]お[00:04.00]け[00:05.00]", new[] { "[0,start]:1000", "[1,start]:2000", "[2,start]:3000", "[3,start]:4000", "[3,end]:5000" })]

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StageElementCategoryChangeHandlerTest.cs
@@ -280,7 +280,7 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
 
         protected override Tuple<double?, double?> GetStartAndEndTime(Lyric lyric)
         {
-            return new Tuple<double?, double?>(lyric.LyricStartTime, lyric.LyricEndTime);
+            return new Tuple<double?, double?>(lyric.LyricTimingInfo?.StartTime, lyric.LyricTimingInfo?.EndTime);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/IO/Serialization/Converters/LyricConverterTest.cs
@@ -42,8 +42,7 @@ public class LyricConverterTest : BaseSingleConverterTest<LyricConverter>
         Assert.AreEqual(expected.ID, actual.ID);
         Assert.AreEqual(expected.Text, actual.Text);
         TimeTagAssert.ArePropertyEqual(expected.TimeTags, actual.TimeTags);
-        Assert.AreEqual(expected.LyricStartTime, actual.LyricStartTime);
-        Assert.AreEqual(expected.LyricEndTime, actual.LyricEndTime);
+        Assert.AreEqual(expected.LyricTimingInfo, actual.LyricTimingInfo);
         RubyTagAssert.ArePropertyEqual(expected.RubyTags, actual.RubyTags);
         Assert.AreEqual(expected.StartTime, actual.StartTime);
         Assert.AreEqual(expected.Duration, actual.Duration);

--- a/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Objects/LyricTest.cs
@@ -55,9 +55,7 @@ public class LyricTest
         Assert.AreNotSame(clonedLyric.TimeTagsBindable, lyric.TimeTagsBindable);
         TimeTagAssert.ArePropertyEqual(clonedLyric.TimeTags, lyric.TimeTags);
 
-        Assert.AreEqual(clonedLyric.LyricStartTime, lyric.LyricStartTime);
-        Assert.AreEqual(clonedLyric.LyricEndTime, lyric.LyricEndTime);
-        Assert.AreEqual(clonedLyric.LyricDuration, lyric.LyricDuration);
+        Assert.AreEqual(clonedLyric.LyricTimingInfo, lyric.LyricTimingInfo);
 
         Assert.AreNotSame(clonedLyric.RubyTagsVersion, lyric.RubyTagsVersion);
         Assert.AreNotSame(clonedLyric.RubyTagsBindable, lyric.RubyTagsBindable);

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
@@ -58,7 +58,7 @@ public class PageInfo : IDeepCloneable<PageInfo>
         }
     }
 
-    public Page? GetPageAt(double? time)
+    public Page? GetPageAt(double time)
     {
         if (SortedPages.Count < 2)
             return null;
@@ -73,7 +73,7 @@ public class PageInfo : IDeepCloneable<PageInfo>
         return page;
     }
 
-    public int? GetPageIndexAt(double? time)
+    public int? GetPageIndexAt(double time)
     {
         var page = GetPageAt(time);
         if (page == null)

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Metadatas/PageInfo.cs
@@ -58,7 +58,7 @@ public class PageInfo : IDeepCloneable<PageInfo>
         }
     }
 
-    public Page? GetPageAt(double time)
+    public Page? GetPageAt(double? time)
     {
         if (SortedPages.Count < 2)
             return null;
@@ -73,7 +73,7 @@ public class PageInfo : IDeepCloneable<PageInfo>
         return page;
     }
 
-    public int? GetPageIndexAt(double time)
+    public int? GetPageIndexAt(double? time)
     {
         var page = GetPageAt(time);
         if (page == null)

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
@@ -64,7 +64,7 @@ public class CheckBeatmapPageInfo : CheckBeatmapProperty<PageInfo, Lyric>
         if (pages.Count < 2)
             yield break;
 
-        var availablePagesInObject = hitObject.ToDictionary(k => k, v => property.GetPageAt(v.LyricStartTime));
+        var availablePagesInObject = hitObject.ToDictionary(k => k, v => property.GetPageAt(v.LyricTimingInfo?.StartTime));
 
         var missingHitObjectPages = pages.Where(page => !availablePagesInObject.ContainsValue(page)).ToArray();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckBeatmapPageInfo.cs
@@ -64,7 +64,7 @@ public class CheckBeatmapPageInfo : CheckBeatmapProperty<PageInfo, Lyric>
         if (pages.Count < 2)
             yield break;
 
-        var availablePagesInObject = hitObject.ToDictionary(k => k, v => property.GetPageAt(v.LyricTimingInfo?.StartTime));
+        var availablePagesInObject = hitObject.ToDictionary(k => k, v => v.LyricTimingInfo != null ? property.GetPageAt(v.LyricTimingInfo.StartTime) : null);
 
         var missingHitObjectPages = pages.Where(page => !availablePagesInObject.ContainsValue(page)).ToArray();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/LyricIssue.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/LyricIssue.cs
@@ -15,6 +15,6 @@ public class LyricIssue : Issue
     {
         Lyric = lyric;
 
-        Time = Lyric.LyricStartTime;
+        Time = Lyric.LyricTimingInfo?.StartTime;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/LyricTimeTagIssue.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/Issues/LyricTimeTagIssue.cs
@@ -15,6 +15,6 @@ public class LyricTimeTagIssue : LyricIssue
     {
         TimeTag = timeTag;
 
-        Time = TimeTag.Time ?? Lyric.LyricStartTime;
+        Time = TimeTag.Time ?? Lyric.LyricTimingInfo?.StartTime;
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
@@ -46,11 +46,14 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
             throw new InvalidOperationException("Interval time should be validate.");
 
         var existPages = Config.ClearExistPages.Value ? Array.Empty<Page>() : item.PageInfo.SortedPages.ToArray();
-        var lyricTimingInfos = item.HitObjects.OfType<Lyric>().Select(x => new LyricTimingInfo
-        {
-            StartTime = x.LyricStartTime,
-            EndTime = x.LyricEndTime,
-        }).OrderBy(x => x).ToList();
+        var lyricTimingInfos = item.HitObjects.OfType<Lyric>()
+                                   .Where(x => x.LyricStartTime != null && x.LyricEndTime != null)
+                                   .Select(x => new LyricTimingInfo
+                                   {
+                                       StartTime = x.LyricStartTime!.Value,
+                                       EndTime = x.LyricEndTime!.Value,
+                                   })
+                                   .OrderBy(x => x).ToList();
 
         if (lyricTimingInfos.Count == 0)
             return existPages;

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Beatmaps/Pages/PageGenerator.cs
@@ -47,11 +47,11 @@ public class PageGenerator : BeatmapPropertyGenerator<Page[], PageGeneratorConfi
 
         var existPages = Config.ClearExistPages.Value ? Array.Empty<Page>() : item.PageInfo.SortedPages.ToArray();
         var lyricTimingInfos = item.HitObjects.OfType<Lyric>()
-                                   .Where(x => x.LyricStartTime != null && x.LyricEndTime != null)
+                                   .Where(x => x.LyricTimingInfo != null)
                                    .Select(x => new LyricTimingInfo
                                    {
-                                       StartTime = x.LyricStartTime!.Value,
-                                       EndTime = x.LyricEndTime!.Value,
+                                       StartTime = x.LyricTimingInfo!.StartTime,
+                                       EndTime = x.LyricTimingInfo.EndTime,
                                    })
                                    .OrderBy(x => x).ToList();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Stages/Classic/ClassicLyricTimingInfoGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Stages/Classic/ClassicLyricTimingInfoGenerator.cs
@@ -29,7 +29,7 @@ public class ClassicLyricTimingInfoGenerator : StageInfoPropertyGenerator<Classi
     {
         int lyricAmount = Config.LyricRowAmount.Value;
 
-        var lyrics = item.HitObjects.OfType<Lyric>().Where(x => x.LyricEndTime != null).ToArray();
+        var lyrics = item.HitObjects.OfType<Lyric>().Where(x => x.LyricTimingInfo != null).ToArray();
         var timingInfo = new ClassicLyricTimingInfo();
 
         // lazy to generate the info if the lyric amount is not enough.
@@ -51,13 +51,13 @@ public class ClassicLyricTimingInfoGenerator : StageInfoPropertyGenerator<Classi
             var disappearLyric = lyrics.ElementAt(i);
             var showLyric = lyrics.ElementAt(i + lyricAmount);
 
-            var timingPoint = timingInfo.AddTimingPoint(x => x.Time = disappearLyric.LyricEndTime!.Value);
+            var timingPoint = timingInfo.AddTimingPoint(x => x.Time = disappearLyric.LyricTimingInfo!.EndTime);
             timingInfo.AddToMapping(timingPoint, disappearLyric);
             timingInfo.AddToMapping(timingPoint, showLyric);
         }
 
         // add end timing info.
-        var lastTimingPoint = timingInfo.AddTimingPoint(x => x.Time = lyrics.Last().LyricEndTime!.Value);
+        var lastTimingPoint = timingInfo.AddTimingPoint(x => x.Time = lyrics.Last().LyricTimingInfo!.EndTime);
 
         for (int i = lyrics.Length - lyricAmount; i < lyrics.Length; i++)
         {

--- a/osu.Game.Rulesets.Karaoke/Edit/Generator/Stages/Classic/ClassicLyricTimingInfoGenerator.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Generator/Stages/Classic/ClassicLyricTimingInfoGenerator.cs
@@ -29,8 +29,12 @@ public class ClassicLyricTimingInfoGenerator : StageInfoPropertyGenerator<Classi
     {
         int lyricAmount = Config.LyricRowAmount.Value;
 
-        var lyrics = item.HitObjects.OfType<Lyric>().ToArray();
+        var lyrics = item.HitObjects.OfType<Lyric>().Where(x => x.LyricEndTime != null).ToArray();
         var timingInfo = new ClassicLyricTimingInfo();
+
+        // lazy to generate the info if the lyric amount is not enough.
+        if (lyrics.Length < lyricAmount)
+            return timingInfo;
 
         // add start timing info.
         var firstTimingPoint = timingInfo.AddTimingPoint();
@@ -47,13 +51,13 @@ public class ClassicLyricTimingInfoGenerator : StageInfoPropertyGenerator<Classi
             var disappearLyric = lyrics.ElementAt(i);
             var showLyric = lyrics.ElementAt(i + lyricAmount);
 
-            var timingPoint = timingInfo.AddTimingPoint(x => x.Time = disappearLyric.LyricEndTime);
+            var timingPoint = timingInfo.AddTimingPoint(x => x.Time = disappearLyric.LyricEndTime!.Value);
             timingInfo.AddToMapping(timingPoint, disappearLyric);
             timingInfo.AddToMapping(timingPoint, showLyric);
         }
 
         // add end timing info.
-        var lastTimingPoint = timingInfo.AddTimingPoint(x => x.Time = lyrics.Last().LyricEndTime);
+        var lastTimingPoint = timingInfo.AddTimingPoint(x => x.Time = lyrics.Last().LyricEndTime!.Value);
 
         for (int i = lyrics.Length - lyricAmount; i < lyrics.Length; i++)
         {

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -182,7 +182,11 @@ public partial class DrawableLyric : DrawableKaraokeHitObject
 
     protected override void CheckForResult(bool userTriggered, double timeOffset)
     {
-        if (timeOffset + HitObject.LyricDuration >= 0 && HitObject.HitWindows.CanBeHit(timeOffset + HitObject.LyricDuration))
+        double? duration = HitObject.LyricDuration;
+        if (duration == null)
+            return;
+
+        if (timeOffset + HitObject.LyricDuration >= 0 && HitObject.HitWindows.CanBeHit(timeOffset + duration.Value))
         {
             // note: CheckForResult will not being triggered when roll-back the time.
             // so there's no need to consider the case while roll-back.

--- a/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Drawables/DrawableLyric.cs
@@ -182,11 +182,11 @@ public partial class DrawableLyric : DrawableKaraokeHitObject
 
     protected override void CheckForResult(bool userTriggered, double timeOffset)
     {
-        double? duration = HitObject.LyricDuration;
-        if (duration == null)
+        var timingInfo = HitObject.LyricTimingInfo;
+        if (timingInfo == null)
             return;
 
-        if (timeOffset + HitObject.LyricDuration >= 0 && HitObject.HitWindows.CanBeHit(timeOffset + duration.Value))
+        if (timeOffset + timingInfo.Duration >= 0 && HitObject.HitWindows.CanBeHit(timeOffset + timingInfo.Duration))
         {
             // note: CheckForResult will not being triggered when roll-back the time.
             // so there's no need to consider the case while roll-back.

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
@@ -135,8 +135,17 @@ public partial class Lyric
 
         void updateLyricTime()
         {
-            LyricStartTime = TimeTagsUtils.GetStartTime(TimeTags);
-            LyricEndTime = TimeTagsUtils.GetEndTime(TimeTags);
+            double? startTime = TimeTagsUtils.GetStartTime(TimeTags);
+            double? endTime = TimeTagsUtils.GetEndTime(TimeTags);
+
+            if (startTime != null && endTime != null)
+            {
+                LyricTimingInfo = new LyricTimingInfo(startTime.Value, endTime.Value);
+            }
+            else
+            {
+                LyricTimingInfo = null;
+            }
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Binding.cs
@@ -135,9 +135,8 @@ public partial class Lyric
 
         void updateLyricTime()
         {
-            // todo: should think about lyric time should be nullable?
-            LyricStartTime = TimeTagsUtils.GetStartTime(TimeTags) ?? StartTime;
-            LyricEndTime = TimeTagsUtils.GetEndTime(TimeTags) ?? EndTime;
+            LyricStartTime = TimeTagsUtils.GetStartTime(TimeTags);
+            LyricEndTime = TimeTagsUtils.GetEndTime(TimeTags);
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -58,7 +58,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
                     break;
 
                 case LyricWorkingProperty.Page:
-                    PageIndex = getPageIndex(beatmap, LyricStartTime);
+                    PageIndex = getPageIndex(beatmap, LyricTimingInfo?.StartTime);
                     break;
 
                 case LyricWorkingProperty.ReferenceLyric:
@@ -114,13 +114,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
     }
 
     [JsonIgnore]
-    public double? LyricStartTime { get; private set; }
-
-    [JsonIgnore]
-    public double? LyricEndTime { get; private set; }
-
-    [JsonIgnore]
-    public double? LyricDuration => LyricEndTime - LyricStartTime;
+    public LyricTimingInfo? LyricTimingInfo { get; private set; }
 
     /// <summary>
     /// Lyric's start time is created from <see cref="StageInfo"/> and should not be saved.
@@ -230,5 +224,47 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
 
             updateStateByWorkingProperty(LyricWorkingProperty.EffectApplier);
         }
+    }
+}
+
+public class LyricTimingInfo : IEquatable<LyricTimingInfo>
+{
+    public LyricTimingInfo(double startTime, double endTime)
+    {
+        StartTime = startTime;
+        EndTime = endTime;
+    }
+
+    public double StartTime { get; }
+
+    public double EndTime { get; }
+
+    public double Duration => EndTime - StartTime;
+
+    public bool Equals(LyricTimingInfo? other)
+    {
+        if (ReferenceEquals(null, other))
+            return false;
+
+        if (ReferenceEquals(this, other))
+            return true;
+
+        return StartTime.Equals(other.StartTime) && EndTime.Equals(other.EndTime);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj))
+            return false;
+
+        if (ReferenceEquals(this, obj))
+            return true;
+
+        return obj.GetType() == GetType() && Equals((LyricTimingInfo)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(StartTime, EndTime);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -58,7 +58,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
                     break;
 
                 case LyricWorkingProperty.Page:
-                    PageIndex = getPageIndex(beatmap, LyricTimingInfo?.StartTime);
+                    PageIndex = LyricTimingInfo != null ? getPageIndex(beatmap, LyricTimingInfo.StartTime) : null;
                     break;
 
                 case LyricWorkingProperty.ReferenceLyric:
@@ -97,7 +97,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
         static IDictionary<Singer, SingerState[]> getSingers(KaraokeBeatmap beatmap, IEnumerable<ElementId> singerIds)
             => beatmap.SingerInfo.GetSingerByIds(singerIds.ToArray());
 
-        static int? getPageIndex(KaraokeBeatmap beatmap, double? startTime)
+        static int? getPageIndex(KaraokeBeatmap beatmap, double startTime)
             => beatmap.PageInfo.GetPageIndexAt(startTime);
 
         static Lyric? findLyricById(IBeatmap beatmap, ElementId? id) =>

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -97,7 +97,7 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
         static IDictionary<Singer, SingerState[]> getSingers(KaraokeBeatmap beatmap, IEnumerable<ElementId> singerIds)
             => beatmap.SingerInfo.GetSingerByIds(singerIds.ToArray());
 
-        static int? getPageIndex(KaraokeBeatmap beatmap, double startTime)
+        static int? getPageIndex(KaraokeBeatmap beatmap, double? startTime)
             => beatmap.PageInfo.GetPageIndexAt(startTime);
 
         static Lyric? findLyricById(IBeatmap beatmap, ElementId? id) =>

--- a/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
+++ b/osu.Game.Rulesets.Karaoke/Objects/Lyric_Working.cs
@@ -114,13 +114,13 @@ public partial class Lyric : IHasWorkingProperty<LyricWorkingProperty>, IHasEffe
     }
 
     [JsonIgnore]
-    public double LyricStartTime { get; private set; }
+    public double? LyricStartTime { get; private set; }
 
     [JsonIgnore]
-    public double LyricEndTime { get; private set; }
+    public double? LyricEndTime { get; private set; }
 
     [JsonIgnore]
-    public double LyricDuration => LyricEndTime - LyricStartTime;
+    public double? LyricDuration => LyricEndTime - LyricStartTime;
 
     /// <summary>
     /// Lyric's start time is created from <see cref="StageInfo"/> and should not be saved.

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
@@ -65,9 +65,14 @@ public partial class AdjustTimeTagScrollContainer : TimeTagScrollContainer, IPos
         // add the little bit delay to make sure that content width is not zero.
         this.FadeOut(1).OnComplete(x =>
         {
-            const float preempt_time = 200;
-            float position = PositionAtTime(newLyric.LyricStartTime - preempt_time);
-            ScrollTo(position, false);
+            double? lyricStartTime = newLyric.LyricStartTime;
+
+            if (lyricStartTime != null)
+            {
+                const float preempt_time = 200;
+                float position = PositionAtTime(lyricStartTime.Value - preempt_time);
+                ScrollTo(position, false);
+            }
 
             this.FadeIn(100);
         });

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/AdjustTimeTags/AdjustTimeTagScrollContainer.cs
@@ -65,7 +65,7 @@ public partial class AdjustTimeTagScrollContainer : TimeTagScrollContainer, IPos
         // add the little bit delay to make sure that content width is not zero.
         this.FadeOut(1).OnComplete(x =>
         {
-            double? lyricStartTime = newLyric.LyricStartTime;
+            double? lyricStartTime = newLyric.LyricTimingInfo?.StartTime;
 
             if (lyricStartTime != null)
             {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
@@ -71,7 +71,7 @@ public partial class NoteEditor : Container
             if (lyric == null)
                 return;
 
-            double? lyricStartTime = lyric.LyricStartTime;
+            double? lyricStartTime = lyric.LyricTimingInfo?.StartTime;
             if (lyricStartTime != null)
                 Playfield.Clock = new StopClock(lyricStartTime.Value);
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/Notes/NoteEditor.cs
@@ -71,7 +71,9 @@ public partial class NoteEditor : Container
             if (lyric == null)
                 return;
 
-            Playfield.Clock = new StopClock(lyric.LyricStartTime);
+            double? lyricStartTime = lyric.LyricStartTime;
+            if (lyricStartTime != null)
+                Playfield.Clock = new StopClock(lyricStartTime.Value);
 
             // add all matched notes into playfield
             var notes = EditorBeatmapUtils.GetNotesByLyric(beatmap, lyric);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricEditorBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricEditorBlueprintContainer.cs
@@ -25,7 +25,7 @@ public partial class SingerLyricEditorBlueprintContainer : EditableTimelineBluep
     }
 
     protected override IEnumerable<SelectionBlueprint<Lyric>> SortForMovement(IReadOnlyList<SelectionBlueprint<Lyric>> blueprints)
-        => blueprints.OrderBy(b => b.Item.LyricStartTime);
+        => blueprints.OrderBy(b => b.Item.LyricTimingInfo?.StartTime);
 
     protected override SelectionHandler<Lyric> CreateSelectionHandler()
         => new SingerLyricSelectionHandler();

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricTimeline.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricTimeline.cs
@@ -66,8 +66,8 @@ public partial class SingerLyricTimeline : EditableTimeline
 
         const float preempt_time = 1000;
 
-        var firstLyric = beatmap.HitObjects.OfType<Lyric>().FirstOrDefault(x => x.LyricStartTime > 0);
-        double? lyricStartTime = firstLyric?.LyricStartTime;
+        var firstLyric = beatmap.HitObjects.OfType<Lyric>().FirstOrDefault(x => x.LyricTimingInfo?.StartTime > 0);
+        double? lyricStartTime = firstLyric?.LyricTimingInfo?.StartTime;
         if (lyricStartTime == null)
             return;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricTimeline.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Singers/Rows/Components/Timeline/SingerLyricTimeline.cs
@@ -67,10 +67,11 @@ public partial class SingerLyricTimeline : EditableTimeline
         const float preempt_time = 1000;
 
         var firstLyric = beatmap.HitObjects.OfType<Lyric>().FirstOrDefault(x => x.LyricStartTime > 0);
-        if (firstLyric == null)
+        double? lyricStartTime = firstLyric?.LyricStartTime;
+        if (lyricStartTime == null)
             return;
 
-        float position = PositionAtTime(firstLyric.LyricStartTime - preempt_time);
+        float position = PositionAtTime(lyricStartTime.Value - preempt_time);
         ScrollTo(position, false);
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
@@ -14,12 +14,15 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Components.Timeline;
 
 public partial class EditableLyricTimelineSelectionBlueprint : EditableTimelineSelectionBlueprint<Lyric>, IHasCustomTooltip<Lyric>
 {
+    private const double default_time = 0;
+    private const double default_duration = 1000;
+
     private const float lyric_size = 20;
 
     public EditableLyricTimelineSelectionBlueprint(Lyric item)
         : base(item)
     {
-        X = (float)Item.LyricStartTime;
+        X = (float)(Item.LyricStartTime ?? default_time);
 
         RelativeSizeAxes = Axes.X;
         Height = lyric_size;
@@ -56,7 +59,7 @@ public partial class EditableLyricTimelineSelectionBlueprint : EditableTimelineS
         base.Update();
 
         // no bindable so we perform this every update
-        float duration = (float)Item.LyricDuration;
+        float duration = (float)(Item.LyricDuration ?? default_duration);
 
         if (Width != duration)
         {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Timeline/EditableLyricTimelineSelectionBlueprint.cs
@@ -22,7 +22,7 @@ public partial class EditableLyricTimelineSelectionBlueprint : EditableTimelineS
     public EditableLyricTimelineSelectionBlueprint(Lyric item)
         : base(item)
     {
-        X = (float)(Item.LyricStartTime ?? default_time);
+        X = (float)(Item.LyricTimingInfo?.StartTime ?? default_time);
 
         RelativeSizeAxes = Axes.X;
         Height = lyric_size;
@@ -59,7 +59,7 @@ public partial class EditableLyricTimelineSelectionBlueprint : EditableTimelineS
         base.Update();
 
         // no bindable so we perform this every update
-        float duration = (float)(Item.LyricDuration ?? default_duration);
+        float duration = (float)(Item.LyricTimingInfo?.Duration ?? default_duration);
 
         if (Width != duration)
         {

--- a/osu.Game.Rulesets.Karaoke/Stages/Classic/ClassicStageDefinition.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Classic/ClassicStageDefinition.cs
@@ -64,12 +64,12 @@ public class ClassicStageDefinition : StageDefinition
     public double FirstLyricStartTimeOffset { get; set; } = 1000;
 
     /// <summary>
-    /// The delay disappear time after touch to the <see cref="Lyric"/>'s <see cref="Lyric.LyricEndTime"/>
+    /// The delay disappear time after touch to the <see cref="Lyric"/>'s <see cref="LyricTimingInfo.StartTime"/>
     /// </summary>
     public double LyricEndTimeOffset { get; set; } = 300;
 
     /// <summary>
-    /// The delay disappear time after touch to the last <see cref="Lyric"/>'s <see cref="Lyric.LyricEndTime"/>
+    /// The delay disappear time after touch to the last <see cref="Lyric"/>'s <see cref="LyricTimingInfo.EndTime"/>
     /// </summary>
     public double LastLyricEndTimeOffset { get; set; } = 10000;
 

--- a/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
@@ -75,7 +75,7 @@ public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
         layoutCategory.ClearElements();
 
         // Note: only deal with those lyrics has time.
-        var matchedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricStartTime != null).OrderBy(x => x.LyricStartTime).ToArray();
+        var matchedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricTimingInfo != null).OrderBy(x => x.LyricTimingInfo!.StartTime).ToArray();
 
         foreach (var lyric in matchedLyrics)
         {

--- a/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageInfo.cs
@@ -74,7 +74,10 @@ public class PreviewStageInfo : StageInfo, IHasCalculatedProperty
         // also, clear all mapping in the layout and re-create one.
         layoutCategory.ClearElements();
 
-        foreach (var lyric in beatmap.HitObjects.OfType<Lyric>())
+        // Note: only deal with those lyrics has time.
+        var matchedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricStartTime != null).OrderBy(x => x.LyricStartTime).ToArray();
+
+        foreach (var lyric in matchedLyrics)
         {
             var element = layoutCategory.AddElement(x =>
             {

--- a/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageTimingCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageTimingCalculator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -23,7 +24,7 @@ public class PreviewStageTimingCalculator
 
     public PreviewStageTimingCalculator(IBeatmap beatmap, PreviewStageDefinition definition)
     {
-        orderedLyrics = beatmap.HitObjects.OfType<Lyric>().OrderBy(x => x.LyricStartTime).ToArray();
+        orderedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricStartTime != null).OrderBy(x => x.LyricStartTime).ToArray();
         numberOfLyrics = definition.NumberOfLyrics;
         fadingTime = definition.FadingTime;
         lineMovingOffsetTime = definition.LineMovingOffsetTime;
@@ -31,6 +32,9 @@ public class PreviewStageTimingCalculator
 
     public double CalculateStartTime(Lyric lyric)
     {
+        if (lyric.LyricStartTime == null)
+            throw new InvalidOperationException();
+
         var matchedLyrics = getRelatedLyrics(lyric, numberOfLyrics + 1).ToArray();
 
         // if true, means those lyrics show at the screening at the beginning.
@@ -41,13 +45,16 @@ public class PreviewStageTimingCalculator
             return 0;
         }
 
-        double startEffectTime = matchedLyrics.Min(x => x.LyricEndTime) + numberOfLyrics * lineMovingOffsetTime;
+        double startEffectTime = matchedLyrics.Min(x => x.LyricEndTime!.Value) + numberOfLyrics * lineMovingOffsetTime;
         return startEffectTime + fadingTime;
     }
 
     public double CalculateEndTime(Lyric lyric)
     {
-        return lyric.LyricEndTime;
+        if (lyric.LyricEndTime == null)
+            throw new InvalidOperationException();
+
+        return lyric.LyricEndTime.Value;
     }
 
     /// <summary>
@@ -65,7 +72,7 @@ public class PreviewStageTimingCalculator
         {
             // line should start from zero.
             int line = matchedLyrics.Length - i - 2;
-            double time = matchedLyrics[i].LyricEndTime + line * lineMovingOffsetTime;
+            double time = matchedLyrics[i].LyricEndTime!.Value + line * lineMovingOffsetTime;
 
             dictionary.Add(line, time);
         }

--- a/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageTimingCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Preview/PreviewStageTimingCalculator.cs
@@ -24,7 +24,7 @@ public class PreviewStageTimingCalculator
 
     public PreviewStageTimingCalculator(IBeatmap beatmap, PreviewStageDefinition definition)
     {
-        orderedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricStartTime != null).OrderBy(x => x.LyricStartTime).ToArray();
+        orderedLyrics = beatmap.HitObjects.OfType<Lyric>().Where(x => x.LyricTimingInfo != null).OrderBy(x => x.LyricTimingInfo!.StartTime).ToArray();
         numberOfLyrics = definition.NumberOfLyrics;
         fadingTime = definition.FadingTime;
         lineMovingOffsetTime = definition.LineMovingOffsetTime;
@@ -32,7 +32,7 @@ public class PreviewStageTimingCalculator
 
     public double CalculateStartTime(Lyric lyric)
     {
-        if (lyric.LyricStartTime == null)
+        if (lyric.LyricTimingInfo == null)
             throw new InvalidOperationException();
 
         var matchedLyrics = getRelatedLyrics(lyric, numberOfLyrics + 1).ToArray();
@@ -45,16 +45,16 @@ public class PreviewStageTimingCalculator
             return 0;
         }
 
-        double startEffectTime = matchedLyrics.Min(x => x.LyricEndTime!.Value) + numberOfLyrics * lineMovingOffsetTime;
+        double startEffectTime = matchedLyrics.Min(x => x.LyricTimingInfo!.EndTime) + numberOfLyrics * lineMovingOffsetTime;
         return startEffectTime + fadingTime;
     }
 
     public double CalculateEndTime(Lyric lyric)
     {
-        if (lyric.LyricEndTime == null)
+        if (lyric.LyricTimingInfo == null)
             throw new InvalidOperationException();
 
-        return lyric.LyricEndTime.Value;
+        return lyric.LyricTimingInfo.EndTime;
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public class PreviewStageTimingCalculator
         {
             // line should start from zero.
             int line = matchedLyrics.Length - i - 2;
-            double time = matchedLyrics[i].LyricEndTime!.Value + line * lineMovingOffsetTime;
+            double time = matchedLyrics[i].LyricTimingInfo!.EndTime + line * lineMovingOffsetTime;
 
             dictionary.Add(line, time);
         }

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -70,8 +70,9 @@ public partial class LyricsPreview : CompositeDrawable
 
     private void triggerLyric(Lyric lyric)
     {
-        double time = lyric.LyricStartTime - bindablePreemptTime.Value;
-        beatmap.Value.Track.Seek(time);
+        double? time = lyric.LyricStartTime - bindablePreemptTime.Value;
+        if (time != null)
+            beatmap.Value.Track.Seek(time.Value);
 
         // because playback might not clear singing lyrics, so we should re-assign the lyric here.
         // todo: find a better place.

--- a/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/UI/PlayerSettings/LyricsPreview.cs
@@ -70,7 +70,7 @@ public partial class LyricsPreview : CompositeDrawable
 
     private void triggerLyric(Lyric lyric)
     {
-        double? time = lyric.LyricStartTime - bindablePreemptTime.Value;
+        double? time = lyric.LyricTimingInfo!.StartTime - bindablePreemptTime.Value;
         if (time != null)
             beatmap.Value.Track.Seek(time.Value);
 


### PR DESCRIPTION
What's done in this PR:
1. Lyric start/end time property should be nullable.
2. Warp lyric start/end time into single property. naming like `LyricStartTime`/`LyricEndTime` might be confused with `StartTime`/`EndTime` in the HitObject.