### PR TITLE
Mark Classic and Preview Stage mods incompatible with each other

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModClassicStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModClassicStage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Stages.Classic;
@@ -15,6 +16,11 @@ public class KaraokeModClassicStage : ModStage<ClassicStageInfo>
     public override string Acronym => "CS";
 
     public override LocalisableString Description => "Karaoke mod like other karaoke game or software.";
+
+    public override Type[] IncompatibleMods => new Type[]
+    {
+        typeof(KaraokeModPreviewStage),
+    };
 
     protected override ClassicStageInfo CreateStageInfo(KaraokeBeatmap beatmap)
     {

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPreviewStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPreviewStage.cs
@@ -1,10 +1,12 @@
 // Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Karaoke.Beatmaps;
 using osu.Game.Rulesets.Karaoke.Edit.Generator.Stages.Preview;
 using osu.Game.Rulesets.Karaoke.Stages.Infos.Preview;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Karaoke.Mods;
 
@@ -15,6 +17,11 @@ public class KaraokeModPreviewStage : ModStage<PreviewStageInfo>
     public override string Acronym => "PS";
 
     public override LocalisableString Description => "Focus on preview the lyric text.";
+
+    public override Type[] IncompatibleMods => new Type[]
+    {
+        typeof(KaraokeModClassicStage),
+    };
 
     protected override PreviewStageInfo CreateStageInfo(KaraokeBeatmap beatmap)
     {


### PR DESCRIPTION
*This is a quick bug fix.*

In the latest release of karaoke!, it's possible to select these two mods at once, and such combination makes it failed to start the gameplay.
