### PR TITLE
Define the interface for mod to modify the stage.

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStage.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Stages.Infos;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Karaoke.Mods;
+
+public interface IApplicableToStage : IApplicableMod
+{
+    bool CanApply(StageInfo stageInfo);
+}

--- a/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageElement.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageElement.cs
@@ -1,0 +1,12 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Stages;
+
+namespace osu.Game.Rulesets.Karaoke.Mods;
+
+public interface IApplicableToStageElement : IApplicableToStage
+{
+    IEnumerable<IStageElement> PostProcess(IEnumerable<IStageElement> stageElements);
+}

--- a/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageHitObjectCommand.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageHitObjectCommand.cs
@@ -1,0 +1,17 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Stages.Commands;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Karaoke.Mods;
+
+public interface IApplicableToStageHitObjectCommand : IApplicableToStage
+{
+    IEnumerable<IStageCommand> PostProcessInitialCommands(HitObject hitObject, IEnumerable<IStageCommand> commands);
+
+    IEnumerable<IStageCommand> PostProcessStartTimeStateCommands(HitObject hitObject, IEnumerable<IStageCommand> commands);
+
+    IEnumerable<IStageCommand> PostProcessHitStateCommands(HitObject hitObject, IEnumerable<IStageCommand> commands);
+}

--- a/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageInfo.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStageInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Stages.Infos;
+
+namespace osu.Game.Rulesets.Karaoke.Mods;
+
+/// <summary>
+/// An interface for mods that prefer to use the type of <see cref="StageInfo"/>.
+/// Also, it can override the parameter of <see cref="StageInfo"/>.
+/// </summary>
+public interface IApplicableToStageInfo : IApplicableToStage
+{
+    StageInfo? CreateDefaultStageInfo(KaraokeBeatmap beatmap);
+
+    void ApplyToStageInfo(StageInfo stageInfo);
+}

--- a/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStagePlayfieldCommand.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/IApplicableToStagePlayfieldCommand.cs
@@ -1,0 +1,13 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets.Karaoke.Stages.Commands;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Karaoke.Mods;
+
+public interface IApplicableToStagePlayfieldCommand : IApplicableToStage
+{
+    IEnumerable<IStageCommand> PostProcessCommands(Playfield playfield, IEnumerable<IStageCommand> commands);
+}

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModClassicStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModClassicStage.cs
@@ -24,7 +24,7 @@ public class KaraokeModClassicStage : ModStage<ClassicStageInfo>
         return (ClassicStageInfo)generator.Generate(beatmap);
     }
 
-    protected override void ApplyToCurrentStageInfo(ClassicStageInfo stageInfo)
+    protected override void ApplyToStageInfo(ClassicStageInfo stageInfo)
     {
         // todo: adjust stage by config.
     }

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPreviewStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPreviewStage.cs
@@ -24,7 +24,7 @@ public class KaraokeModPreviewStage : ModStage<PreviewStageInfo>
         return (PreviewStageInfo)generator.Generate(beatmap);
     }
 
-    protected override void ApplyToCurrentStageInfo(PreviewStageInfo stageInfo)
+    protected override void ApplyToStageInfo(PreviewStageInfo stageInfo)
     {
         // todo: adjust stage by config.
     }

--- a/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
@@ -3,43 +3,14 @@
 
 using System;
 using System.Linq;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Karaoke.Mods;
 
-public abstract class ModStage<TStageInfo> : ModStage
+public abstract class ModStage<TStageInfo> : Mod, IApplicableToStageInfo
     where TStageInfo : StageInfo
-{
-    public override bool IsStageInfoMatched(StageInfo stageInfo)
-    {
-       return stageInfo is TStageInfo;
-    }
-
-    public override StageInfo GenerateDefaultStageInfo(IBeatmap beatmap)
-    {
-        if (beatmap is not KaraokeBeatmap karaokeBeatmap)
-            throw new InvalidOperationException();
-
-        return CreateStageInfo(karaokeBeatmap) ?? throw new InvalidOperationException();
-    }
-
-    public override void ApplyToStageInfo(StageInfo stageInfo)
-    {
-        if (stageInfo is not TStageInfo tStageInfo)
-            throw new InvalidOperationException();
-
-        ApplyToCurrentStageInfo(tStageInfo);
-    }
-
-    protected abstract void ApplyToCurrentStageInfo(TStageInfo stageInfo);
-
-    protected abstract TStageInfo? CreateStageInfo(KaraokeBeatmap beatmap);
-}
-
-public abstract class ModStage : Mod, IApplicableMod
 {
     public sealed override ModType Type => ModType.Conversion;
 
@@ -48,11 +19,27 @@ public abstract class ModStage : Mod, IApplicableMod
     /// </summary>
     public override double ScoreMultiplier => 1;
 
-    public override Type[] IncompatibleMods => new[] { typeof(ModStage) }.Except(new[] { GetType() }).ToArray();
+    public override Type[] IncompatibleMods => new[] { typeof(ModStage<TStageInfo>) }.Except(new[] { GetType() }).ToArray();
 
-    public abstract bool IsStageInfoMatched(StageInfo stageInfo);
+    public bool CanApply(StageInfo stageInfo)
+    {
+        return stageInfo is TStageInfo;
+    }
 
-    public abstract StageInfo GenerateDefaultStageInfo(IBeatmap beatmap);
+    public StageInfo? CreateDefaultStageInfo(KaraokeBeatmap beatmap)
+    {
+        return CreateStageInfo(beatmap);
+    }
 
-    public abstract void ApplyToStageInfo(StageInfo stageInfo);
+    public void ApplyToStageInfo(StageInfo stageInfo)
+    {
+        if (stageInfo is not TStageInfo tStageInfo)
+            throw new ArgumentException($"The stage info is not matched with {GetType().Name}");
+
+        ApplyToStageInfo(tStageInfo);
+    }
+
+    protected abstract TStageInfo? CreateStageInfo(KaraokeBeatmap beatmap);
+
+    protected abstract void ApplyToStageInfo(TStageInfo stageInfo);
 }

--- a/osu.Game.Rulesets.Karaoke/Stages/Drawables/StageElementRunner.cs
+++ b/osu.Game.Rulesets.Karaoke/Stages/Drawables/StageElementRunner.cs
@@ -1,8 +1,11 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Karaoke.Mods;
 using osu.Game.Rulesets.Karaoke.Stages.Infos;
 using osu.Game.Rulesets.Mods;
 
@@ -11,11 +14,13 @@ namespace osu.Game.Rulesets.Karaoke.Stages.Drawables;
 public class StageElementRunner : StageRunner, IStageElementRunner
 {
     private IStageElementProvider? elementProvider;
+    private IList<IApplicableToStageElement>? stageMods;
     private Container? elementContainer;
 
     public override void OnStageInfoChanged(StageInfo stageInfo, bool scorable, IReadOnlyList<Mod> mods)
     {
         elementProvider = stageInfo.CreateStageElementProvider(scorable);
+        stageMods = mods.OfType<IApplicableToStageElement>().Where(x => x.CanApply(stageInfo)).ToList();
         applyTransforms();
     }
 
@@ -32,12 +37,25 @@ public class StageElementRunner : StageRunner, IStageElementRunner
 
     private void applyTransforms()
     {
-        if (elementProvider == null || elementContainer == null)
+        if (elementContainer == null)
             return;
 
         elementContainer.Clear();
 
-        foreach (var element in elementProvider.GetElements())
+        foreach (var element in getCommand())
             elementContainer.Add(element.CreateDrawable());
+    }
+
+    private IEnumerable<IStageElement> getCommand()
+    {
+        if (elementProvider == null)
+            return Array.Empty<IStageElement>();
+
+        var commands = elementProvider.GetElements();
+
+        if (stageMods == null)
+            return commands;
+
+        return stageMods.Aggregate(commands, (current, mod) => mod.PostProcess(current));
     }
 }


### PR DESCRIPTION
Some of the styles are affected by ruleset configuration and skin.
For example, `DrawableLyric` reads the `fontInfo` from ruleset config and applies the change directly.

After all style-related property should be adjust by command, should changed to:
1. create a default command for each stage info.
2. If want to override the default font, should create a mod that can read the ruleset configuration, and generate the command by the mod.
