### PR TITLE
Rewrite logic of getting overlay placement container

### DIFF
--- a/osu.Game.Rulesets.Karaoke/Extensions/OsuGameExtensions.cs
+++ b/osu.Game.Rulesets.Karaoke/Extensions/OsuGameExtensions.cs
@@ -21,12 +21,12 @@ public static class OsuGameExtensions
     }
 
     private static Container? getBasePlacementContainer(this OsuGame game)
-        => game.Children[3] as Container;
+        => game.Children.OfType<Container>().FirstOrDefault(c => c.ChildrenOfType<WaveOverlayContainer>().Any());
 
     public static Container? GetChangelogPlacementContainer(this OsuGame game)
     {
-        // will place the container with same location like WikiOverlay.
-        return game.getBasePlacementContainer()?.Children[0] as Container;
+        // will place the container where components of an WaveOverlayContainer type exist
+        return game.getBasePlacementContainer()?.Children.OfType<Container>().FirstOrDefault(c => c.Children.OfType<WaveOverlayContainer>().Any());
     }
 
     public static SettingsOverlay? GetSettingsOverlay(this OsuGame game)


### PR DESCRIPTION
The latest version of this ruleset won't display the changelog overlay properly. It would appear in the FPS counter display at the bottom right corner... So I make this PR to attempt to resolve this issue.

For stability and performance concerns, it should be better to use `WaveOverlayContainer` to locate our target. Below is what I got when debugging for reference:

<img width="1151" height="714" alt="图片" src="https://github.com/user-attachments/assets/60fda55b-2b09-4294-834f-987faf92995b" />
