### PR TITLE
Refactor ruleset icon for displaying

### DIFF
--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -310,7 +310,11 @@ public partial class KaraokeRuleset : Ruleset
         public KaraokeIcon(KaraokeRuleset ruleset)
         {
             this.ruleset = ruleset;
-            AutoSizeAxes = Axes.Both;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            // Set a fixed size to make Song Select V2 happy
+            Size = new Vector2(32);
         }
 
         [BackgroundDependencyLoader]
@@ -322,6 +326,8 @@ public partial class KaraokeRuleset : Ruleset
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fit,
                     Scale = new Vector2(0.9f),
                     Texture = new TextureStore(renderer, new TextureLoaderStore(ruleset.CreateResourceStore()), false).Get("Textures/logo"),
                 },
@@ -329,7 +335,7 @@ public partial class KaraokeRuleset : Ruleset
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Scale = new Vector2(45f),
+                    RelativeSizeAxes = Axes.Both,
                     Icon = FontAwesome.Regular.Circle,
                 },
             };


### PR DESCRIPTION
Now the icon should look like that of other builtin rulesets. Setting to fixed size of the icon component because:

- AutoSize is generally unsupported;
- Song Select V2 won't accept RelativeSize since it uses `FillFlowContainer` somewhere (the beatmap panel?)

Appearance preview:

| Footer and toolbar | Song Select V2 |
| :-: | :-: |
| <img width="373" height="93" alt="图片" src="https://github.com/user-attachments/assets/9f4af0aa-f392-4d42-a6cf-39949ef109a1" /> <img width="865" height="201" alt="图片" src="https://github.com/user-attachments/assets/4d331cfe-0f31-4ccf-a3f7-926058730e89" /> | <img width="990" height="679" alt="图片" src="https://github.com/user-attachments/assets/87d0ec2f-469e-41e5-8746-d66aa4df375c" /> |
