### PR TITLE
Hide default left sidebar in ruleset settings

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/KaraokeSettingsPanel.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/KaraokeSettingsPanel.cs
@@ -56,6 +56,24 @@ public partial class KaraokeSettingsPanel : SettingsPanel
     // prevent let main content darker.
     protected override bool DimMainContent => false;
 
+    protected override void PopIn()
+    {
+        base.PopIn();
+
+        // We use our implementation of section display, thus not needed.
+        Sidebar.FinishTransforms();
+        Sidebar.Hide();
+        Sidebar.MoveToX(-PANEL_WIDTH);
+    }
+
+    protected override void UpdateAfterChildren()
+    {
+        base.UpdateAfterChildren();
+
+        // Reset margin
+        ContentContainer.Margin = new MarginPadding();
+    }
+
     // prevent hide the overlay.
     public override void Hide() { }
 


### PR DESCRIPTION
This is done by hiding sidebar *content* in `PopIn()`. Also needed to reset the margin of the content container.
