### PR TITLE
Add Metadata and Resources sections to the editor's setup screen

### DIFF
--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -284,12 +284,14 @@ public partial class KaraokeRuleset : Ruleset
         return statistic.ToArray();
     }
 
-    public override IEnumerable<SetupSection> CreateEditorSetupSections() => new SetupSection[]
-    {
+    public override IEnumerable<Drawable> CreateEditorSetupSections() =>
+    [
+        new MetadataSection(),
+        new ResourcesSection(),
         new KaraokeSingerSection(),
         new KaraokeTranslationSection(),
         new KaraokeNoteSection(),
-    };
+    ];
 
     public KaraokeRuleset()
     {

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -284,14 +284,14 @@ public partial class KaraokeRuleset : Ruleset
         return statistic.ToArray();
     }
 
-    public override IEnumerable<Drawable> CreateEditorSetupSections() =>
-    [
+    public override IEnumerable<Drawable> CreateEditorSetupSections() => new Drawable[]
+    {
         new MetadataSection(),
         new ResourcesSection(),
         new KaraokeSingerSection(),
         new KaraokeTranslationSection(),
         new KaraokeNoteSection(),
-    ];
+    };
 
     public KaraokeRuleset()
     {


### PR DESCRIPTION
Metadata and resource editing are essential features for a beatmap, and adding them should be fine.
Also changing the items' type to `Drawable` so it's convenient to "group" sections together with `FillFlowContainer` or something else X)
