### PR TITLE
Improve recording timeline area.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/RecordingTimeTagCaretPosition.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/CaretPosition/RecordingTimeTagCaretPosition.cs
@@ -54,6 +54,18 @@ public readonly struct RecordingTimeTagCaretPosition : IIndexCaretPosition, ICom
         return Lyric.TimeTags.SkipWhile(x => x != currentTimeTag).Skip(1).TakeWhile(x => x.Index == currentTimeTag.Index).Count();
     }
 
+    public TimeTag[] GetRecordedTimeTags()
+    {
+        var currentTimeTag = TimeTag;
+        return Lyric.TimeTags.TakeWhile(tag => tag != currentTimeTag).ToArray();
+    }
+
+    public TimeTag[] GetPendingTimeTags()
+    {
+        var currentTimeTag = TimeTag;
+        return Lyric.TimeTags.SkipWhile(tag => tag != currentTimeTag).Skip(1).ToArray();
+    }
+
     public Tuple<int, int> GetLyricCharRange()
     {
         return GetLyricCharRange(TimeTag);

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTagBottomEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTagBottomEditor.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomE
 
 public partial class RecordingTimeTagBottomEditor : BaseBottomEditor
 {
-    public override float ContentHeight => 60;
+    public override float ContentHeight => 100;
 
     protected override Drawable CreateInfo()
     {

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagPart.cs
@@ -92,16 +92,16 @@ public partial class RecordingTimeTagPart : TimelinePart
             position = lyricCaretState.BindableCaretPosition.GetBoundCopy();
             position.BindValueChanged(e =>
             {
-                if (e.NewValue is not TimeTagCaretPosition timeTagCaretPosition)
+                if (e.NewValue is not RecordingTimeTagCaretPosition recordingTimeTagCaretPosition)
                     return;
 
-                if (timeTagCaretPosition.Lyric != lyric)
+                if (recordingTimeTagCaretPosition.Lyric != lyric)
                 {
                     Hide();
                     return;
                 }
 
-                var timeTag = timeTagCaretPosition.TimeTag;
+                var timeTag = recordingTimeTagCaretPosition.TimeTag;
                 var textIndex = timeTag.Index;
                 var state = timeTag.Index.State;
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/RecordingTimeTagScrollContainer.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomE
 [Cached]
 public partial class RecordingTimeTagScrollContainer : TimeTagScrollContainer
 {
+    private const float time_tag_visualisation_spacing = 60;
     public const float TIMELINE_HEIGHT = 20;
 
     [Resolved]
@@ -67,11 +68,17 @@ public partial class RecordingTimeTagScrollContainer : TimeTagScrollContainer
 
         AddRangeInternal(new Drawable[]
         {
+            new TimeTagsVisualisation
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopLeft,
+                Y = 5,
+            },
             new Box
             {
                 Name = "Background",
                 Depth = 1,
-                Y = 10,
+                Y = time_tag_visualisation_spacing,
                 RelativeSizeAxes = Axes.X,
                 Height = TIMELINE_HEIGHT,
                 Colour = colours.Gray3,
@@ -90,7 +97,7 @@ public partial class RecordingTimeTagScrollContainer : TimeTagScrollContainer
     protected override void PostProcessContent(Container content)
     {
         content.Height = TIMELINE_HEIGHT;
-        content.Y = 10;
+        content.Y = time_tag_visualisation_spacing;
         content.AddRange(new[]
         {
             centreMarker.CreateProxy(),

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/TimeTagsVisualisation.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Compose/BottomEditor/RecordingTimeTags/TimeTagsVisualisation.cs
@@ -1,0 +1,237 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Edit.Components.Sprites;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Karaoke.Objects.Utils;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.CaretPosition;
+using osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.States;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Beatmaps.Lyrics.Compose.BottomEditor.RecordingTimeTags;
+
+/// <summary>
+/// Display all time-tags in the lyric, and current time-tag.
+/// </summary>
+public partial class TimeTagsVisualisation : CompositeDrawable
+{
+    private readonly IBindable<ICaretPosition?> bindableCaret = new Bindable<ICaretPosition?>();
+
+    public TimeTagsVisualisation()
+    {
+        AutoSizeAxes = Axes.Both;
+
+        FocusedTimeTagArea focusedTimeTagArea;
+        PendingTimeTagsArea leftPendingTimeTagsArea;
+        PendingTimeTagsArea rightPendingTimeTagsArea;
+
+        InternalChildren = new Drawable[]
+        {
+            focusedTimeTagArea = new FocusedTimeTagArea
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            },
+            leftPendingTimeTagsArea = new PendingTimeTagsArea
+            {
+                X = -5,
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreRight,
+            },
+            rightPendingTimeTagsArea = new PendingTimeTagsArea
+            {
+                X = 5,
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreLeft,
+            },
+        };
+
+        bindableCaret.BindValueChanged(x =>
+        {
+            if (x.NewValue is not RecordingTimeTagCaretPosition newCaret)
+                return;
+
+            focusedTimeTagArea.UpdateDisplayTimeTag(newCaret.Lyric, newCaret.TimeTag);
+            leftPendingTimeTagsArea.UpdateDisplayTimeTags(newCaret.Lyric, newCaret.GetRecordedTimeTags());
+            rightPendingTimeTagsArea.UpdateDisplayTimeTags(newCaret.Lyric, newCaret.GetPendingTimeTags());
+        });
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(ILyricCaretState lyricCaretState)
+    {
+        bindableCaret.BindTo(lyricCaretState.BindableCaretPosition);
+    }
+
+    private partial class FocusedTimeTagArea : CompositeDrawable
+    {
+        private readonly IBindable<double?> bindableTime = new Bindable<double?>();
+
+        private readonly Box background;
+        private readonly DrawableTextIndex drawableTextIndex;
+        private readonly OsuSpriteText timeTagText;
+
+        public FocusedTimeTagArea()
+        {
+            Size = new Vector2(30);
+
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    Masking = true,
+                    CornerRadius = 5,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                },
+                drawableTextIndex = new DrawableTextIndex
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(20),
+                },
+                timeTagText = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.TopLeft,
+                    X = 5,
+                },
+            };
+        }
+
+        private TimeTag? timeTag;
+
+        public void UpdateDisplayTimeTag(Lyric lyric, TimeTag timeTag)
+        {
+            this.timeTag = timeTag;
+
+            drawableTextIndex.State = timeTag.Index.State;
+            timeTagText.Text = LyricUtils.GetTimeTagDisplayRubyText(lyric, timeTag);
+
+            bindableTime.UnbindBindings();
+            bindableTime.BindTo(timeTag.TimeBindable);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            background.Colour = colours.Gray6;
+
+            bindableTime.BindValueChanged(x =>
+            {
+                if (timeTag == null)
+                    return;
+
+                drawableTextIndex.Colour = colours.GetTimeTagColour(timeTag);
+            });
+        }
+    }
+
+    public partial class PendingTimeTagsArea : CompositeDrawable
+    {
+        private readonly Box background;
+
+        private readonly FillFlowContainer drawableTimeTags;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public PendingTimeTagsArea()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    Masking = true,
+                    CornerRadius = 5,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                },
+                drawableTimeTags = new FillFlowContainer
+                {
+                    Margin = new MarginPadding(5),
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(25),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            background.Colour = colours.Gray4;
+        }
+
+        public void UpdateDisplayTimeTags(Lyric lyric, TimeTag[] timeTags)
+        {
+            drawableTimeTags.Clear();
+
+            Alpha = timeTags.Length > 0 ? 1 : 0;
+
+            foreach (var timeTag in timeTags)
+            {
+                drawableTimeTags.Add(new TimeTagDisplay(lyric, timeTag));
+            }
+        }
+
+        private partial class TimeTagDisplay : CompositeDrawable
+        {
+            private readonly IBindable<double?> bindableTime;
+
+            private readonly TimeTag timeTag;
+            private readonly DrawableTextIndex drawableTextIndex;
+
+            public TimeTagDisplay(Lyric lyric, TimeTag timeTag)
+            {
+                this.timeTag = timeTag;
+                bindableTime = timeTag.TimeBindable.GetBoundCopy();
+
+                Width = 12;
+                Height = 12;
+                InternalChildren = new Drawable[]
+                {
+                    drawableTextIndex = new DrawableTextIndex
+                    {
+                        State = timeTag.Index.State,
+                        Size = new Vector2(12),
+                    },
+                    new OsuSpriteText
+                    {
+                        Font = OsuFont.Default.With(size: 12),
+                        Text = LyricUtils.GetTimeTagDisplayRubyText(lyric, timeTag),
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.TopLeft,
+                        Y = 10,
+                    },
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                bindableTime.BindValueChanged(x =>
+                {
+                    drawableTextIndex.Colour = colours.GetTimeTagColour(timeTag);
+                }, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
![image](https://github.com/karaoke-dev/karaoke/assets/9100368/41d279f8-11a4-4e94-9089-d7a84f071e13)

![image](https://github.com/karaoke-dev/karaoke/assets/9100368/5ec486a8-5aec-494d-82c2-a4000a56789f)

Implement part of #2207
Create the area for able to show the recorded time-tags, current time-tag and pending time-tags.
