### PR TITLE
Add more strict check about test assert usage and naming.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Architectures/Edit/Checks/TestCheck.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/Edit/Checks/TestCheck.cs
@@ -34,8 +34,8 @@ public class TestCheck : BaseTest
 
             foreach (var checkClass in issues)
             {
-                Assert.True(checkClass.InheritedClasses.Contains(baseIssue), $"Class inherit is invalid: {checkClass}");
-                Assert.True(checkClass.NameEndsWith("Issue"), $"Class name is invalid: {checkClass}");
+                Assert.IsTrue(checkClass.InheritedClasses.Contains(baseIssue), $"Class inherit is invalid: {checkClass}");
+                Assert.IsTrue(checkClass.NameEndsWith("Issue"), $"Class name is invalid: {checkClass}");
             }
 
             // checks
@@ -43,8 +43,8 @@ public class TestCheck : BaseTest
 
             foreach (var check in checks)
             {
-                Assert.True(check.ImplementsInterface(baseCheck), $"Class inherit is invalid: {check}");
-                Assert.True(check.NameStartsWith("Check"), $"Class name is invalid: {check}");
+                Assert.IsTrue(check.ImplementsInterface(baseCheck), $"Class inherit is invalid: {check}");
+                Assert.IsTrue(check.NameStartsWith("Check"), $"Class name is invalid: {check}");
             }
 
             // issue templates.
@@ -52,8 +52,8 @@ public class TestCheck : BaseTest
 
             foreach (var checkClass in issueTemplates)
             {
-                Assert.True(checkClass.InheritedClasses.Contains(baseIssueTemplate), $"Class inherit is invalid: {checkClass}");
-                Assert.True(checkClass.NameStartsWith("IssueTemplate"), $"Class name is invalid: {checkClass}");
+                Assert.IsTrue(checkClass.InheritedClasses.Contains(baseIssueTemplate), $"Class inherit is invalid: {checkClass}");
+                Assert.IsTrue(checkClass.NameStartsWith("IssueTemplate"), $"Class name is invalid: {checkClass}");
             }
         });
     }

--- a/osu.Game.Rulesets.Karaoke.Architectures/Edit/Checks/TestCheckTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/Edit/Checks/TestCheckTest.cs
@@ -96,8 +96,8 @@ public class TestCheckTest : BaseTest
 
                 if (calledMethods != null)
                 {
-                    // todo: should get the generic type from the AssertNotOk method.
-                    return testMethod.NameStartsWith("IssueTemplate");
+                    // todo: should get the generic type from the AssertNotOk method. the end of the method should be the issue template.
+                    return testMethod.NameStartsWith("TestCheck");
                 }
 
                 return true;

--- a/osu.Game.Rulesets.Karaoke.Architectures/Extensions.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/Extensions.cs
@@ -8,12 +8,39 @@ using System.Text.RegularExpressions;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Extensions;
 using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Tests;
 using Attribute = ArchUnitNET.Domain.Attribute;
 
 namespace osu.Game.Rulesets.Karaoke.Architectures;
 
 public static class Extensions
 {
+    #region Architecture
+
+    public static IEnumerable<Class> GetAllTestClass(this Architecture architecture)
+    {
+        var testProject = new Project.KaraokeTestAttribute();
+        var testClasses = architecture.Classes.Where(x =>
+                                      {
+                                          if (x.Namespace.RelativeNameStartsWith(testProject, "Helper"))
+                                              return false;
+
+                                          return x.Namespace.RelativeNameStartsWith(testProject, "");
+                                      })
+                                      .Except(new[]
+                                      {
+                                          architecture.GetClassOfType(typeof(KaraokeTestBrowser)),
+                                          architecture.GetClassOfType(typeof(VisualTestRunner)),
+                                      }).ToArray();
+
+        if (testClasses.Length == 0)
+            throw new InvalidOperationException("No test class found in the project.");
+
+        return testClasses;
+    }
+
+    #endregion
+
     #region Class
 
     public static IEnumerable<Class> GetInnerClasses(this Class @class)

--- a/osu.Game.Rulesets.Karaoke.Architectures/Extensions.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/Extensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ArchUnitNET.Domain;
+using ArchUnitNET.Domain.Dependencies;
 using ArchUnitNET.Domain.Extensions;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Tests;
@@ -66,6 +67,11 @@ public static class Extensions
     #endregion
 
     #region Name
+
+    public static IEnumerable<IType> GetGenericTypes(this Class @class)
+    {
+        return @class.GetInheritsBaseClassDependencies().SelectMany(x => x.TargetGenericArguments.Select(arg => arg.Type));
+    }
 
     public static bool RelativeNameStartsWith(
         this IHasName cls,

--- a/osu.Game.Rulesets.Karaoke.Architectures/TestClass.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/TestClass.cs
@@ -42,7 +42,7 @@ public class TestClass : BaseTest
                 if (allChildClasses.Length == 0)
                     continue;
 
-                Assert.True(isAllowAbstractClassPosition(abstractClass, allChildClasses), $"Those child class: \n{string.Join('\n', allChildClasses.Select(x => x.ToString()))}\n\n is not in the child namespace of: \n{abstractClass}");
+                Assert.IsTrue(isAllowAbstractClassPosition(abstractClass, allChildClasses), $"Those child class: \n{string.Join('\n', allChildClasses.Select(x => x.ToString()))}\n\n is not in the child namespace of: \n{abstractClass}");
             }
         });
         return;

--- a/osu.Game.Rulesets.Karaoke.Architectures/TestTestClass.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/TestTestClass.cs
@@ -1,10 +1,13 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
+using ArchUnitNET.Domain;
 using ArchUnitNET.Domain.Extensions;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Game.Rulesets.Karaoke.Tests;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Karaoke.Architectures;
@@ -71,6 +74,27 @@ public class TestTestClass : BaseTest
                 {
                     Assert.IsTrue(testMethod.NameStartsWith("Test"), $"Test method {testMethod} should start with 'Test'.");
                 }
+            }
+        });
+    }
+
+    [Test]
+    [Project.KaraokeTest(true)]
+    public void CheckAssertion()
+    {
+        var architecture = GetProjectArchitecture();
+        var tests = architecture.GetAllTestClass();
+        var assert = architecture.GetClassOfType(typeof(Assert));
+
+        Assertion(() =>
+        {
+            foreach (var test in tests)
+            {
+                var assertions = test.GetCalledMethods().Where(x => EqualityComparer<IType>.Default.Equals(x.DeclaringType, assert)).ToArray();
+
+                // Assertion.
+                Assert.IsFalse(assertions.Any(x => x.NameStartsWith("True")), $"Should use {nameof(Assert.IsTrue)} instead of {nameof(Assert.True)} in the {test}.");
+                Assert.IsFalse(assertions.Any(x => x.NameStartsWith("False")), $"Should use {nameof(Assert.IsFalse)} instead of {nameof(Assert.False)} in the {test}.");
             }
         });
     }

--- a/osu.Game.Rulesets.Karaoke.Architectures/TestTestClass.cs
+++ b/osu.Game.Rulesets.Karaoke.Architectures/TestTestClass.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using ArchUnitNET.Domain.Extensions;
 using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Rulesets.Karaoke.Tests;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Karaoke.Architectures;
@@ -32,23 +31,10 @@ public class TestTestClass : BaseTest
         var headlessTestScene = architecture.GetAttributeOfType(typeof(HeadlessTestAttribute));
 
         // get all test classes
-        var testClasses = architecture.Classes.Where(x =>
-                                      {
-                                          if (x.Namespace.RelativeNameStartsWith(GetExecuteProject(), "Helper"))
-                                              return false;
-
-                                          return x.Namespace.RelativeNameStartsWith(GetExecuteProject(), "");
-                                      })
-                                      .Except(new[]
-                                      {
-                                          architecture.GetClassOfType(typeof(KaraokeTestBrowser)),
-                                          architecture.GetClassOfType(typeof(VisualTestRunner)),
-                                      }).ToArray();
+        var testClasses = architecture.GetAllTestClass().ToArray();
 
         Assertion(() =>
         {
-            Assert.NotZero(testClasses.Length, "No test class found");
-
             foreach (var testClass in testClasses)
             {
                 var testMethods = testClass.GetAllTestMembers(architecture).ToArray();

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapAvailableTranslatesTest.cs
@@ -49,7 +49,20 @@ public class CheckBeatmapAvailableTranslatesTest : BeatmapPropertyCheckTest<Chec
     }
 
     [Test]
-    public void TestHaveLyricAndLanguage()
+    public void TestEveryLyricContainsTranslate()
+    {
+        var translateLanguages = new List<CultureInfo> { new("Ja-jp") };
+        var beatmap = createTestingBeatmap(translateLanguages, new[]
+        {
+            createLyric(new CultureInfo("Ja-jp"), "translate1"),
+            createLyric(new CultureInfo("Ja-jp"), "translate2"),
+        });
+
+        AssertOk(getContext(beatmap));
+    }
+
+    [Test]
+    public void TestCheckMissingTranslate()
     {
         // no lyric with translate string. (should have issue)
         var translateLanguages = new List<CultureInfo> { new("Ja-jp") };
@@ -75,39 +88,30 @@ public class CheckBeatmapAvailableTranslatesTest : BeatmapPropertyCheckTest<Chec
             createLyric(new CultureInfo("Ja-jp"), string.Empty),
         });
         AssertNotOk<IssueTemplateMissingTranslate>(getContext(beatmap3));
+    }
 
+    [Test]
+    public void TestCheckMissingPartialTranslate()
+    {
         // some lyric with translate string. (should have issue)
+        var translateLanguages = new List<CultureInfo> { new("Ja-jp") };
         var beatmap4 = createTestingBeatmap(translateLanguages, new[]
         {
             createLyric(new CultureInfo("Ja-jp"), "translate1"),
             createLyric(new CultureInfo("Ja-jp")),
         });
         AssertNotOk<IssueTemplateMissingPartialTranslate>(getContext(beatmap4));
+    }
 
-        // every lyric with translate string. (should not have issue)
-        var beatmap5 = createTestingBeatmap(translateLanguages, new[]
-        {
-            createLyric(new CultureInfo("Ja-jp"), "translate1"),
-            createLyric(new CultureInfo("Ja-jp"), "translate2"),
-        });
-        AssertOk(getContext(beatmap5));
-
+    [Test]
+    public void TestCheckContainsNotListedLanguage()
+    {
         // lyric translate not listed. (should have issue)
         var beatmap6 = createTestingBeatmap(null, new[]
         {
             createLyric(new CultureInfo("en-US"), "translate1"),
         });
         AssertNotOk<IssueTemplateContainsNotListedLanguage>(getContext(beatmap6));
-
-        static Lyric createLyric(CultureInfo? cultureInfo = null, string translate = null!)
-        {
-            var lyric = new Lyric();
-            if (cultureInfo == null)
-                return lyric;
-
-            lyric.Translates.Add(cultureInfo, translate);
-            return lyric;
-        }
     }
 
     private static IBeatmap createTestingBeatmap(List<CultureInfo>? translateLanguage, IEnumerable<Lyric>? lyrics)
@@ -126,4 +130,14 @@ public class CheckBeatmapAvailableTranslatesTest : BeatmapPropertyCheckTest<Chec
 
     private static BeatmapVerifierContext getContext(IBeatmap beatmap)
         => new(beatmap, new TestWorkingBeatmap(beatmap));
+
+    private static Lyric createLyric(CultureInfo? cultureInfo = null, string translate = null!)
+    {
+        var lyric = new Lyric();
+        if (cultureInfo == null)
+            return lyric;
+
+        lyric.Translates.Add(cultureInfo, translate);
+        return lyric;
+    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapStageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckBeatmapStageInfoTest.cs
@@ -19,7 +19,7 @@ using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapStageInfo<osu.Gam
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
 
-public class CheckBeatmapStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapStageInfoTest.TestCheckBeatmapStageInfo>
+public class CheckBeatmapStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapStageInfoTest.CheckBeatmapStageInfo>
 {
     [Test]
     public void TestCheckNoElement()
@@ -63,11 +63,11 @@ public class CheckBeatmapStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapSt
         AssertNotOk<IssueTemplateMappingItemNotExist>(getContext(beatmap));
     }
 
-    public class TestCheckBeatmapStageInfo : CheckBeatmapStageInfo<ClassicStageInfo>
+    public class CheckBeatmapStageInfo : CheckBeatmapStageInfo<ClassicStageInfo>
     {
         protected override string Description => "Checks for testing the shared logic";
 
-        public TestCheckBeatmapStageInfo()
+        public CheckBeatmapStageInfo()
         {
             // Note that we only test the lyric layout category.
             RegisterCategory(x => x.StyleCategory, 0);


### PR DESCRIPTION
What's add in this PR:
- Cannot use `Assert.True`, use `Assert.IsTrue` instead.
- Check the check test naming.