### PR TITLE
Update to ppy.osu.Game 2026.730.0

### DIFF
--- a/osu.Game.Rulesets.Karaoke.Tests/KaraokeRulesetTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/KaraokeRulesetTest.cs
@@ -1,0 +1,19 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+
+namespace osu.Game.Rulesets.Karaoke.Tests;
+
+[TestFixture]
+public class KaraokeRulesetTest
+{
+    [TestCase(0, "Vocal")]
+    [TestCase(1, "Gameplay")]
+    [TestCase(2, "Composer")]
+    [TestCase(-1, "")]
+    public void TestVariantName(int variant, string expected)
+    {
+        Assert.That(new KaraokeRuleset().GetVariantName(variant).ToString(), Is.EqualTo(expected));
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Scoring/KaraokeNoteHitWindowsTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Scoring/KaraokeNoteHitWindowsTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Karaoke.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Scoring;
+
+[TestFixture]
+public class KaraokeNoteHitWindowsTest
+{
+    [Test]
+    public void TestGreatWindowIsAvailableForDifficultyCalculation()
+    {
+        var hitWindows = new KaraokeNoteHitWindows();
+        hitWindows.SetDifficulty(5);
+
+        Assert.That(hitWindows.WindowFor(HitResult.Great), Is.EqualTo(hitWindows.WindowFor(HitResult.Perfect)));
+    }
+}

--- a/osu.Game.Rulesets.Karaoke.Tests/Scoring/KaraokeScoreMultiplierCalculatorTest.cs
+++ b/osu.Game.Rulesets.Karaoke.Tests/Scoring/KaraokeScoreMultiplierCalculatorTest.cs
@@ -1,0 +1,32 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Karaoke.Mods;
+using osu.Game.Rulesets.Karaoke.Scoring;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Karaoke.Tests.Scoring;
+
+[TestFixture]
+public class KaraokeScoreMultiplierCalculatorTest
+{
+    [TestCase(1.0)]
+    [TestCase(0.5, typeof(KaraokeModNoFail))]
+    [TestCase(1.06, typeof(KaraokeModHiddenNote))]
+    [TestCase(0, typeof(KaraokeModPractice))]
+    [TestCase(0, typeof(KaraokeModDisableNote))]
+    [TestCase(0.53, typeof(KaraokeModNoFail), typeof(KaraokeModHiddenNote))]
+    public void TestMultiplier(double expected, params System.Type[] modTypes)
+    {
+        var calculator = new KaraokeScoreMultiplierCalculator(new ScoreMultiplierContext(new BeatmapDifficulty()));
+        var mods = new Mod[modTypes.Length];
+
+        for (int i = 0; i < modTypes.Length; i++)
+            mods[i] = (Mod)System.Activator.CreateInstance(modTypes[i])!;
+
+        Assert.That(calculator.CalculateFor(mods), Is.EqualTo(expected));
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeJsonBeatmapDecoder.cs
@@ -24,7 +24,7 @@ public class KaraokeJsonBeatmapDecoder : JsonBeatmapDecoder
         SetFallbackDecoder<Beatmap>(() => new KaraokeJsonBeatmapDecoder());
     }
 
-    protected override void ParseStreamInto(LineBufferedReader stream, Beatmap output)
+    protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, Beatmap output)
     {
         var globalSetting = KaraokeJsonSerializableExtensions.CreateGlobalSettings();
         globalSetting.ContractResolver = new KaraokeBeatmapContractResolver();

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/Formats/KaraokeLegacyBeatmapDecoder.cs
@@ -35,7 +35,7 @@ public class KaraokeLegacyBeatmapDecoder : LegacyBeatmapDecoder
     private readonly IList<string> noteLines = new List<string>();
     private readonly IList<string> translations = new List<string>();
 
-    protected override void ParseLine(Beatmap beatmap, Section section, string line)
+    protected override void ParseLine(Beatmap beatmap, Section section, string line, bool isPrimaryStream)
     {
         if (section != Section.HitObjects)
         {
@@ -46,7 +46,7 @@ public class KaraokeLegacyBeatmapDecoder : LegacyBeatmapDecoder
                 return;
             }
 
-            base.ParseLine(beatmap, section, line);
+            base.ParseLine(beatmap, section, line, isPrimaryStream);
             return;
         }
 

--- a/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Karaoke/Beatmaps/KaraokeBeatmapConverter.cs
@@ -18,7 +18,9 @@ public class KaraokeBeatmapConverter : BeatmapConverter<KaraokeHitObject>
     {
     }
 
-    public override bool CanConvert() => Beatmap.HitObjects.All(h => h is KaraokeHitObject);
+    // Native karaoke objects are passed through by BeatmapConverter. Objects from other
+    // rulesets are ignored so that song select can safely preview incompatible beatmaps.
+    public override bool CanConvert() => true;
 
     protected override Beatmap<KaraokeHitObject> ConvertBeatmap(IBeatmap original, CancellationToken cancellationToken)
     {
@@ -40,7 +42,7 @@ public class KaraokeBeatmapConverter : BeatmapConverter<KaraokeHitObject>
     }
 
     protected override IEnumerable<KaraokeHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
-        => throw new NotImplementedException();
+        => Array.Empty<KaraokeHitObject>();
 
     protected override Beatmap<KaraokeHitObject> CreateBeatmap() => new KaraokeBeatmap();
 }

--- a/osu.Game.Rulesets.Karaoke/Difficulty/KaraokeDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Difficulty/KaraokeDifficultyCalculator.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Karaoke.Difficulty.Skills;
 using osu.Game.Rulesets.Karaoke.Mods;
 using osu.Game.Rulesets.Karaoke.Objects;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Karaoke.Difficulty;
 
@@ -32,10 +33,12 @@ public class KaraokeDifficultyCalculator : DifficultyCalculator
         originalOverallDifficulty = beatmap.BeatmapInfo.Difficulty.OverallDifficulty;
     }
 
-    protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
+    protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills)
     {
         if (beatmap.HitObjects.Count == 0)
             return new KaraokeDifficultyAttributes { Mods = mods };
+
+        double clockRate = ModUtils.CalculateRateWithMods(mods);
 
         return new KaraokeDifficultyAttributes
         {
@@ -47,9 +50,10 @@ public class KaraokeDifficultyCalculator : DifficultyCalculator
         };
     }
 
-    protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
+    protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, Mod[] mods)
     {
         var sortedObjects = beatmap.HitObjects.OfType<Note>().ToArray();
+        double clockRate = ModUtils.CalculateRateWithMods(mods);
 
         // todo : might have a sort.
         // LegacySortHelper<HitObject>.Sort(sortedObjects, Comparer<HitObject>.Create((a, b) => (int)Math.Round(a.StartTime) - (int)Math.Round(b.StartTime)));
@@ -65,7 +69,7 @@ public class KaraokeDifficultyCalculator : DifficultyCalculator
     // Sorting is done in CreateDifficultyHitObjects, since the full list of hitobjects is required.
     protected override IEnumerable<DifficultyHitObject> SortObjects(IEnumerable<DifficultyHitObject> input) => input;
 
-    protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate) => new Skill[]
+    protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods) => new Skill[]
     {
         new Strain(mods, ((KaraokeBeatmap)beatmap).NoteInfo),
     };

--- a/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
+++ b/osu.Game.Rulesets.Karaoke/KaraokeRuleset.cs
@@ -49,6 +49,7 @@ public partial class KaraokeRuleset : Ruleset
 {
     public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod>? mods = null) => new DrawableKaraokeRuleset(this, beatmap, mods);
     public override ScoreProcessor CreateScoreProcessor() => new KaraokeScoreProcessor();
+    public override ScoreMultiplierCalculator CreateScoreMultiplierCalculator(ScoreMultiplierContext context) => new KaraokeScoreMultiplierCalculator(context);
     public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new KaraokeBeatmapConverter(beatmap, this);
     public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new KaraokeBeatmapProcessor(beatmap);
 
@@ -132,9 +133,10 @@ public partial class KaraokeRuleset : Ruleset
     public override LocalisableString GetVariantName(int variant)
         => variant switch
         {
+            0 => "Vocal",
             GAMEPLAY_INPUT_VARIANT => "Gameplay",
             EDIT_INPUT_VARIANT => "Composer",
-            _ => throw new ArgumentNullException(nameof(variant)),
+            _ => string.Empty,
         };
 
     public override IEnumerable<Mod> GetModsFor(ModType type) =>

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModDisableNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModDisableNote.cs
@@ -16,7 +16,6 @@ public class KaraokeModDisableNote : Mod, IApplicableToHitObject
 
     public override LocalisableString Description => "Disable note";
     public override string Acronym => "DN";
-    public override double ScoreMultiplier => 0;
     public override IconUsage? Icon => KaraokeIcon.ModDisableNote;
     public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModFlashlight.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModFlashlight.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Karaoke.Mods;
 
 public partial class KaraokeModFlashlight : ModFlashlight<KaraokeHitObject>
 {
-    public override double ScoreMultiplier => 1;
     public override Type[] IncompatibleMods => new[] { typeof(ModHidden) };
 
     [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModHiddenNote.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModHiddenNote.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Karaoke.Mods;
 public class KaraokeModHiddenNote : ModHidden
 {
     public override LocalisableString Description => "Notes fade out before you sing them!";
-    public override double ScoreMultiplier => 1.06;
     public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<KaraokeHitObject>) };
     public override IconUsage? Icon => KaraokeIcon.ModHiddenNote;
 

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModLyricConfiguration.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModLyricConfiguration.cs
@@ -15,7 +15,6 @@ public class KaraokeModLyricConfiguration : Mod, IApplicableToDrawableHitObject
 {
     public override string Name => "Adjust Lyric Display";
     public override LocalisableString Description => "Determined display lyric or romanisation, show the ruby, translation or not.";
-    public override double ScoreMultiplier => 1.0f;
     public override string Acronym => "AL";
 
     [SettingSource("Display type", "Display the lyric or romanisation as main text.", 0)]

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPractice.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModPractice.cs
@@ -21,7 +21,6 @@ public class KaraokeModPractice : ModAutoplay, IApplicableToDrawableRuleset<Kara
 {
     public override string Name => "Practice";
     public override string Acronym => "Practice";
-    public override double ScoreMultiplier => 0.0f;
     public override IconUsage? Icon => KaraokeIcon.ModPractice;
     public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModSnow.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModSnow.cs
@@ -22,7 +22,6 @@ public partial class KaraokeModSnow : Mod, IApplicableToHUD
 
     public override LocalisableString Description => "Display some snow";
     public override string Acronym => "SW";
-    public override double ScoreMultiplier => 1.0f;
     public override IconUsage? Icon => FontAwesome.Regular.Snowflake;
     public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModTranslation.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModTranslation.cs
@@ -17,7 +17,6 @@ public class KaraokeModTranslation : Mod, IApplicableToDrawableHitObject
 
     public override LocalisableString Description => "Display prefer translation by ruleset configuration.";
 
-    public override double ScoreMultiplier => 1.0f;
 
     public override string Acronym => "LT";
 

--- a/osu.Game.Rulesets.Karaoke/Mods/KaraokeModTranslation.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/KaraokeModTranslation.cs
@@ -17,7 +17,6 @@ public class KaraokeModTranslation : Mod, IApplicableToDrawableHitObject
 
     public override LocalisableString Description => "Display prefer translation by ruleset configuration.";
 
-
     public override string Acronym => "LT";
 
     [SettingSource("Default language", "Select default language", 0, SettingControlType = typeof(LanguageSettingsControl))]

--- a/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
+++ b/osu.Game.Rulesets.Karaoke/Mods/ModStage.cs
@@ -14,11 +14,6 @@ public abstract class ModStage<TStageInfo> : Mod, IApplicableToStageInfo
 {
     public sealed override ModType Type => ModType.Conversion;
 
-    /// <summary>
-    /// Change the stage type should not affect the score.
-    /// </summary>
-    public override double ScoreMultiplier => 1;
-
     public override Type[] IncompatibleMods => new[] { typeof(ModStage<TStageInfo>) }.Except(new[] { GetType() }).ToArray();
 
     public bool CanApply(StageInfo stageInfo)

--- a/osu.Game.Rulesets.Karaoke/Scoring/KaraokeNoteHitWindows.cs
+++ b/osu.Game.Rulesets.Karaoke/Scoring/KaraokeNoteHitWindows.cs
@@ -40,6 +40,12 @@ public class KaraokeNoteHitWindows : KaraokeHitWindows
             case HitResult.Perfect:
                 return perfect;
 
+            // DifficultyHitObject always requests a Great window, even when Great is not
+            // an allowed timing result for this object type. Use the highest successful
+            // timing window so difficulty calculation can proceed.
+            case HitResult.Great:
+                return perfect;
+
             case HitResult.Meh:
                 return meh;
 

--- a/osu.Game.Rulesets.Karaoke/Scoring/KaraokeScoreMultiplierCalculator.cs
+++ b/osu.Game.Rulesets.Karaoke/Scoring/KaraokeScoreMultiplierCalculator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Karaoke.Mods;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Karaoke.Scoring;
+
+public class KaraokeScoreMultiplierCalculator : ScoreMultiplierCalculator
+{
+    public KaraokeScoreMultiplierCalculator(ScoreMultiplierContext context)
+        : base(context)
+    {
+        Single<KaraokeModNoFail>(hasMultiplier: 0.5);
+        Single<KaraokeModHiddenNote>(hasMultiplier: 1.06);
+        Single<KaraokeModPractice>(hasMultiplier: 0);
+        Single<KaraokeModDisableNote>(hasMultiplier: 0);
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/ScoringSettingsPreview.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Previews/Gameplay/ScoringSettingsPreview.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) andy840119 <andy840119@gmail.com>. Licensed under the GPL Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Karaoke.Configuration;
+using osuTK;
+
+namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay;
+
+public partial class ScoringSettingsPreview : SettingsSubsectionPreview
+{
+    private readonly BindableBool overridePitch = new();
+    private readonly BindableInt pitch = new();
+    private readonly BindableBool overrideVocalPitch = new();
+    private readonly BindableInt vocalPitch = new();
+    private readonly BindableBool overrideScoringPitch = new();
+    private readonly BindableInt scoringPitch = new();
+
+    private readonly PitchPreviewRow songRow;
+    private readonly PitchPreviewRow vocalRow;
+    private readonly PitchPreviewRow scoringRow;
+
+    public ScoringSettingsPreview()
+    {
+        Size = new Vector2(0.85f, 0.58f);
+
+        Child = new FillFlowContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Padding = new MarginPadding(16),
+            Spacing = new Vector2(0, 8),
+            Direction = FillDirection.Vertical,
+            Children = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Text = "Gameplay pitch offsets",
+                    Font = OsuFont.Default.With(size: 24, weight: FontWeight.Bold),
+                },
+                new OsuSpriteText
+                {
+                    Text = "Each step represents one semitone.",
+                    Font = OsuFont.Default.With(size: 14),
+                },
+                songRow = new PitchPreviewRow("Song"),
+                vocalRow = new PitchPreviewRow("Vocal"),
+                scoringRow = new PitchPreviewRow("Scoring"),
+            },
+        };
+
+        bindRow(songRow, overridePitch, pitch);
+        bindRow(vocalRow, overrideVocalPitch, vocalPitch);
+        bindRow(scoringRow, overrideScoringPitch, scoringPitch);
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(KaraokeRulesetConfigManager config)
+    {
+        config.BindWith(KaraokeRulesetSetting.OverridePitchAtGameplay, overridePitch);
+        config.BindWith(KaraokeRulesetSetting.Pitch, pitch);
+        config.BindWith(KaraokeRulesetSetting.OverrideVocalPitchAtGameplay, overrideVocalPitch);
+        config.BindWith(KaraokeRulesetSetting.VocalPitch, vocalPitch);
+        config.BindWith(KaraokeRulesetSetting.OverrideScoringPitchAtGameplay, overrideScoringPitch);
+        config.BindWith(KaraokeRulesetSetting.ScoringPitch, scoringPitch);
+    }
+
+    private static void bindRow(PitchPreviewRow row, BindableBool enabled, BindableInt value)
+    {
+        enabled.BindValueChanged(_ => update(), true);
+        value.BindValueChanged(_ => update(), true);
+
+        void update()
+        {
+            row.Value = value.Value;
+            row.Enabled = enabled.Value;
+        }
+    }
+
+    private partial class PitchPreviewRow : CompositeDrawable
+    {
+        private readonly Box background;
+        private readonly PitchOffsetBar offsetBar;
+        private readonly OsuSpriteText valueText;
+
+        private int value;
+
+        public int Value
+        {
+            get => value;
+            set
+            {
+                this.value = value;
+                offsetBar.Value = value;
+                updateValueText();
+            }
+        }
+
+        private bool enabled;
+
+        public bool Enabled
+        {
+            get => enabled;
+            set
+            {
+                enabled = value;
+                this.FadeTo(value ? 1 : 0.45f, 150, Easing.OutQuint);
+                updateValueText();
+            }
+        }
+
+        public PitchPreviewRow(string label)
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = 44;
+            Masking = true;
+            CornerRadius = 6;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding(8),
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.Absolute, 62),
+                        new Dimension(GridSizeMode.Relative, 1),
+                        new Dimension(GridSizeMode.Absolute, 38),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Text = label,
+                                Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
+                            },
+                            offsetBar = new PitchOffsetBar(),
+                            valueText = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Font = OsuFont.Default.With(size: 15, weight: FontWeight.Bold),
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            background.Colour = colours.Gray3;
+            valueText.Colour = colours.Yellow;
+        }
+
+        private void updateValueText()
+            => valueText.Text = Enabled ? Value.ToString("+0;-0;0") : "Off";
+    }
+
+    private partial class PitchOffsetBar : CompositeDrawable
+    {
+        private readonly Box track;
+        private readonly Box centreMarker;
+        private readonly Circle valueMarker;
+
+        public int Value
+        {
+            set => valueMarker.MoveToX(0.5f + Math.Clamp(value, -10, 10) / 20f, 180, Easing.OutQuint);
+        }
+
+        public PitchOffsetBar()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Padding = new MarginPadding { Horizontal = 8 };
+
+            InternalChildren = new Drawable[]
+            {
+                track = new Box
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 3,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                centreMarker = new Box
+                {
+                    Width = 2,
+                    Height = 13,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                valueMarker = new Circle
+                {
+                    RelativePositionAxes = Axes.X,
+                    X = 0.5f,
+                    Size = new Vector2(12),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.Centre,
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            track.Colour = colours.Gray6;
+            centreMarker.Colour = colours.GrayF;
+            valueMarker.Colour = colours.Yellow;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/ScoringSettings.cs
+++ b/osu.Game.Rulesets.Karaoke/Screens/Settings/Sections/Gameplay/ScoringSettings.cs
@@ -7,12 +7,16 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Karaoke.Configuration;
+using osu.Game.Rulesets.Karaoke.Screens.Settings.Previews;
+using osu.Game.Rulesets.Karaoke.Screens.Settings.Previews.Gameplay;
 
 namespace osu.Game.Rulesets.Karaoke.Screens.Settings.Sections.Gameplay;
 
 public partial class ScoringSettings : KaraokeSettingsSubsection
 {
     protected override LocalisableString Header => "Scoring";
+
+    public override SettingsSubsectionPreview CreatePreview() => new ScoringSettingsPreview();
 
     [BackgroundDependencyLoader]
     private void load()

--- a/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
+++ b/osu.Game.Rulesets.Karaoke/osu.Game.Rulesets.Karaoke.csproj
@@ -17,13 +17,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ppy.osu.Game" Version="2026.408.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2026.730.0" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />
     <PackageReference Include="SixLabors.Fonts" Version="2.1.3" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <!--install because it might cause "Could not load file or assembly" error, might be removed eventually-->
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
     <PackageReference Include="WanaKanaSharp" Version="0.2.0" />
     <PackageReference Include="Zipangu" Version="1.1.8" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- update `ppy.osu.Game` to the latest published package (`2026.730.0`)
- adapt beatmap decoders and difficulty calculation to the current APIs
- migrate mod multipliers from the obsolete `Mod.ScoreMultiplier` property to `ScoreMultiplierCalculator`
- provide the default vocal variant name instead of throwing in song select
- allow song select to preview beatmaps from other rulesets without throwing conversion errors
- update `System.Text.Encodings.Web` and add regression tests for variant names and score multipliers

## Testing

- Release build succeeds with 0 warnings and 0 errors
- focused API regression tests pass (10 passed)

Companion font compatibility fix: karaoke-dev/osu-framework-font#554. That dependency change is intentionally not bundled into this repository PR.