### PR TITLE
Fix preview lyric not change the size if size changed.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeEditInputManager.cs
@@ -99,4 +99,11 @@ public enum KaraokeEditAction
 
     [Description("Clear time")]
     ClearTime,
+
+    // Action for compose mode.
+    [Description("Increase font size.")]
+    IncreasePreviewFontSize,
+
+    [Description("Decrease font size.")]
+    DecreasePreviewFontSize,
 }

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -121,6 +121,10 @@ public partial class KaraokeRuleset : Ruleset
                 new KeyBinding(InputKey.S, KaraokeEditAction.RemoveEndTimeTag),
                 new KeyBinding(InputKey.Enter, KaraokeEditAction.SetTime),
                 new KeyBinding(InputKey.BackSpace, KaraokeEditAction.ClearTime),
+
+                // Action for compose mode.
+                new KeyBinding(new[] { InputKey.Control, InputKey.Plus }, KaraokeEditAction.IncreasePreviewFontSize),
+                new KeyBinding(new[] { InputKey.Control, InputKey.Minus }, KaraokeEditAction.DecreasePreviewFontSize),
             },
             _ => Array.Empty<KeyBinding>(),
         };

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Content/Compose/LyricEditor.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Content/Compose/LyricEditor.cs
@@ -38,50 +38,55 @@ public partial class LyricEditor : CompositeDrawable
 
         bindableFocusedLyric.BindValueChanged(e =>
         {
-            skinProvidingContainer.Clear();
-
-            var lyric = e.NewValue;
-            if (lyric == null)
-                return;
-
-            const int border = 36;
-
-            skinProvidingContainer.Add(new InteractableLyric(lyric)
-            {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                TextSizeChanged = (self, size) =>
-                {
-                    self.Width = size.X + border * 2;
-                    self.Height = size.Y + border * 2;
-                },
-                Loaders = new LayerLoader[]
-                {
-                    new LayerLoader<GridLayer>
-                    {
-                        OnLoad = layer =>
-                        {
-                            layer.Spacing = 10;
-                        },
-                    },
-                    new LayerLoader<LyricLayer>
-                    {
-                        OnLoad = layer =>
-                        {
-                            layer.LyricPosition = new Vector2(border);
-                        },
-                    },
-                    new LayerLoader<EditLyricLayer>(),
-                    new LayerLoader<TimeTagLayer>(),
-                    new LayerLoader<CaretLayer>(),
-                    new LayerLoader<BlueprintLayer>(),
-                },
-            });
+            refreshPreviewLyric(e.NewValue);
         });
 
         bindableFontSize.BindValueChanged(e =>
         {
             skin.FontSize = e.NewValue;
+            refreshPreviewLyric(bindableFocusedLyric.Value);
+        });
+    }
+
+    private void refreshPreviewLyric(Lyric? lyric)
+    {
+        skinProvidingContainer.Clear();
+
+        if (lyric == null)
+            return;
+
+        const int border = 36;
+
+        skinProvidingContainer.Add(new InteractableLyric(lyric)
+        {
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
+            TextSizeChanged = (self, size) =>
+            {
+                self.Width = size.X + border * 2;
+                self.Height = size.Y + border * 2;
+            },
+            Loaders = new LayerLoader[]
+            {
+                new LayerLoader<GridLayer>
+                {
+                    OnLoad = layer =>
+                    {
+                        layer.Spacing = 10;
+                    },
+                },
+                new LayerLoader<LyricLayer>
+                {
+                    OnLoad = layer =>
+                    {
+                        layer.LyricPosition = new Vector2(border);
+                    },
+                },
+                new LayerLoader<EditLyricLayer>(),
+                new LayerLoader<TimeTagLayer>(),
+                new LayerLoader<CaretLayer>(),
+                new LayerLoader<BlueprintLayer>(),
+            },
         });
     }
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Content/Compose/Toolbar/ToolbarEditActionButton.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Beatmaps/Lyrics/Content/Compose/Toolbar/ToolbarEditActionButton.cs
@@ -17,10 +17,11 @@ public abstract partial class ToolbarEditActionButton : ToolbarButton, IKeyBindi
 
     public bool OnPressed(KeyBindingPressEvent<KaraokeEditAction> e)
     {
-        if (e.Action == EditAction)
-            ToggleClickEffect();
+        if (e.Action != EditAction)
+            return false;
 
-        return false;
+        // press button should did the same things as click.
+        return TriggerClick();
     }
 
     public void OnReleased(KeyBindingReleaseEvent<KaraokeEditAction> e)


### PR DESCRIPTION
What's done in this PR:
1. Should re-draw the interactable lyric if change the skin's font size.
2. Add key for increase/decrease the preview font size.
3. Click the button and handle the keyboard event should did the same things(trigger the action).
4. Change size button should inherit the `ToolbarEditActionButton`.