### PR TITLE
Improve time-tag tap area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/RecordingTimeTagCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/RecordingTimeTagCaretPosition.cs
@@ -38,6 +38,16 @@ public readonly struct RecordingTimeTagCaretPosition : IIndexCaretPosition, ICom
         return CompareTo(recordingTagCaretPosition);
     }
 
+    public int GetTotalTimeTags()
+    {
+        return Lyric.TimeTags.Count;
+    }
+
+    public int GetCurrentTimeTagIndex()
+    {
+        return Lyric.TimeTags.IndexOf(TimeTag);
+    }
+
     public int GetPaddingTextIndex()
     {
         var currentTimeTag = TimeTag;

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TapButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Settings/TimeTags/TapButton.cs
@@ -64,7 +64,7 @@ internal partial class TapButton : CircularContainer
     {
         Size = new Vector2(SIZE);
 
-        const float ring_width = 22;
+        const float ring_width = 10;
         const float light_padding = 3;
 
         InternalChild = scaleContainer = new Container


### PR DESCRIPTION
Before:
![image](https://github.com/karaoke-dev/karaoke/assets/9100368/b295b14b-c2d0-4051-a573-2eca60dce723)

After:
![image](https://github.com/karaoke-dev/karaoke/assets/9100368/28a2d59c-79e1-441d-a659-4b124fa942ed)

Improvement of #2222

What's changed in this PR:
1. make the border size smaller because it's not that important.
2. make the border able to show the total time-tag amount, current time-tag index and tapped time tags.

