### PR TITLE
Remove stage info from beatmap.

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/BaseChangeHandlerTest.cs
@@ -192,10 +192,6 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         // also, technically should not call the change handler if there's no possible to change the properties.
         AssertTransactionOnlyTriggerOnce();
 
-        // We should make sure that the stage info is in the latest state.
-        // Should trigger the beatmap editor to run the beatmap processor if not the latest.
-        AssertCalculatedPropertyInStageInfoValid();
-
         // We should make sure that if the working property is changed by the change handler.
         // Should trigger the beatmap editor to run the beatmap processor to re-fill the working property.
         AssertWorkingPropertyInHitObjectValid();
@@ -206,21 +202,6 @@ public abstract partial class BaseChangeHandlerTest<TChangeHandler> : EditorCloc
         AddStep("Transaction should be only triggered once.", () =>
         {
             Assert.AreEqual(1, transactionCount);
-        });
-    }
-
-    protected void AssertCalculatedPropertyInStageInfoValid()
-    {
-        AddWaitStep("Waiting for working property being re-filled in the beatmap processor.", 1);
-        AddAssert("Check if working property in the hit object is valid", () =>
-        {
-            var editorBeatmap = Dependencies.Get<EditorBeatmap>();
-            var karaokeBeatmap = EditorBeatmapUtils.GetPlayableBeatmap(editorBeatmap);
-            if (karaokeBeatmap.CurrentStageInfo is IHasCalculatedProperty calculatedProperty)
-                return calculatedProperty.IsUpdated();
-
-            // ignore check if current stage info no need to calculate the property.
-            return true;
         });
     }
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/BaseStageInfoChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/BaseStageInfoChangeHandlerTest.cs
@@ -1,0 +1,22 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Stages.Infos;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Stages;
+
+public abstract partial class BaseStageInfoChangeHandlerTest<TChangeHandler> : BaseChangeHandlerTest<TChangeHandler>
+    where TChangeHandler : Component
+{
+    protected virtual void SetUpStageInfo<TStageInfo>(Action<TStageInfo>? action = null)
+        => throw new NotImplementedException();
+
+    public void AssertStageInfos(Action<IList<StageInfo>> assert)
+        => throw new NotImplementedException();
+
+    public void AssertStageInfo<TStageInfo>(Action<TStageInfo> assert) where TStageInfo: StageInfo
+        => throw new NotImplementedException();
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/ClassicStageChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/ClassicStageChangeHandlerTest.cs
@@ -1,25 +1,24 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Stages;
 
-public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<ClassicStageChangeHandler>
+[Ignore("Ignore all stage-related change handler test until able to edit the stage info.")]
+public partial class ClassicStageChangeHandlerTest : BaseStageInfoChangeHandlerTest<ClassicStageChangeHandler>
 {
     #region Layout definition
 
     [Test]
     public void TestEditLayoutDefinition()
     {
+        SetUpStageInfo<ClassicStageInfo>();
+
         TriggerHandlerChanged(c =>
         {
             c.EditLayoutDefinition(x =>
@@ -28,13 +27,12 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             });
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var classicStageInfo = getClassicStageInfo(karaokeBeatmap);
-            Assert.IsNotNull(classicStageInfo);
+            Assert.IsNotNull(stageInfo);
 
             // assert definition.
-            var definition = classicStageInfo.StageDefinition;
+            var definition = stageInfo.StageDefinition;
             Assert.AreEqual(12, definition.LineHeight);
         });
     }
@@ -46,6 +44,8 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
     [Test]
     public void TestAddTimingPoint()
     {
+        SetUpStageInfo<ClassicStageInfo>();
+
         TriggerHandlerChanged(c =>
         {
             c.AddTimingPoint(x =>
@@ -54,9 +54,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             });
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert timing.
@@ -71,9 +71,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
     {
         ClassicLyricTimingPoint removedTimingPoint = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             timingInfo.Timings.Add(new ClassicLyricTimingPoint
             {
                 Time = 1000,
@@ -90,9 +90,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             c.RemoveTimingPoint(removedTimingPoint);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert timing.
@@ -107,9 +107,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
     {
         ClassicLyricTimingPoint removedTimingPoint = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             timingInfo.Timings.Add(new ClassicLyricTimingPoint
             {
                 Time = 1000,
@@ -126,9 +126,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             c.RemoveRangeOfTimingPoints(new[] { removedTimingPoint });
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert timing.
@@ -144,9 +144,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
         ClassicLyricTimingPoint shiftingTimingPoint1 = null!;
         ClassicLyricTimingPoint shiftingTimingPoint2 = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             timingInfo.Timings.Add(shiftingTimingPoint1 = new ClassicLyricTimingPoint
             {
                 Time = 1000,
@@ -163,9 +163,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             c.ShiftingTimingPoints(new[] { shiftingTimingPoint1, shiftingTimingPoint2 }, 100);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert timing.
@@ -181,9 +181,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
     {
         ClassicLyricTimingPoint timingPoint = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             timingInfo.Timings.Add(timingPoint = new ClassicLyricTimingPoint
             {
                 Time = 1000,
@@ -201,9 +201,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             c.AddLyricIntoTimingPoint(timingPoint);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert mapping status.
@@ -223,9 +223,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
         PrepareHitObject(() => lyric1 = new Lyric());
         PrepareHitObject(() => lyric2 = new Lyric(), false);
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             timingInfo.Timings.Add(timingPoint = new ClassicLyricTimingPoint
             {
                 Time = 1000,
@@ -239,9 +239,9 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
             c.RemoveLyricFromTimingPoint(timingPoint);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<ClassicStageInfo>(stageInfo =>
         {
-            var timingInfo = getLyricTimingInfo(karaokeBeatmap);
+            var timingInfo = stageInfo.LyricTimingInfo;
             Assert.IsNotNull(timingInfo);
 
             // assert mapping status.
@@ -251,25 +251,4 @@ public partial class ClassicStageChangeHandlerTest : BaseChangeHandlerTest<Class
     }
 
     #endregion
-
-    protected override void SetUpKaraokeBeatmap(Action<KaraokeBeatmap> action)
-    {
-        base.SetUpKaraokeBeatmap(karaokeBeatmap =>
-        {
-            var stageInfo = new ClassicStageInfo();
-            karaokeBeatmap.StageInfos = new List<StageInfo>
-            {
-                stageInfo,
-            };
-            karaokeBeatmap.CurrentStageInfo = stageInfo;
-
-            action(karaokeBeatmap);
-        });
-    }
-
-    private static ClassicStageInfo getClassicStageInfo(KaraokeBeatmap karaokeBeatmap)
-        => karaokeBeatmap.StageInfos.OfType<ClassicStageInfo>().First();
-
-    private static ClassicLyricTimingInfo getLyricTimingInfo(KaraokeBeatmap karaokeBeatmap)
-        => getClassicStageInfo(karaokeBeatmap).LyricTimingInfo;
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StageElementCategoryChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StageElementCategoryChangeHandlerTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Karaoke.Stages;
@@ -16,7 +15,8 @@ using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Stages;
 
-public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTest<StageElementCategoryChangeHandlerTest.TestStageElementCategoryChangeHandler>
+[Ignore("Ignore all stage-related change handler test until able to edit the stage info.")]
+public partial class StageElementCategoryChangeHandlerTest : BaseStageInfoChangeHandlerTest<StageElementCategoryChangeHandlerTest.TestStageElementCategoryChangeHandler>
 {
     protected override TestStageElementCategoryChangeHandler CreateChangeHandler()
         => new(x => x.OfType<TestStageInfo>().First().Category);
@@ -32,9 +32,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             });
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             var firstElement = category.AvailableElements.First();
 
             Assert.AreEqual("Element 1", firstElement.Name);
@@ -46,9 +46,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
     {
         TestStageElement element = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             element = category.AddElement();
         });
 
@@ -60,9 +60,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             });
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             var firstElement = category.AvailableElements.First();
 
             Assert.AreEqual("Edit Element 1", firstElement.Name);
@@ -74,9 +74,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
     {
         TestStageElement element = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             element = category.AddElement();
         });
 
@@ -85,9 +85,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             c.RemoveElement(element);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
 
             Assert.IsEmpty(category.AvailableElements);
         });
@@ -98,9 +98,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
     {
         TestStageElement element = null!;
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             element = category.AddElement();
         });
 
@@ -111,9 +111,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             c.AddToMapping(element);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
 
             Assert.IsNotEmpty(category.Mappings);
         });
@@ -125,9 +125,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
         Lyric lyric = new Lyric();
         Lyric unSelectedLyric = new Lyric();
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             var element = category.AddElement(x => x.Name = "Element 1");
             category.AddElement(x => x.Name = "Element 2");
 
@@ -144,9 +144,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             c.OffsetMapping(1);
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
 
             Assert.AreEqual("Element 2", category.GetElementByItem(lyric).Name);
             Assert.AreEqual("Element 1", category.GetElementByItem(unSelectedLyric).Name); // should not change the id if lyric is not selected.
@@ -167,9 +167,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
     {
         Lyric lyric = new Lyric();
 
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             var element = category.AddElement();
 
             // Add to Mapping
@@ -183,9 +183,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             c.RemoveFromMapping();
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
 
             Assert.IsEmpty(category.Mappings);
         });
@@ -194,9 +194,9 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
     [Test]
     public void TestClearUnusedMapping()
     {
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
+        SetUpStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
             var element = category.AddElement();
 
             // Add to Mapping
@@ -208,31 +208,13 @@ public partial class StageElementCategoryChangeHandlerTest : BaseChangeHandlerTe
             c.ClearUnusedMapping();
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfo<TestStageInfo>(stageInfo =>
         {
-            var category = getStageCategory(karaokeBeatmap);
+            var category = stageInfo.Category;
 
             Assert.IsEmpty(category.Mappings);
         });
     }
-
-    protected override void SetUpKaraokeBeatmap(Action<KaraokeBeatmap> action)
-    {
-        base.SetUpKaraokeBeatmap(karaokeBeatmap =>
-        {
-            var stageInfo = new TestStageInfo();
-            karaokeBeatmap.StageInfos = new List<StageInfo>
-            {
-                stageInfo,
-            };
-            karaokeBeatmap.CurrentStageInfo = stageInfo;
-
-            action(karaokeBeatmap);
-        });
-    }
-
-    private static TestCategory getStageCategory(KaraokeBeatmap beatmap)
-        => beatmap.StageInfos.OfType<TestStageInfo>().First().Category;
 
     public partial class TestStageElementCategoryChangeHandler : StageElementCategoryChangeHandler<TestStageElement, Lyric>
     {

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StagesChangeHandlerTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/ChangeHandlers/Stages/StagesChangeHandlerTest.cs
@@ -2,16 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
 using osu.Game.Rulesets.Karaoke.Objects;
-using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.ChangeHandlers.Stages;
 
-public partial class StagesChangeHandlerTest : BaseChangeHandlerTest<StagesChangeHandler>
+[Ignore("Ignore all stage-related change handler test until able to edit the stage info.")]
+public partial class StagesChangeHandlerTest : BaseStageInfoChangeHandlerTest<StagesChangeHandler>
 {
     protected override bool IncludeAutoGenerator => true;
 
@@ -26,9 +25,8 @@ public partial class StagesChangeHandlerTest : BaseChangeHandlerTest<StagesChang
             c.AutoGenerate<ClassicStageInfo>();
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfos(stageInfos =>
         {
-            var stageInfos = karaokeBeatmap.StageInfos;
             Assert.AreEqual(1, stageInfos.Count);
             Assert.AreEqual(typeof(ClassicStageInfo), stageInfos[0].GetType());
         });
@@ -43,24 +41,15 @@ public partial class StagesChangeHandlerTest : BaseChangeHandlerTest<StagesChang
     [Test]
     public void TestRemove()
     {
-        SetUpKaraokeBeatmap(karaokeBeatmap =>
-        {
-            var stageInfo = new ClassicStageInfo();
-            karaokeBeatmap.StageInfos = new List<StageInfo>
-            {
-                stageInfo,
-            };
-            karaokeBeatmap.CurrentStageInfo = stageInfo;
-        });
+        SetUpStageInfo<ClassicStageInfo>();
 
         TriggerHandlerChanged(c =>
         {
             c.Remove<ClassicStageInfo>();
         });
 
-        AssertKaraokeBeatmap(karaokeBeatmap =>
+        AssertStageInfos(stageInfos =>
         {
-            var stageInfos = karaokeBeatmap.StageInfos;
             Assert.AreEqual(0, stageInfos.Count);
         });
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckClassicStageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckClassicStageInfoTest.cs
@@ -15,11 +15,11 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Beatmaps;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapClassicStageInfo;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckClassicStageInfo;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
 
-public class CheckBeatmapClassicStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapClassicStageInfo>
+public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicStageInfo>
 {
     #region stage definition
 

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckClassicStageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckClassicStageInfoTest.cs
@@ -19,24 +19,27 @@ using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckClassicStageInfo;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
 
-public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicStageInfo>
+[Ignore("Disable this test until able to get the stage info from the resource file.")]
+public class CheckClassicStageInfoTest : BaseCheckTest<CheckClassicStageInfo>
 {
     #region stage definition
 
     [Test]
     public void TestCheckInvalidRowHeight()
     {
-        var beatmap = createTestingBeatmap(Array.Empty<Lyric>(), stage =>
+        var beatmap = createTestingBeatmap(Array.Empty<Lyric>());
+        var stageInfo = createTestingStageInfo(stage =>
         {
             stage.StageDefinition.LineHeight = MIN_ROW_HEIGHT - 1;
         });
-        AssertNotOk<IssueTemplateInvalidRowHeight>(getContext(beatmap));
+        AssertNotOk<IssueTemplateInvalidRowHeight>(getContext(beatmap, stageInfo));
 
-        var beatmap2 = createTestingBeatmap(Array.Empty<Lyric>(), stage =>
+        var beatmap2 = createTestingBeatmap(Array.Empty<Lyric>());
+        var stageInfo2 = createTestingStageInfo(stage =>
         {
             stage.StageDefinition.LineHeight = MAX_ROW_HEIGHT + 1;
         });
-        AssertNotOk<IssueTemplateInvalidRowHeight>(getContext(beatmap2));
+        AssertNotOk<IssueTemplateInvalidRowHeight>(getContext(beatmap2, stageInfo2));
     }
 
     #endregion
@@ -52,44 +55,50 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
         };
 
         // test with 0 lyric and 0 timing points.
-        var beatmap = createTestingBeatmap(null, timingInfos => timingInfos.Timings.Clear());
-        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap));
+        var beatmap = createTestingBeatmap(null);
+        var stageInfo = createTestingStageInfo(info => info.LyricTimingInfo.Timings.Clear());
+        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap, stageInfo));
 
         // test with 0 lyric and 1 timing points.
-        var beatmap2 = createTestingBeatmap(null, timingInfos => timingInfos.AddTimingPoint());
-        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap2));
+        var beatmap2 = createTestingBeatmap(null);
+        var stageInfo2 = createTestingStageInfo(timingInfos => timingInfos.AddTimingPoint());
+        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap2, stageInfo2));
 
         // test with 1 lyric and 0 timing points.
-        var beatmap3 = createTestingBeatmap(lyrics, timingInfos => timingInfos.Timings.Clear());
-        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap3));
+        var beatmap3 = createTestingBeatmap(lyrics);
+        var stageInfo3 = createTestingStageInfo(timingInfos => timingInfos.Timings.Clear());
+        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap3, stageInfo3));
 
         // test with 1 lyric and 1 timing points.
-        var beatmap4 = createTestingBeatmap(lyrics, timingInfos => timingInfos.AddTimingPoint());
-        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap4));
+        var beatmap4 = createTestingBeatmap(lyrics);
+        var stageInfo4 = createTestingStageInfo(timingInfos => timingInfos.AddTimingPoint());
+        AssertNotOk<IssueTemplateLessThanTwoTimingPoints>(getContext(beatmap4, stageInfo4));
     }
 
     [Test]
     public void TestCheckTimingIntervalTooShort()
     {
-        var beatmap = createTestingBeatmap(null, timingInfos =>
+        var beatmap = createTestingBeatmap(null);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             timingInfos.AddTimingPoint(x => x.Time = 0);
             timingInfos.AddTimingPoint(x => x.Time = MIN_TIMING_INTERVAL - 1);
         });
-        AssertNotOk<BeatmapClassicLyricTimingPointIssue, IssueTemplateTimingIntervalTooShort>(getContext(beatmap));
+        AssertNotOk<BeatmapClassicLyricTimingPointIssue, IssueTemplateTimingIntervalTooShort>(getContext(beatmap, stageInfo));
     }
 
     [Test]
     public void TestCheckTimingIntervalTooLong()
     {
-        var beatmap = createTestingBeatmap(null, timingInfos =>
+        var beatmap = createTestingBeatmap(null);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             timingInfos.AddTimingPoint(x => x.Time = 0);
             timingInfos.AddTimingPoint(x => x.Time = MAX_TIMING_INTERVAL + 1);
         });
-        AssertNotOk<BeatmapClassicLyricTimingPointIssue, IssueTemplateTimingIntervalTooLong>(getContext(beatmap));
+        AssertNotOk<BeatmapClassicLyricTimingPointIssue, IssueTemplateTimingIntervalTooLong>(getContext(beatmap, stageInfo));
     }
 
     [TestCase(true)]
@@ -101,7 +110,8 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             new(),
         };
 
-        var beatmap = createTestingBeatmap(hasHitObjectsInBeatmap ? lyrics : null, timingInfos =>
+        var beatmap = createTestingBeatmap(hasHitObjectsInBeatmap ? lyrics : null);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             var timingPoint = timingInfos.AddTimingPoint(x => x.Time = 0);
@@ -112,7 +122,7 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             // should have error because lyric is not in the beatmap.
             timingInfos.AddToMapping(timingPoint, lyric);
         });
-        AssertNotOk<IssueTemplateTimingInfoHitObjectNotExist>(getContext(beatmap));
+        AssertNotOk<IssueTemplateTimingInfoHitObjectNotExist>(getContext(beatmap, stageInfo));
     }
 
     [Test]
@@ -123,7 +133,8 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             new(),
         };
 
-        var beatmap = createTestingBeatmap(lyrics, timingInfos =>
+        var beatmap = createTestingBeatmap(lyrics);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             timingInfos.AddTimingPoint(x => x.Time = 0);
@@ -132,7 +143,7 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             // should have error because mapping value is empty.
             timingInfos.Mappings.Add(lyrics.First().ID, Array.Empty<ElementId>());
         });
-        AssertNotOk<IssueTemplateTimingInfoMappingHasNoTiming>(getContext(beatmap));
+        AssertNotOk<IssueTemplateTimingInfoMappingHasNoTiming>(getContext(beatmap, stageInfo));
     }
 
     [Test]
@@ -143,7 +154,8 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             new(),
         };
 
-        var beatmap = createTestingBeatmap(lyrics, timingInfos =>
+        var beatmap = createTestingBeatmap(lyrics);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             timingInfos.AddTimingPoint(x => x.Time = 0);
@@ -152,7 +164,7 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             // should have error because mapping value is not exist.
             timingInfos.Mappings.Add(lyrics.First().ID, new[] { ElementId.NewElementId() });
         });
-        AssertNotOk<IssueTemplateTimingInfoTimingNotExist>(getContext(beatmap));
+        AssertNotOk<IssueTemplateTimingInfoTimingNotExist>(getContext(beatmap, stageInfo));
     }
 
     [Test]
@@ -163,7 +175,8 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             new(),
         };
 
-        var beatmap = createTestingBeatmap(lyrics, timingInfos =>
+        var beatmap = createTestingBeatmap(lyrics);
+        var stageInfo = createTestingStageInfo(timingInfos =>
         {
             timingInfos.Timings.Clear();
             timingInfos.AddTimingPoint(x => x.Time = 0);
@@ -173,7 +186,7 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
             // should have error because mapping value is not exactly 2.
             timingInfos.Mappings.Add(lyrics.First().ID, timingInfos.Timings.Select(x => x.ID).ToArray());
         });
-        AssertNotOk<IssueTemplateTimingInfoLyricNotHaveTwoTiming>(getContext(beatmap));
+        AssertNotOk<IssueTemplateTimingInfoLyricNotHaveTwoTiming>(getContext(beatmap, stageInfo));
     }
 
     #endregion
@@ -183,26 +196,41 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
     [Test]
     public void TestCheckLyricLayoutInvalidLineNumber()
     {
-        var beatmap = createTestingBeatmap(Array.Empty<Lyric>(), stage =>
+        var beatmap = createTestingBeatmap(Array.Empty<Lyric>());
+        var stageInfo = createTestingStageInfo(stage =>
         {
             var layoutElement = stage.LyricLayoutCategory.AvailableElements.First();
             layoutElement.Line = MIN_LINE_SIZE - 1;
         });
-        AssertNotOk<IssueTemplateLyricLayoutInvalidLineNumber>(getContext(beatmap));
+        AssertNotOk<IssueTemplateLyricLayoutInvalidLineNumber>(getContext(beatmap, stageInfo));
 
-        var beatmap2 = createTestingBeatmap(Array.Empty<Lyric>(), stage =>
+        var beatmap2 = createTestingBeatmap(Array.Empty<Lyric>());
+        var stageInfo2 = createTestingStageInfo(stage =>
         {
             var layoutElement = stage.LyricLayoutCategory.AvailableElements.First();
             layoutElement.Line = MAX_LINE_SIZE + 1;
         });
-        AssertNotOk<IssueTemplateLyricLayoutInvalidLineNumber>(getContext(beatmap2));
+        AssertNotOk<IssueTemplateLyricLayoutInvalidLineNumber>(getContext(beatmap2, stageInfo2));
     }
 
     #endregion
 
-    private static IBeatmap createTestingBeatmap(IEnumerable<Lyric>? lyrics, Action<ClassicLyricTimingInfo>? editStageAction = null)
+    private static IBeatmap createTestingBeatmap(IEnumerable<Lyric>? lyrics)
     {
-        return createTestingBeatmap(lyrics, info =>
+        var karaokeBeatmap = new KaraokeBeatmap
+        {
+            BeatmapInfo =
+            {
+                Ruleset = new KaraokeRuleset().RulesetInfo,
+            },
+            HitObjects = lyrics?.OfType<KaraokeHitObject>().ToList() ?? new List<KaraokeHitObject>(),
+        };
+        return new EditorBeatmap(karaokeBeatmap);
+    }
+
+    private static StageInfo createTestingStageInfo(Action<ClassicLyricTimingInfo>? editStageAction = null)
+    {
+        return createTestingStageInfo(info =>
         {
             // clear the timing info created in the base method.
             info.LyricTimingInfo.Timings.Clear();
@@ -210,7 +238,7 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
         });
     }
 
-    private static IBeatmap createTestingBeatmap(IEnumerable<Lyric>? lyrics, Action<ClassicStageInfo>? editStageAction = null)
+    private static StageInfo createTestingStageInfo(Action<ClassicStageInfo>? editStageAction = null)
     {
         var stageInfo = new ClassicStageInfo();
 
@@ -225,21 +253,9 @@ public class CheckClassicStageInfoTest : BeatmapPropertyCheckTest<CheckClassicSt
 
         editStageAction?.Invoke(stageInfo);
 
-        var karaokeBeatmap = new KaraokeBeatmap
-        {
-            BeatmapInfo =
-            {
-                Ruleset = new KaraokeRuleset().RulesetInfo,
-            },
-            StageInfos = new List<StageInfo>
-            {
-                stageInfo,
-            },
-            HitObjects = lyrics?.OfType<KaraokeHitObject>().ToList() ?? new List<KaraokeHitObject>(),
-        };
-        return new EditorBeatmap(karaokeBeatmap);
+        return stageInfo;
     }
 
-    private static BeatmapVerifierContext getContext(IBeatmap beatmap)
+    private static BeatmapVerifierContext getContext(IBeatmap beatmap, StageInfo stageInfo)
         => new(beatmap, new TestWorkingBeatmap(beatmap));
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckStageInfoTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Editor/Checks/CheckStageInfoTest.cs
@@ -15,11 +15,11 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Beatmaps;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapStageInfo<osu.Game.Rulesets.Karaoke.Stages.Infos.Classic.ClassicStageInfo>;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckStageInfo<osu.Game.Rulesets.Karaoke.Stages.Infos.Classic.ClassicStageInfo>;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Editor.Checks;
 
-public class CheckBeatmapStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapStageInfoTest.CheckBeatmapStageInfo>
+public class CheckStageInfoTest : BeatmapPropertyCheckTest<CheckStageInfoTest.CheckStageInfo>
 {
     [Test]
     public void TestCheckNoElement()
@@ -63,11 +63,11 @@ public class CheckBeatmapStageInfoTest : BeatmapPropertyCheckTest<CheckBeatmapSt
         AssertNotOk<IssueTemplateMappingItemNotExist>(getContext(beatmap));
     }
 
-    public class CheckBeatmapStageInfo : CheckBeatmapStageInfo<ClassicStageInfo>
+    public class CheckStageInfo : CheckStageInfo<ClassicStageInfo>
     {
         protected override string Description => "Checks for testing the shared logic";
 
-        public CheckBeatmapStageInfo()
+        public CheckStageInfo()
         {
             // Note that we only test the lyric layout category.
             RegisterCategory(x => x.StyleCategory, 0);

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/ClassicStageScreenTestScene.cs
@@ -1,24 +1,11 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
-using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
 
 public abstract partial class ClassicStageScreenTestScene<T> : GenericEditorScreenTestScene<T, ClassicStageEditorScreenMode>
     where T : ClassicStageScreen
 {
-    protected override KaraokeBeatmap CreateBeatmap()
-    {
-        var karaokeBeatmap = base.CreateBeatmap();
-
-        // add classic stage info for testing purpose.
-        var stageInfo = new ClassicStageInfo();
-        karaokeBeatmap.StageInfos.Add(stageInfo);
-        karaokeBeatmap.CurrentStageInfo = stageInfo;
-
-        return karaokeBeatmap;
-    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneClassicStageEditor.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneClassicStageEditor.cs
@@ -1,21 +1,10 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic;
-using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
 
 public partial class TestSceneClassicStageEditor : GenericEditorTestScene<ClassicStageEditor, ClassicStageEditorScreenMode>
 {
-    protected override KaraokeBeatmap CreateBeatmap()
-    {
-        var karaokeBeatmap = base.CreateBeatmap();
-
-        // add classic stage info for testing purpose.
-        karaokeBeatmap.StageInfos.Add(new ClassicStageInfo());
-
-        return karaokeBeatmap;
-    }
 }

--- a/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Screens/Edit/Stages/Classic/TestSceneStageScreen.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
 
 namespace osu.Game.Rulesets.Karaoke.Tests.Screens.Edit.Stages.Classic;
 
+[Ignore("Ingore this test until able to edit the stage.")]
 public partial class TestSceneStageScreen : ClassicStageScreenTestScene<StageScreen>
 {
     protected override StageScreen CreateEditorScreen() => new();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmap.cs
@@ -21,14 +21,6 @@ public class KaraokeBeatmap : Beatmap<KaraokeHitObject>
 
     public PageInfo PageInfo { get; set; } = new();
 
-    public IList<StageInfo> StageInfos { get; set; } = new List<StageInfo>();
-
-    /// <summary>
-    /// This property will not be null after <see cref="KaraokeBeatmapProcessor.PreProcess"/> is called.
-    /// </summary>
-    [JsonIgnore]
-    public StageInfo? CurrentStageInfo { get; set; }
-
     public NoteInfo NoteInfo { get; set; } = new();
 
     public bool Scorable { get; set; }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/ClassicStageChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/ClassicStageChangeHandler.cs
@@ -11,7 +11,7 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
 
-public partial class ClassicStageChangeHandler : BeatmapPropertyChangeHandler, IClassicStageChangeHandler
+public partial class ClassicStageChangeHandler : StagePropertyChangeHandler, IClassicStageChangeHandler
 {
     [Resolved]
     private EditorBeatmap beatmap { get; set; } = null!;
@@ -103,22 +103,11 @@ public partial class ClassicStageChangeHandler : BeatmapPropertyChangeHandler, I
 
     private void performStageInfoChanged(Action<ClassicStageInfo> action)
     {
-        PerformBeatmapChanged(beatmap =>
-        {
-            if (beatmap.CurrentStageInfo is not ClassicStageInfo classicStageInfo)
-                throw new NotSupportedException($"Current stage info in the beatmap should be {nameof(ClassicStageInfo)}");
-
-            action(classicStageInfo);
-        });
+        throw new NotImplementedException();
     }
 
     private void performTimingInfoChanged(Action<ClassicLyricTimingInfo> action)
     {
-        performStageInfoChanged(stageInfo =>
-        {
-            action(stageInfo.LyricTimingInfo);
-
-            // todo: should trigger the stage wrapper to update the view.
-        });
+        throw new NotImplementedException();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/StageElementCategoryChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/StageElementCategoryChangeHandler.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
 
-public partial class StageElementCategoryChangeHandler<TStageElement, THitObject> : BeatmapPropertyChangeHandler, IStageElementCategoryChangeHandler<TStageElement>
+public partial class StageElementCategoryChangeHandler<TStageElement, THitObject> : StagePropertyChangeHandler, IStageElementCategoryChangeHandler<TStageElement>
     where TStageElement : StageElement, IComparable<TStageElement>, new()
     where THitObject : KaraokeHitObject, IHasPrimaryKey
 {
@@ -102,10 +102,6 @@ public partial class StageElementCategoryChangeHandler<TStageElement, THitObject
 
     private void performStageInfoChanged(Action<StageElementCategory<TStageElement, THitObject>> stageAction)
     {
-        PerformBeatmapChanged(beatmap =>
-        {
-            var stageCategory = stageCategoryAction(beatmap.StageInfos);
-            stageAction(stageCategory);
-        });
+        throw new NotImplementedException();
     }
 }

--- a/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/StagePropertyChangeHandler.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/ChangeHandlers/Stages/StagePropertyChangeHandler.cs
@@ -1,0 +1,23 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Karaoke.Objects;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Edit.ChangeHandlers.Stages;
+
+/// <summary>
+/// Note: will start to implement this class after the stage info is able to edit.
+/// </summary>
+public partial class StagePropertyChangeHandler : Component
+{
+    protected IEnumerable<Lyric> Lyrics => throw new NotImplementedException();
+
+    protected void PerformOnSelection<T>(Action<T> action) where T : HitObject
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckClassicStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckClassicStageInfo.cs
@@ -24,7 +24,7 @@ public class CheckClassicStageInfo : CheckStageInfo<ClassicStageInfo>
 
     protected override string Description => "Check invalid info in the classic stage info.";
 
-    public override IEnumerable<IssueTemplate> StageTemplates => new IssueTemplate[]
+    public override IEnumerable<IssueTemplate> CustomTemplates => new IssueTemplate[]
     {
         new IssueTemplateInvalidRowHeight(this),
         new IssueTemplateLessThanTwoTimingPoints(this),
@@ -43,7 +43,7 @@ public class CheckClassicStageInfo : CheckStageInfo<ClassicStageInfo>
         RegisterCategory(x => x.LyricLayoutCategory, 2);
     }
 
-    public override IEnumerable<Issue> CheckStageInfo(ClassicStageInfo stageInfo, IReadOnlyList<KaraokeHitObject> hitObjects)
+    public override IEnumerable<Issue> CheckStageInfoWithHitObjects(ClassicStageInfo stageInfo, IReadOnlyList<KaraokeHitObject> hitObjects)
     {
         var issues = new List<Issue>();
 

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckClassicStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckClassicStageInfo.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos.Classic;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
 
-public class CheckBeatmapClassicStageInfo : CheckBeatmapStageInfo<ClassicStageInfo>
+public class CheckClassicStageInfo : CheckStageInfo<ClassicStageInfo>
 {
     public const float MIN_ROW_HEIGHT = 30;
     public const float MAX_ROW_HEIGHT = 200;
@@ -37,7 +37,7 @@ public class CheckBeatmapClassicStageInfo : CheckBeatmapStageInfo<ClassicStageIn
         new IssueTemplateLyricLayoutInvalidLineNumber(this),
     };
 
-    public CheckBeatmapClassicStageInfo()
+    public CheckClassicStageInfo()
     {
         RegisterCategory(x => x.StyleCategory, 0);
         RegisterCategory(x => x.LyricLayoutCategory, 2);

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckStageInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Objects;
@@ -11,19 +12,23 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
 
-public abstract class CheckStageInfo<TStageInfo> : CheckBeatmapProperty<TStageInfo, KaraokeHitObject>
+public abstract class CheckStageInfo<TStageInfo> : ICheck
     where TStageInfo : StageInfo
 {
-    public sealed override IEnumerable<IssueTemplate> PossibleTemplates => checkTemplates.Concat(StageTemplates);
+    public CheckMetadata Metadata => new(CheckCategory.Files, Description);
 
-    private IEnumerable<IssueTemplate> checkTemplates => new IssueTemplate[]
+    protected abstract string Description { get; }
+
+    public IEnumerable<IssueTemplate> PossibleTemplates => baseTemplates.Concat(CustomTemplates);
+
+    private IEnumerable<IssueTemplate> baseTemplates => new IssueTemplate[]
     {
         new IssueTemplateNoElement(this),
         new IssueTemplateMappingHitObjectNotExist(this),
         new IssueTemplateMappingItemNotExist(this),
     };
 
-    public abstract IEnumerable<IssueTemplate> StageTemplates { get; }
+    public abstract IEnumerable<IssueTemplate> CustomTemplates { get; }
 
     private readonly IList<Func<TStageInfo, IReadOnlyList<KaraokeHitObject>, IEnumerable<Issue>>> stageInfoCategoryActions
         = new List<Func<TStageInfo, IReadOnlyList<KaraokeHitObject>, IEnumerable<Issue>>>();
@@ -38,23 +43,6 @@ public abstract class CheckStageInfo<TStageInfo> : CheckBeatmapProperty<TStageIn
             return checkElementCategory(category, hitObjects.OfType<THitObject>().ToList(), minimumRequiredElements);
         });
     }
-
-    protected sealed override TStageInfo? GetPropertyFromBeatmap(KaraokeBeatmap karaokeBeatmap)
-        => karaokeBeatmap.StageInfos.OfType<TStageInfo>().FirstOrDefault();
-
-    protected sealed override IEnumerable<Issue> CheckHitObjects(TStageInfo property, IReadOnlyList<KaraokeHitObject> hitObjects)
-    {
-        var issues = CheckStageInfo(property, hitObjects).ToList();
-
-        foreach (var stageInfoCategoryAction in stageInfoCategoryActions)
-        {
-            issues.AddRange(stageInfoCategoryAction(property, hitObjects));
-        }
-
-        return issues;
-    }
-
-    public abstract IEnumerable<Issue> CheckStageInfo(TStageInfo stageInfo, IReadOnlyList<KaraokeHitObject> hitObjects);
 
     private IEnumerable<Issue> checkElementCategory<TStageElement, THitObject>(StageElementCategory<TStageElement, THitObject> category, IReadOnlyList<THitObject> hitObjects,
                                                                                int minimumRequiredElements)
@@ -79,8 +67,6 @@ public abstract class CheckStageInfo<TStageInfo> : CheckBeatmapProperty<TStageIn
         return issues;
     }
 
-    protected abstract IEnumerable<Issue> CheckElement<TStageElement>(TStageElement element) where TStageElement : StageElement;
-
     private IEnumerable<Issue> checkMappings<TStageElement, THitObject>(StageElementCategory<TStageElement, THitObject> category, IReadOnlyList<THitObject> hitObjects)
         where TStageElement : StageElement, IComparable<TStageElement>, new()
         where THitObject : KaraokeHitObject, IHasPrimaryKey
@@ -97,6 +83,31 @@ public abstract class CheckStageInfo<TStageInfo> : CheckBeatmapProperty<TStageIn
                 yield return new IssueTemplateMappingItemNotExist(this).Create();
         }
     }
+
+    public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+    {
+        var property = getStageInfo(context);
+        if (property == null)
+            return Array.Empty<Issue>();
+
+        var hitObjects = context.Beatmap.HitObjects.OfType<KaraokeHitObject>().ToList();
+        var issues = CheckStageInfoWithHitObjects(property, hitObjects).ToList();
+
+        foreach (var stageInfoCategoryAction in stageInfoCategoryActions)
+        {
+            issues.AddRange(stageInfoCategoryAction(property, hitObjects));
+        }
+
+        return issues;
+
+        // todo: get stage info from context.
+        static TStageInfo? getStageInfo(BeatmapVerifierContext context)
+            => throw new NotImplementedException();
+    }
+
+    public abstract IEnumerable<Issue> CheckStageInfoWithHitObjects(TStageInfo stageInfo, IReadOnlyList<KaraokeHitObject> hitObjects);
+
+    protected abstract IEnumerable<Issue> CheckElement<TStageElement>(TStageElement element) where TStageElement : StageElement;
 
     public class IssueTemplateNoElement : IssueTemplate
     {

--- a/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/Checks/CheckStageInfo.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Karaoke.Stages.Infos;
 
 namespace osu.Game.Rulesets.Karaoke.Edit.Checks;
 
-public abstract class CheckBeatmapStageInfo<TStageInfo> : CheckBeatmapProperty<TStageInfo, KaraokeHitObject>
+public abstract class CheckStageInfo<TStageInfo> : CheckBeatmapProperty<TStageInfo, KaraokeHitObject>
     where TStageInfo : StageInfo
 {
     public sealed override IEnumerable<IssueTemplate> PossibleTemplates => checkTemplates.Concat(StageTemplates);

--- a/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Edit/KaraokeBeatmapVerifier.cs
@@ -14,7 +14,7 @@ public class KaraokeBeatmapVerifier : IBeatmapVerifier
     private readonly List<ICheck> checks = new()
     {
         new CheckBeatmapAvailableTranslations(),
-        new CheckBeatmapClassicStageInfo(),
+        new CheckClassicStageInfo(),
         new CheckBeatmapNoteInfo(),
         new CheckBeatmapPageInfo(),
         new CheckLyricLanguage(),

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Issues/IssueIcon.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Components/Issues/IssueIcon.cs
@@ -66,7 +66,7 @@ public partial class IssueIcon : CompositeDrawable
         check switch
         {
             CheckBeatmapAvailableTranslations => FontAwesome.Solid.Language,
-            CheckBeatmapClassicStageInfo => FontAwesome.Solid.AlignLeft,
+            CheckClassicStageInfo => FontAwesome.Solid.AlignLeft,
             CheckBeatmapNoteInfo => FontAwesome.Solid.Microphone,
             CheckBeatmapPageInfo => FontAwesome.Solid.Pager,
             CheckLyricLanguage => FontAwesome.Solid.Globe,

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageEditorVerifier.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageEditorVerifier.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Karaoke.Edit.Checks;
-using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckBeatmapClassicStageInfo;
+using static osu.Game.Rulesets.Karaoke.Edit.Checks.CheckClassicStageInfo;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Edit.Stages.Classic.Stage;
 
@@ -15,9 +15,9 @@ public partial class StageEditorVerifier : EditorVerifier<StageEditorEditCategor
     protected override IEnumerable<ICheck> CreateChecks(StageEditorEditCategory type) =>
         type switch
         {
-            StageEditorEditCategory.Layout => new ICheck[] { new CheckBeatmapClassicStageInfo() },
-            StageEditorEditCategory.Timing => new ICheck[] { new CheckBeatmapClassicStageInfo() },
-            StageEditorEditCategory.Style => new ICheck[] { new CheckBeatmapClassicStageInfo() },
+            StageEditorEditCategory.Layout => new ICheck[] { new CheckClassicStageInfo() },
+            StageEditorEditCategory.Timing => new ICheck[] { new CheckClassicStageInfo() },
+            StageEditorEditCategory.Style => new ICheck[] { new CheckClassicStageInfo() },
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
         };
 

--- a/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Edit/Stages/Classic/Stage/StageScreen.cs
@@ -28,20 +28,12 @@ public partial class StageScreen : ClassicStageScreen, IStageEditorStateProvider
     [Cached(typeof(IStageEditorVerifier))]
     private readonly StageEditorVerifier stageEditorVerifier;
 
-    [Resolved]
-    private EditorBeatmap editorBeatmap { get; set; } = null!;
-
     public ClassicStageInfo StageInfo
     {
         get
         {
-            // we should make sure that current stage info is classic stage info.
-            // otherwise, we might not able to see the edit result in the editor.
-            var currentStageInfo = EditorBeatmapUtils.GetPlayableBeatmap(editorBeatmap).CurrentStageInfo;
-            if (currentStageInfo is not ClassicStageInfo classicStageInfo)
-                throw new NotSupportedException();
-
-            return classicStageInfo;
+            // todo: should be able to read the stage info from the beatmap.
+            throw new NotImplementedException();
         }
     }
 

--- a/osu.Game.Rulesets.Karaoke/Stages/Drawables/DrawableStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Drawables/DrawableStage.cs
@@ -33,21 +33,17 @@ public partial class DrawableStage : Container
 
     private readonly StageElementRunner stageElementRunner = new();
 
-    private readonly Container stageLayer;
-
-    public DrawableStage()
-    {
-        AddInternal(stageLayer = new Container
-        {
-            RelativeSizeAxes = Axes.Both,
-        });
-
-        stageElementRunner.UpdateStageElements(stageLayer);
-    }
-
     [BackgroundDependencyLoader]
     private void load(IReadOnlyList<Mod> mods, IBeatmap beatmap)
     {
+        Container stageLayer = new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+        };
+
+        AddInternal(stageLayer);
+        stageElementRunner.UpdateStageElements(stageLayer);
+
         if (beatmap is not KaraokeBeatmap karaokeBeatmap)
             throw new InvalidOperationException();
 


### PR DESCRIPTION
It's the last step of the #2090

And note that because it's not able to edit the stage now, and change handler might be migrate to [command pattern](https://github.com/ppy/osu/pull/30314/files) after. 
So some of the method might replace the old logic into the `throw new NotImplementedException();` instead.